### PR TITLE
Added display of forces and frame trajectories + improved of contact classes

### DIFF
--- a/bindings/python/crocoddyl/__init__.py
+++ b/bindings/python/crocoddyl/__init__.py
@@ -156,8 +156,8 @@ class CallbackLogger(libcrocoddyl_pywrap.CallbackAbstract):
 def plotOCSolution(xs=None, us=None, figIndex=1, show=True):
     import matplotlib.pyplot as plt
     import numpy as np
-    plt.rcParams['pdf.fonttype'] = 42
-    plt.rcParams['ps.fonttype'] = 42
+    plt.rcParams["pdf.fonttype"] = 42
+    plt.rcParams["ps.fonttype"] = 42
 
     # Getting the state and control trajectories
     if xs is not None:
@@ -180,15 +180,15 @@ def plotOCSolution(xs=None, us=None, figIndex=1, show=True):
     # Plotting the state trajectories
     if xs is not None:
         plt.subplot(xsPlotIdx)
-        [plt.plot(X[i], label='x' + str(i)) for i in range(nx)]
+        [plt.plot(X[i], label="x" + str(i)) for i in range(nx)]
         plt.legend()
 
     # Plotting the control commands
     if us is not None:
         plt.subplot(usPlotIdx)
-        [plt.plot(U[i], label='u' + str(i)) for i in range(nu)]
+        [plt.plot(U[i], label="u" + str(i)) for i in range(nu)]
         plt.legend()
-        plt.xlabel('knots')
+        plt.xlabel("knots")
     if show:
         plt.show()
 
@@ -196,36 +196,36 @@ def plotOCSolution(xs=None, us=None, figIndex=1, show=True):
 def plotConvergence(costs, muLM, muV, gamma, theta, alpha, figIndex=1, show=True, figTitle=""):
     import matplotlib.pyplot as plt
     import numpy as np
-    plt.rcParams['pdf.fonttype'] = 42
-    plt.rcParams['ps.fonttype'] = 42
+    plt.rcParams["pdf.fonttype"] = 42
+    plt.rcParams["ps.fonttype"] = 42
     plt.figure(figIndex, figsize=(6.4, 8))
     plt.suptitle(figTitle, fontsize=14)
 
     # Plotting the total cost sequence
     plt.subplot(511)
-    plt.ylabel('cost')
+    plt.ylabel("cost")
     plt.plot(costs)
 
     # Ploting mu sequences
     plt.subplot(512)
-    plt.ylabel('mu')
-    plt.plot(muLM, label='LM')
-    plt.plot(muV, label='V')
+    plt.ylabel("mu")
+    plt.plot(muLM, label="LM")
+    plt.plot(muV, label="V")
     plt.legend()
 
     # Plotting the gradient sequence (gamma and theta)
     plt.subplot(513)
-    plt.ylabel('gamma')
+    plt.ylabel("gamma")
     plt.plot(gamma)
     plt.subplot(514)
-    plt.ylabel('theta')
+    plt.ylabel("theta")
     plt.plot(theta)
 
     # Plotting the alpha sequence
     plt.subplot(515)
-    plt.ylabel('alpha')
+    plt.ylabel("alpha")
     ind = np.arange(len(alpha))
     plt.bar(ind, alpha)
-    plt.xlabel('iteration')
+    plt.xlabel("iteration")
     if show:
         plt.show()

--- a/bindings/python/crocoddyl/__init__.py
+++ b/bindings/python/crocoddyl/__init__.py
@@ -1,11 +1,12 @@
 from .libcrocoddyl_pywrap import *
 from .libcrocoddyl_pywrap import __version__
 
+import pinocchio
+import numpy as np
+import time
+
 
 def rotationMatrixFromTwoVectors(a, b):
-    import pinocchio
-    import numpy as np
-
     a_copy = a / np.linalg.norm(a)
     b_copy = b / np.linalg.norm(b)
     a_cross_b = pinocchio.utils.cross(a_copy, b_copy)
@@ -17,14 +18,20 @@ def rotationMatrixFromTwoVectors(a, b):
 
 class GepettoDisplay:
     def __init__(self, robot, rate=-1, freq=1, cameraTF=None, floor=True):
-        import time
-        import numpy as np
-        import pinocchio
         self.robot = robot
         self.rate = rate
         self.freq = freq
 
+        # Visuals properties
+        self.floorGroup = "world/floor"
+        self.forceGroup = "world/robot/contact_forces"
         self.backgroundColor = [1., 1., 1., 1.]
+        self.floorScale = [0.5, 0.5, 0.5]
+        self.floorColor = [0.7, 0.7, 0.7, 1.]
+        self.forceRadius = 0.015
+        self.forceLength = 0.5
+        self.forceColor = [1., 0., 1., 1.]
+
         self.addRobot()
         self.setBackground()
         if cameraTF is not None:
@@ -32,78 +39,44 @@ class GepettoDisplay:
 
         # floor visuals properties
         if floor:
-            self.floorGroup = "world/floor"
-            self.floorScale = [0.5, 0.5, 0.5]
-            self.floorColor = [0.7, 0.7, 0.7, 1.]
             self.addFloor()
 
         # Force visuals properties
-        self.forceGroup = "world/robot/contact_forces"
         self.totalWeight = sum(m.mass
                                for m in self.robot.model.inertias) * np.linalg.norm(self.robot.model.gravity.linear)
-        self.forceRadius = 0.015
-        self.forceLength = 0.5
-        self.forceColor = [1., 0., 1., 1.]
         self.x_axis = np.matrix([1., 0., 0.]).T
         self.robot.viewer.gui.createGroup(self.forceGroup)
 
-    def display(self, xs, fs=None, dt=0.1):
-        if fs is not None:
+    def display(self, xs, fs=[], dts=[]):
+        if fs:
             for f in fs[0]:
-                key = f['key']
-                t, R = f['oMf'].translation, rotationMatrixFromTwoVectors(self.x_axis, f['f'].linear)
+                key = f["key"]
                 self.robot.viewer.gui.addArrow(self.forceGroup + "/" + key, self.forceRadius, self.forceLength,
                                                self.forceColor)
+        if not dts:
+            dts = [0.] * len(xs)
 
         S = 1 if self.rate <= 0 else max(len(xs) / self.rate, 1)
         for i, x in enumerate(xs):
             if not i % S:
-                if fs is not None:
-                    self.robot.viewer.gui.setFloatProperty(self.forceGroup, 'Alpha', 0.)
+                if fs:
+                    self.robot.viewer.gui.setFloatProperty(self.forceGroup, "Alpha", 0.)
                     for f in fs[i]:
-                        key = f['key']
-                        self.robot.viewer.gui.setFloatProperty(self.forceGroup + "/" + key, 'Alpha', 1.)
+                        key = f["key"]
+                        self.robot.viewer.gui.setFloatProperty(self.forceGroup + "/" + key, "Alpha", 1.)
                     for f in fs[i]:
-                        key = f['key']
-                        force = f['f'].linear
-                        t, R = f['oMf'].translation, rotationMatrixFromTwoVectors(x_axis, force)
+                        key = f["key"]
+                        force = f["f"].linear
+                        t, R = f["oMf"].translation, rotationMatrixFromTwoVectors(self.x_axis, force)
                         pose = pinocchio.se3ToXYZQUATtuple(pinocchio.SE3(R, t))
                         forceMagnitud = np.linalg.norm(force) / self.totalWeight
-                        self.robot.viewer.gui.setVector3Property(self.forceGroup + "/" + key, 'Scale',
+                        self.robot.viewer.gui.setVector3Property(self.forceGroup + "/" + key, "Scale",
                                                                  [1. * forceMagnitud, 1., 1.])
                         self.robot.viewer.gui.applyConfiguration(self.forceGroup + "/" + key, pose)
                 self.robot.display(x[:self.robot.nq])
-                time.sleep(dt)
+                time.sleep(dts[i])
 
-    def addRobot(self):
-        # Spawn robot model
-        self.robot.initViewer(windowName="crocoddyl", loadModel=False)
-        self.robot.loadViewerModel(rootNodeName="robot")
-
-    def setBackground(self):
-        # Set white background and floor
-        window_id = self.robot.viewer.gui.getWindowID("crocoddyl")
-        self.robot.viewer.gui.setBackgroundColor1(window_id, self.backgroundColor)
-        self.robot.viewer.gui.setBackgroundColor2(window_id, self.backgroundColor)
-
-    def addFloor(self):
-        self.robot.viewer.gui.createGroup(self.floorGroup)
-        self.robot.viewer.gui.addFloor(self.floorGroup + "/flat")
-        self.robot.viewer.gui.setScale(self.floorGroup + "/flat", self.floorScale)
-        self.robot.viewer.gui.setColor(self.floorGroup + "/flat", self.floorColor)
-        self.robot.viewer.gui.setLightingMode(self.floorGroup + "/flat", 'OFF')
-
-
-class CallbackDisplay(libcrocoddyl_pywrap.CallbackAbstract):
-    def __init__(self, display):
-        libcrocoddyl_pywrap.CallbackAbstract.__init__(self)
-        self.visualization = display
-
-    def __call__(self, solver):
-        if (solver.iter + 1) % self.visualization.freq:
-            return
-        dt = solver.models()[0].dt
-
+    def displayFromSolver(self, solver):
         fs = []
         for data in solver.datas():
             if hasattr(data, "differential"):
@@ -121,7 +94,38 @@ class CallbackDisplay(libcrocoddyl_pywrap.CallbackAbstract):
                     oMf = impulse.pinocchio.oMi[impulse.joint] * impulse.jMf
                     fc.append({"key": str(impulse.joint), "oMf": oMf, "f": force})
                 fs.append(fc)
-        self.visualization.display(solver.xs, fs, dt)
+
+        dts = [m.dt if hasattr(m, "differential") else 0. for m in solver.models()]
+        self.display(solver.xs, fs, dts)
+
+    def addRobot(self):
+        # Spawn robot model
+        self.robot.initViewer(windowName="crocoddyl", loadModel=False)
+        self.robot.loadViewerModel(rootNodeName="robot")
+
+    def setBackground(self):
+        # Set white background and floor
+        window_id = self.robot.viewer.gui.getWindowID("crocoddyl")
+        self.robot.viewer.gui.setBackgroundColor1(window_id, self.backgroundColor)
+        self.robot.viewer.gui.setBackgroundColor2(window_id, self.backgroundColor)
+
+    def addFloor(self):
+        self.robot.viewer.gui.createGroup(self.floorGroup)
+        self.robot.viewer.gui.addFloor(self.floorGroup + "/flat")
+        self.robot.viewer.gui.setScale(self.floorGroup + "/flat", self.floorScale)
+        self.robot.viewer.gui.setColor(self.floorGroup + "/flat", self.floorColor)
+        self.robot.viewer.gui.setLightingMode(self.floorGroup + "/flat", "OFF")
+
+
+class CallbackDisplay(libcrocoddyl_pywrap.CallbackAbstract):
+    def __init__(self, display):
+        libcrocoddyl_pywrap.CallbackAbstract.__init__(self)
+        self.visualization = display
+
+    def __call__(self, solver):
+        if (solver.iter + 1) % self.visualization.freq:
+            return
+        self.visualization.displayFromSolver(solver)
 
 
 class CallbackLogger(libcrocoddyl_pywrap.CallbackAbstract):
@@ -140,7 +144,6 @@ class CallbackLogger(libcrocoddyl_pywrap.CallbackAbstract):
 
     def __call__(self, solver):
         import copy
-        import numpy as np
         self.xs = copy.copy(solver.xs)
         self.us = copy.copy(solver.us)
         self.steps.append(solver.stepLength)

--- a/bindings/python/crocoddyl/__init__.py
+++ b/bindings/python/crocoddyl/__init__.py
@@ -5,19 +5,34 @@ from .libcrocoddyl_pywrap import __version__
 def setGepettoViewerBackground(robot, floor):
     if not hasattr(robot, 'viewer'):
         # Spawn robot model
-        robot.initViewer(loadModel=True)
+        robot.initViewer(windowName="crocoddyl", loadModel=False)
+        robot.loadViewerModel(rootNodeName="robot")
         # Set white background and floor
-        window_id = robot.viewer.gui.getWindowID('python-pinocchio')
+        window_id = robot.viewer.gui.getWindowID("crocoddyl")
         robot.viewer.gui.setBackgroundColor1(window_id, [1., 1., 1., 1.])
         robot.viewer.gui.setBackgroundColor2(window_id, [1., 1., 1., 1.])
+        robot.viewer.gui.createGroup("world/floor")
         if floor:
-            robot.viewer.gui.addFloor('hpp-gui/floor')
-            robot.viewer.gui.setScale('hpp-gui/floor', [0.5, 0.5, 0.5])
-            robot.viewer.gui.setColor('hpp-gui/floor', [0.7, 0.7, 0.7, 1.])
-            robot.viewer.gui.setLightingMode('hpp-gui/floor', 'OFF')
+            robot.viewer.gui.addFloor("world/floor/flat")
+            robot.viewer.gui.setScale("world/floor/flat", [0.5, 0.5, 0.5])
+            robot.viewer.gui.setColor("world/floor/flat", [0.7, 0.7, 0.7, 1.])
+            robot.viewer.gui.setLightingMode("world/floor/flat", 'OFF')
 
 
-def displayTrajectory(robot, xs, dt=0.1, rate=-1, cameraTF=None, floor=True):
+def rotationMatrixFromTwoVectors(a, b):
+    import pinocchio
+    import numpy as np
+
+    a_copy = a / np.linalg.norm(a)
+    b_copy = b / np.linalg.norm(b)
+    a_cross_b = pinocchio.utils.cross(a_copy, b_copy)
+    s = np.linalg.norm(a_cross_b)
+    c = np.asscalar(a_copy.T * b_copy)
+    ab_skew = pinocchio.utils.skew(a_cross_b)
+    return np.matrix(np.eye(3)) + ab_skew + ab_skew * ab_skew * (1 - c) / s**2
+
+
+def displayTrajectory(robot, xs, fs=None, dt=0.1, rate=-1, cameraTF=None, floor=True):
     """  Display a robot trajectory xs using Gepetto-viewer gui.
 
     :param robot: Robot wrapper
@@ -30,11 +45,38 @@ def displayTrajectory(robot, xs, dt=0.1, rate=-1, cameraTF=None, floor=True):
     if cameraTF is not None:
         robot.viewer.gui.setCameraTransform(0, cameraTF)
     import numpy as np
+    if fs is not None:
+        import pinocchio
+
+        totalWeight = sum(m.mass for m in robot.model.inertias) * np.linalg.norm(robot.model.gravity.linear)
+
+        forceGroup = "world/robot/contact_forces"
+        forceRadius = 0.015
+        forceLength = 0.5
+        forceColor = [1., 0., 1., 1.]
+        robot.viewer.gui.createGroup(forceGroup)
+        for f in fs[0]:
+            key = f['key']
+            t, R = f['oMf'].translation, rotationMatrixFromTwoVectors(np.matrix([1., 0., 0.]).T, f['f'].linear)
+            robot.viewer.gui.addArrow(forceGroup + "/" + key, forceRadius, forceLength, forceColor)
 
     import time
     S = 1 if rate <= 0 else max(len(xs) / rate, 1)
     for i, x in enumerate(xs):
         if not i % S:
+            if fs is not None:
+                robot.viewer.gui.setFloatProperty(forceGroup, 'Alpha', 0.)
+                for f in fs[i]:
+                    key = f['key']
+                    robot.viewer.gui.setFloatProperty(forceGroup + "/" + key, 'Alpha', 1.)
+                for f in fs[i]:
+                    key = f['key']
+                    force = f['f'].linear
+                    t, R = f['oMf'].translation, rotationMatrixFromTwoVectors(np.matrix([1., 0., 0.]).T, force)
+                    pose = pinocchio.se3ToXYZQUATtuple(pinocchio.SE3(R, t))
+                    forceMagnitud = np.linalg.norm(force) / totalWeight
+                    robot.viewer.gui.setVector3Property(forceGroup + "/" + key, 'Scale', [1. * forceMagnitud, 1., 1.])
+                    robot.viewer.gui.applyConfiguration(forceGroup + "/" + key, pose)
             robot.display(x[:robot.nq])
             time.sleep(dt)
 
@@ -52,7 +94,25 @@ class CallbackDisplay(libcrocoddyl_pywrap.CallbackAbstract):
         if (solver.iter + 1) % self.freq:
             return
         dt = solver.models()[0].dt
-        displayTrajectory(self.robotwrapper, solver.xs, dt, self.rate, self.cameraTF, self.floor)
+
+        fs = []
+        for data in solver.datas():
+            if hasattr(data, "differential"):
+                if isinstance(data.differential, libcrocoddyl_pywrap.DifferentialActionDataContactFwdDynamics):
+                    fc = []
+                    for key, contact in data.differential.contacts.contacts.items():
+                        oMf = contact.pinocchio.oMi[contact.joint] * contact.jMf
+                        force = contact.jMf.actInv(contact.f)
+                        fc.append({"key": str(contact.joint), "oMf": oMf, "f": force})
+                    fs.append(fc)
+            elif isinstance(data, libcrocoddyl_pywrap.ActionDataImpulseFwdDynamics):
+                fc = []
+                for key, impulse in data.impulses.impulses.items():
+                    force = impulse.jMf.actInv(impulse.f)
+                    oMf = impulse.pinocchio.oMi[impulse.joint] * impulse.jMf
+                    fc.append({"key": str(impulse.joint), "oMf": oMf, "f": force})
+                fs.append(fc)
+        displayTrajectory(self.robotwrapper, solver.xs, fs, dt, self.rate, self.cameraTF, self.floor)
 
 
 class CallbackLogger(libcrocoddyl_pywrap.CallbackAbstract):

--- a/bindings/python/crocoddyl/__init__.py
+++ b/bindings/python/crocoddyl/__init__.py
@@ -47,7 +47,7 @@ class GepettoDisplay:
         self.x_axis = np.matrix([1., 0., 0.]).T
         self.robot.viewer.gui.createGroup(self.forceGroup)
 
-    def display(self, xs, fs=[], dts=[]):
+    def display(self, xs, fs=[], dts=[], factor=1.):
         if fs:
             for f in fs[0]:
                 key = f["key"]
@@ -74,9 +74,9 @@ class GepettoDisplay:
                                                                  [1. * forceMagnitud, 1., 1.])
                         self.robot.viewer.gui.applyConfiguration(self.forceGroup + "/" + key, pose)
                 self.robot.display(x[:self.robot.nq])
-                time.sleep(dts[i])
+                time.sleep(dts[i] * factor)
 
-    def displayFromSolver(self, solver):
+    def displayFromSolver(self, solver, factor=1.):
         fs = []
         for data in solver.datas():
             if hasattr(data, "differential"):
@@ -96,7 +96,7 @@ class GepettoDisplay:
                 fs.append(fc)
 
         dts = [m.dt if hasattr(m, "differential") else 0. for m in solver.models()]
-        self.display(solver.xs, fs, dts)
+        self.display(solver.xs, fs, dts, factor)
 
     def addRobot(self):
         # Spawn robot model

--- a/bindings/python/crocoddyl/__init__.py
+++ b/bindings/python/crocoddyl/__init__.py
@@ -2,23 +2,6 @@ from .libcrocoddyl_pywrap import *
 from .libcrocoddyl_pywrap import __version__
 
 
-def setGepettoViewerBackground(robot, floor):
-    if not hasattr(robot, 'viewer'):
-        # Spawn robot model
-        robot.initViewer(windowName="crocoddyl", loadModel=False)
-        robot.loadViewerModel(rootNodeName="robot")
-        # Set white background and floor
-        window_id = robot.viewer.gui.getWindowID("crocoddyl")
-        robot.viewer.gui.setBackgroundColor1(window_id, [1., 1., 1., 1.])
-        robot.viewer.gui.setBackgroundColor2(window_id, [1., 1., 1., 1.])
-        robot.viewer.gui.createGroup("world/floor")
-        if floor:
-            robot.viewer.gui.addFloor("world/floor/flat")
-            robot.viewer.gui.setScale("world/floor/flat", [0.5, 0.5, 0.5])
-            robot.viewer.gui.setColor("world/floor/flat", [0.7, 0.7, 0.7, 1.])
-            robot.viewer.gui.setLightingMode("world/floor/flat", 'OFF')
-
-
 def rotationMatrixFromTwoVectors(a, b):
     import pinocchio
     import numpy as np
@@ -32,66 +15,77 @@ def rotationMatrixFromTwoVectors(a, b):
     return np.matrix(np.eye(3)) + ab_skew + ab_skew * ab_skew * (1 - c) / s**2
 
 
-def displayTrajectory(robot, xs, fs=None, dt=0.1, rate=-1, cameraTF=None, floor=True):
-    """  Display a robot trajectory xs using Gepetto-viewer gui.
+class GepettoDisplay:
+    def __init__(self, robot, rate=-1, freq=1, cameraTF=None, floor=True):
+        self.robot = robot
+        self.rate = rate
+        self.freq = freq
+        self.cameraTF = cameraTF
+        self.setBackground(floor)
+        if cameraTF is not None:
+            robot.viewer.gui.setCameraTransform(0, cameraTF)
 
-    :param robot: Robot wrapper
-    :param xs: state trajectory
-    :param dt: step duration
-    :param rate: visualization rate
-    :param cameraTF: camera transform
-    """
-    setGepettoViewerBackground(robot, floor)
-    if cameraTF is not None:
-        robot.viewer.gui.setCameraTransform(0, cameraTF)
-    import numpy as np
-    if fs is not None:
-        import pinocchio
+    def display(self, xs, fs=None, dt=0.1):
+        import numpy as np
+        if fs is not None:
+            import pinocchio
 
-        totalWeight = sum(m.mass for m in robot.model.inertias) * np.linalg.norm(robot.model.gravity.linear)
+            totalWeight = sum(m.mass for m in self.robot.model.inertias) * np.linalg.norm(self.robot.model.gravity.linear)
+            forceGroup = "world/robot/contact_forces"
+            forceRadius = 0.015
+            forceLength = 0.5
+            forceColor = [1., 0., 1., 1.]
+            self.robot.viewer.gui.createGroup(forceGroup)
+            for f in fs[0]:
+                key = f['key']
+                t, R = f['oMf'].translation, rotationMatrixFromTwoVectors(np.matrix([1., 0., 0.]).T, f['f'].linear)
+                self.robot.viewer.gui.addArrow(forceGroup + "/" + key, forceRadius, forceLength, forceColor)
 
-        forceGroup = "world/robot/contact_forces"
-        forceRadius = 0.015
-        forceLength = 0.5
-        forceColor = [1., 0., 1., 1.]
-        robot.viewer.gui.createGroup(forceGroup)
-        for f in fs[0]:
-            key = f['key']
-            t, R = f['oMf'].translation, rotationMatrixFromTwoVectors(np.matrix([1., 0., 0.]).T, f['f'].linear)
-            robot.viewer.gui.addArrow(forceGroup + "/" + key, forceRadius, forceLength, forceColor)
+        import time
+        S = 1 if self.rate <= 0 else max(len(xs) / self.rate, 1)
+        for i, x in enumerate(xs):
+            if not i % S:
+                if fs is not None:
+                    self.robot.viewer.gui.setFloatProperty(forceGroup, 'Alpha', 0.)
+                    for f in fs[i]:
+                        key = f['key']
+                        self.robot.viewer.gui.setFloatProperty(forceGroup + "/" + key, 'Alpha', 1.)
+                    for f in fs[i]:
+                        key = f['key']
+                        force = f['f'].linear
+                        t, R = f['oMf'].translation, rotationMatrixFromTwoVectors(np.matrix([1., 0., 0.]).T, force)
+                        pose = pinocchio.se3ToXYZQUATtuple(pinocchio.SE3(R, t))
+                        forceMagnitud = np.linalg.norm(force) / totalWeight
+                        self.robot.viewer.gui.setVector3Property(forceGroup + "/" + key, 'Scale', [1. * forceMagnitud, 1., 1.])
+                        self.robot.viewer.gui.applyConfiguration(forceGroup + "/" + key, pose)
+                self.robot.display(x[:self.robot.nq])
+                time.sleep(dt)
 
-    import time
-    S = 1 if rate <= 0 else max(len(xs) / rate, 1)
-    for i, x in enumerate(xs):
-        if not i % S:
-            if fs is not None:
-                robot.viewer.gui.setFloatProperty(forceGroup, 'Alpha', 0.)
-                for f in fs[i]:
-                    key = f['key']
-                    robot.viewer.gui.setFloatProperty(forceGroup + "/" + key, 'Alpha', 1.)
-                for f in fs[i]:
-                    key = f['key']
-                    force = f['f'].linear
-                    t, R = f['oMf'].translation, rotationMatrixFromTwoVectors(np.matrix([1., 0., 0.]).T, force)
-                    pose = pinocchio.se3ToXYZQUATtuple(pinocchio.SE3(R, t))
-                    forceMagnitud = np.linalg.norm(force) / totalWeight
-                    robot.viewer.gui.setVector3Property(forceGroup + "/" + key, 'Scale', [1. * forceMagnitud, 1., 1.])
-                    robot.viewer.gui.applyConfiguration(forceGroup + "/" + key, pose)
-            robot.display(x[:robot.nq])
-            time.sleep(dt)
+    def setBackground(self, floor):
+        if not hasattr(self.robot, 'viewer'):
+            # Spawn robot model
+            self.robot.initViewer(windowName="crocoddyl", loadModel=False)
+            self.robot.loadViewerModel(rootNodeName="robot")
+            # Set white background and floor
+            window_id = self.robot.viewer.gui.getWindowID("crocoddyl")
+            self.robot.viewer.gui.setBackgroundColor1(window_id, [1., 1., 1., 1.])
+            self.robot.viewer.gui.setBackgroundColor2(window_id, [1., 1., 1., 1.])
+            self.robot.viewer.gui.createGroup("world/floor")
+            if floor:
+                self.robot.viewer.gui.addFloor("world/floor/flat")
+                self.robot.viewer.gui.setScale("world/floor/flat", [0.5, 0.5, 0.5])
+                self.robot.viewer.gui.setColor("world/floor/flat", [0.7, 0.7, 0.7, 1.])
+                self.robot.viewer.gui.setLightingMode("world/floor/flat", 'OFF')
+
 
 
 class CallbackDisplay(libcrocoddyl_pywrap.CallbackAbstract):
-    def __init__(self, robotwrapper, rate=-1, freq=1, cameraTF=None, floor=True):
+    def __init__(self, display):
         libcrocoddyl_pywrap.CallbackAbstract.__init__(self)
-        self.robotwrapper = robotwrapper
-        self.rate = rate
-        self.cameraTF = cameraTF
-        self.freq = freq
-        self.floor = floor
+        self.visualization = display
 
     def __call__(self, solver):
-        if (solver.iter + 1) % self.freq:
+        if (solver.iter + 1) % self.visualization.freq:
             return
         dt = solver.models()[0].dt
 
@@ -112,7 +106,7 @@ class CallbackDisplay(libcrocoddyl_pywrap.CallbackAbstract):
                     oMf = impulse.pinocchio.oMi[impulse.joint] * impulse.jMf
                     fc.append({"key": str(impulse.joint), "oMf": oMf, "f": force})
                 fs.append(fc)
-        displayTrajectory(self.robotwrapper, solver.xs, fs, dt, self.rate, self.cameraTF, self.floor)
+        self.visualization.display(solver.xs, fs, dt)
 
 
 class CallbackLogger(libcrocoddyl_pywrap.CallbackAbstract):

--- a/bindings/python/crocoddyl/core/numdiff/diff-action.hpp
+++ b/bindings/python/crocoddyl/core/numdiff/diff-action.hpp
@@ -10,7 +10,7 @@
 #define BINDINGS_PYTHON_CROCODDYL_CORE_NUMDIFF_DIFF_ACTION_HPP_
 
 #include "crocoddyl/core/numdiff/diff-action.hpp"
-#include "python/crocoddyl/utils.hpp"
+#include "python/crocoddyl/utils/vector-converter.hpp"
 
 namespace crocoddyl {
 namespace python {

--- a/bindings/python/crocoddyl/core/optctrl/shooting.hpp
+++ b/bindings/python/crocoddyl/core/optctrl/shooting.hpp
@@ -12,7 +12,7 @@
 #include <vector>
 #include <memory>
 #include "crocoddyl/core/optctrl/shooting.hpp"
-#include "python/crocoddyl/utils.hpp"
+#include "python/crocoddyl/utils/vector-converter.hpp"
 
 namespace crocoddyl {
 namespace python {

--- a/bindings/python/crocoddyl/core/solver-base.hpp
+++ b/bindings/python/crocoddyl/core/solver-base.hpp
@@ -12,7 +12,7 @@
 #include <vector>
 #include <memory>
 #include "crocoddyl/core/solver-base.hpp"
-#include "python/crocoddyl/utils.hpp"
+#include "python/crocoddyl/utils/vector-converter.hpp"
 
 namespace crocoddyl {
 namespace python {

--- a/bindings/python/crocoddyl/crocoddyl.cpp
+++ b/bindings/python/crocoddyl/crocoddyl.cpp
@@ -16,7 +16,6 @@
 #include "python/crocoddyl/multibody.hpp"
 #include "crocoddyl/core/utils/version.hpp"
 #include "python/crocoddyl/utils/vector-converter.hpp"
-#include "python/crocoddyl/utils/map-converter.hpp"
 
 namespace crocoddyl {
 namespace python {

--- a/bindings/python/crocoddyl/crocoddyl.cpp
+++ b/bindings/python/crocoddyl/crocoddyl.cpp
@@ -15,7 +15,8 @@
 #include "python/crocoddyl/core.hpp"
 #include "python/crocoddyl/multibody.hpp"
 #include "crocoddyl/core/utils/version.hpp"
-#include "python/crocoddyl/utils.hpp"
+#include "python/crocoddyl/utils/vector-converter.hpp"
+#include "python/crocoddyl/utils/map-converter.hpp"
 
 namespace crocoddyl {
 namespace python {

--- a/bindings/python/crocoddyl/multibody/contact-base.hpp
+++ b/bindings/python/crocoddyl/multibody/contact-base.hpp
@@ -109,6 +109,10 @@ void exposeContactAbstract() {
           ":param data: Pinocchio data")[bp::with_custodian_and_ward<1, 2, bp::with_custodian_and_ward<1, 3> >()])
       .add_property("pinocchio", bp::make_getter(&ContactDataAbstract::pinocchio, bp::return_internal_reference<>()),
                     "pinocchio data")
+      .add_property("jMf", bp::make_getter(&ContactDataAbstract::jMf, bp::return_value_policy<bp::return_by_value>()),
+                    "local frame placement of the contact frame")
+      .add_property("fXj", bp::make_getter(&ContactDataAbstract::fXj, bp::return_value_policy<bp::return_by_value>()),
+                    "action matrix from contact to local frames")
       .add_property("Jc", bp::make_getter(&ContactDataAbstract::Jc, bp::return_value_policy<bp::return_by_value>()),
                     bp::make_setter(&ContactDataAbstract::Jc), "contact Jacobian")
       .add_property("a0", bp::make_getter(&ContactDataAbstract::a0, bp::return_value_policy<bp::return_by_value>()),

--- a/bindings/python/crocoddyl/multibody/contact-base.hpp
+++ b/bindings/python/crocoddyl/multibody/contact-base.hpp
@@ -127,8 +127,9 @@ void exposeContactAbstract() {
                     bp::make_getter(&ContactDataAbstract::df_du, bp::return_value_policy<bp::return_by_value>()),
                     bp::make_setter(&ContactDataAbstract::df_du), "Jacobian of the contact forces")
       .def_readwrite("joint", &ContactDataAbstract::joint, "joint index of the contact frame")
-      .def_readwrite("f", &ContactDataAbstract::f, "external spatial force at the parent joint level.")
-      .def_readwrite("frame_force", &ContactDataAbstract::frame_force, "external spatial force at contact frame");
+      .def_readwrite("f", &ContactDataAbstract::f,
+                     "external spatial force at the parent joint level. Note that we could compute the force at the "
+                     "contact frame by using jMf (i.e. data.jMF.actInv(data.f)");
 }
 
 }  // namespace python

--- a/bindings/python/crocoddyl/multibody/contacts/contact-3d.hpp
+++ b/bindings/python/crocoddyl/multibody/contacts/contact-3d.hpp
@@ -76,10 +76,6 @@ void exposeContact3D() {
           "Create 3D contact data.\n\n"
           ":param model: 3D contact model\n"
           ":param data: Pinocchio data")[bp::with_custodian_and_ward<1, 2, bp::with_custodian_and_ward<1, 3> >()])
-      .add_property("jMf", bp::make_getter(&ContactData3D::jMf, bp::return_value_policy<bp::return_by_value>()),
-                    "local frame placement of the contact frame")
-      .add_property("fXj", bp::make_getter(&ContactData3D::fXj, bp::return_value_policy<bp::return_by_value>()),
-                    "action matrix from contact to local frames")
       .add_property("v", bp::make_getter(&ContactData3D::v, bp::return_value_policy<bp::return_by_value>()),
                     "spatial velocity of the contact body")
       .add_property("a", bp::make_getter(&ContactData3D::a, bp::return_value_policy<bp::return_by_value>()),

--- a/bindings/python/crocoddyl/multibody/contacts/contact-6d.hpp
+++ b/bindings/python/crocoddyl/multibody/contacts/contact-6d.hpp
@@ -76,12 +76,8 @@ void exposeContact6D() {
           "Create 6D contact data.\n\n"
           ":param model: 6D contact model\n"
           ":param data: Pinocchio data")[bp::with_custodian_and_ward<1, 2, bp::with_custodian_and_ward<1, 3> >()])
-      .add_property("jMf", bp::make_getter(&ContactData6D::jMf, bp::return_value_policy<bp::return_by_value>()),
-                    "local frame placement of the contact frame")
       .add_property("rMf", bp::make_getter(&ContactData6D::jMf, bp::return_value_policy<bp::return_by_value>()),
                     "error frame placement of the contact frame")
-      .add_property("fXj", bp::make_getter(&ContactData6D::fXj, bp::return_value_policy<bp::return_by_value>()),
-                    "action matrix from contact to local frames")
       .add_property("v", bp::make_getter(&ContactData6D::v, bp::return_value_policy<bp::return_by_value>()),
                     "spatial velocity of the contact body")
       .add_property("a", bp::make_getter(&ContactData6D::a, bp::return_value_policy<bp::return_by_value>()),

--- a/bindings/python/crocoddyl/multibody/contacts/multiple-contacts.hpp
+++ b/bindings/python/crocoddyl/multibody/contacts/multiple-contacts.hpp
@@ -15,6 +15,7 @@
 #include <utility>
 #include <string>
 #include "crocoddyl/multibody/contacts/multiple-contacts.hpp"
+#include "python/crocoddyl/utils/map-converter.hpp"
 
 namespace crocoddyl {
 namespace python {

--- a/bindings/python/crocoddyl/multibody/costs/contact-force.hpp
+++ b/bindings/python/crocoddyl/multibody/costs/contact-force.hpp
@@ -18,40 +18,35 @@ namespace bp = boost::python;
 
 void exposeCostContactForce() {
   bp::class_<CostModelContactForce, bp::bases<CostModelAbstract> >(
-      "CostModelContactForce", bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActivationModelAbstract>,
-                                        boost::shared_ptr<ContactModelAbstract>, Eigen::VectorXd, int>(
-                                   bp::args(" self", " state", " activation", " contact", " fref", " nu"),
-                                   "Initialize the contact force cost model.\n\n"
-                                   ":param state: state of the multibody system\n"
-                                   ":param activation: activation model\n"
-                                   ":param contact: contact model\n"
-                                   ":param fref: reference force\n"
-                                   ":param nu: dimension of control vector"))
-      .def(bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActivationModelAbstract>,
-                    boost::shared_ptr<ContactModelAbstract>, Eigen::VectorXd>(
-          bp::args(" self", " state", " activation", " contact", " fref"),
+      "CostModelContactForce",
+      bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActivationModelAbstract>, FrameForce, int>(
+          bp::args(" self", " state", " activation", " fref", " nu"),
+          "Initialize the contact force cost model.\n\n"
+          ":param state: state of the multibody system\n"
+          ":param activation: activation model\n"
+          ":param fref: reference frame force\n"
+          ":param nu: dimension of control vector"))
+      .def(bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActivationModelAbstract>, FrameForce>(
+          bp::args(" self", " state", " activation", " fref"),
           "Initialize the contact force cost model.\n\n"
           "For this case the default nu is equals to model.nv.\n"
           ":param state: state of the multibody system\n"
           ":param activation: activation model\n"
-          ":param contact: contact model\n"
-          ":param fref: reference force\n"))
-      .def(bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ContactModelAbstract>, Eigen::VectorXd, int>(
-          bp::args(" self", " state", " contact", " fref", " nu"),
+          ":param fref: reference frame force\n"))
+      .def(bp::init<boost::shared_ptr<StateMultibody>, FrameForce, int>(
+          bp::args(" self", " state", " fref", " nu"),
           "Initialize the contact force cost model.\n\n"
           "For this case the default activation model is quadratic, i.e.\n"
           "crocoddyl.ActivationModelQuad(6).\n"
           ":param state: state of the multibody system\n"
-          ":param contact: contact model\n"
-          ":param fref: reference force\n"
+          ":param fref: reference frame force\n"
           ":param nu: dimension of control vector"))
-      .def(bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ContactModelAbstract>, Eigen::VectorXd>(
-          bp::args(" self", " state", " contact", " fref"),
+      .def(bp::init<boost::shared_ptr<StateMultibody>, FrameForce>(
+          bp::args(" self", " state", " fref"),
           "Initialize the contact force cost model.\n\n"
           "For this case the default activation model is quadratic, i.e.\n"
           "crocoddyl.ActivationModelQuad(6), and nu is equals to model.nv.\n"
           ":param state: state of the multibody system\n"
-          ":param contact: contact model\n"
           ":param fref: reference force\n"))
       .def("calc", &CostModelContactForce::calc_wrap,
            CostModel_calc_wraps(bp::args(" self", " data", " x", " u=None"),

--- a/bindings/python/crocoddyl/multibody/costs/cost-sum.hpp
+++ b/bindings/python/crocoddyl/multibody/costs/cost-sum.hpp
@@ -15,6 +15,7 @@
 #include <utility>
 #include <string>
 #include "crocoddyl/multibody/costs/cost-sum.hpp"
+#include "python/crocoddyl/utils/map-converter.hpp"
 
 namespace crocoddyl {
 namespace python {

--- a/bindings/python/crocoddyl/multibody/frames.hpp
+++ b/bindings/python/crocoddyl/multibody/frames.hpp
@@ -63,6 +63,17 @@ void exposeFrames() {
                                               ":param oMf: Frame motion w.r.t. the origin"))
       .def_readwrite("frame", &FrameMotion::frame, "frame ID")
       .add_property("oMf", bp::make_getter(&FrameMotion::oMf, bp::return_internal_reference<>()), "frame motion");
+
+  bp::class_<FrameForce, boost::noncopyable>(
+      "FrameForce",
+      "Frame force describe using Pinocchio.\n\n"
+      "It defines a frame motion (tangent of SE(3) point) for a given frame ID",
+      bp::init<FrameIndex, pinocchio::Force>(bp::args(" self", " frame", " oFf"),
+                                              "Initialize the frame motion.\n\n"
+                                              ":param frame: frame ID\n"
+                                              ":param oFf: Frame force w.r.t. the origin"))
+      .def_readwrite("frame", &FrameForce::frame, "frame ID")
+      .add_property("oFf", bp::make_getter(&FrameForce::oFf, bp::return_internal_reference<>()), "frame force");
 }
 
 }  // namespace python

--- a/bindings/python/crocoddyl/multibody/frames.hpp
+++ b/bindings/python/crocoddyl/multibody/frames.hpp
@@ -10,6 +10,7 @@
 #define BINDINGS_PYTHON_CROCODDYL_MULTIBODY_FRAMES_HPP_
 
 #include "crocoddyl/multibody/frames.hpp"
+#include "python/crocoddyl/utils/printable.hpp"
 
 namespace crocoddyl {
 namespace python {

--- a/bindings/python/crocoddyl/multibody/frames.hpp
+++ b/bindings/python/crocoddyl/multibody/frames.hpp
@@ -27,7 +27,8 @@ void exposeFrames() {
                                             ":param oxf: Frame translation w.r.t. the origin"))
       .def_readwrite("frame", &FrameTranslation::frame, "frame ID")
       .add_property("oxf", bp::make_getter(&FrameTranslation::oxf, bp::return_value_policy<bp::return_by_value>()),
-                    bp::make_setter(&FrameTranslation::oxf), "frame translation");
+                    bp::make_setter(&FrameTranslation::oxf), "frame translation")
+      .def(PrintableVisitor<FrameTranslation>());
 
   bp::class_<FrameRotation, boost::noncopyable>(
       "FrameRotation",
@@ -39,7 +40,8 @@ void exposeFrames() {
                                             ":param oRf: Frame rotation w.r.t. the origin"))
       .def_readwrite("frame", &FrameRotation::frame, "frame ID")
       .add_property("oRf", bp::make_getter(&FrameRotation::oRf, bp::return_value_policy<bp::return_by_value>()),
-                    bp::make_setter(&FrameRotation::oRf), "frame rotation");
+                    bp::make_setter(&FrameRotation::oRf), "frame rotation")
+      .def(PrintableVisitor<FrameRotation>());
 
   bp::class_<FramePlacement, boost::noncopyable>(
       "FramePlacement",
@@ -50,8 +52,8 @@ void exposeFrames() {
                                            ":param frame: frame ID\n"
                                            ":param oMf: Frame placement w.r.t. the origin"))
       .def_readwrite("frame", &FramePlacement::frame, "frame ID")
-      .add_property("oMf", bp::make_getter(&FramePlacement::oMf, bp::return_internal_reference<>()),
-                    "frame placement");
+      .add_property("oMf", bp::make_getter(&FramePlacement::oMf, bp::return_internal_reference<>()), "frame placement")
+      .def(PrintableVisitor<FramePlacement>());
 
   bp::class_<FrameMotion, boost::noncopyable>(
       "FrameMotion",
@@ -62,18 +64,20 @@ void exposeFrames() {
                                               ":param frame: frame ID\n"
                                               ":param oMf: Frame motion w.r.t. the origin"))
       .def_readwrite("frame", &FrameMotion::frame, "frame ID")
-      .add_property("oMf", bp::make_getter(&FrameMotion::oMf, bp::return_internal_reference<>()), "frame motion");
+      .add_property("oMf", bp::make_getter(&FrameMotion::oMf, bp::return_internal_reference<>()), "frame motion")
+      .def(PrintableVisitor<FrameMotion>());
 
   bp::class_<FrameForce, boost::noncopyable>(
       "FrameForce",
       "Frame force describe using Pinocchio.\n\n"
       "It defines a frame motion (tangent of SE(3) point) for a given frame ID",
       bp::init<FrameIndex, pinocchio::Force>(bp::args(" self", " frame", " oFf"),
-                                              "Initialize the frame motion.\n\n"
-                                              ":param frame: frame ID\n"
-                                              ":param oFf: Frame force w.r.t. the origin"))
+                                             "Initialize the frame motion.\n\n"
+                                             ":param frame: frame ID\n"
+                                             ":param oFf: Frame force w.r.t. the origin"))
       .def_readwrite("frame", &FrameForce::frame, "frame ID")
-      .add_property("oFf", bp::make_getter(&FrameForce::oFf, bp::return_internal_reference<>()), "frame force");
+      .add_property("oFf", bp::make_getter(&FrameForce::oFf, bp::return_internal_reference<>()), "frame force")
+      .def(PrintableVisitor<FrameForce>());
 }
 
 }  // namespace python

--- a/bindings/python/crocoddyl/multibody/impulses/multiple-impulses.hpp
+++ b/bindings/python/crocoddyl/multibody/impulses/multiple-impulses.hpp
@@ -15,6 +15,7 @@
 #include <utility>
 #include <string>
 #include "crocoddyl/multibody/impulses/multiple-impulses.hpp"
+#include "python/crocoddyl/utils/map-converter.hpp"
 
 namespace crocoddyl {
 namespace python {

--- a/bindings/python/crocoddyl/utils.hpp
+++ b/bindings/python/crocoddyl/utils.hpp
@@ -171,4 +171,21 @@ struct dict_to_map {
 }  // namespace python
 }  // namespace crocoddyl
 
+namespace crocoddyl {
+namespace python {
+namespace bp = boost::python;
+
+///
+/// \brief Set the Python method __str__ and __repr__ to use the overloading operator<<.
+///
+template <class C>
+struct PrintableVisitor : public bp::def_visitor<PrintableVisitor<C> > {
+  template <class PyClass>
+  void visit(PyClass& cl) const {
+    cl.def(bp::self_ns::str(bp::self_ns::self)).def(bp::self_ns::repr(bp::self_ns::self));
+  }
+};
+}  // namespace python
+}  // namespace crocoddyl
+
 #endif  // BINDINGS_PYTHON_CROCODDYL_UTILS_HPP_

--- a/bindings/python/crocoddyl/utils/map-converter.hpp
+++ b/bindings/python/crocoddyl/utils/map-converter.hpp
@@ -1,16 +1,15 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2018-2019, LAAS-CNRS
+// Copyright (C) 2018-2020, LAAS-CNRS, University of Edinburgh
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifndef BINDINGS_PYTHON_CROCODDYL_UTILS_HPP_
-#define BINDINGS_PYTHON_CROCODDYL_UTILS_HPP_
+#ifndef BINDINGS_PYTHON_CROCODDYL_UTILS_MAP_CONVERTER_HPP_
+#define BINDINGS_PYTHON_CROCODDYL_UTILS_MAP_CONVERTER_HPP_
 
 #include <Eigen/Dense>
-#include <vector>
 #include <map>
 #include <boost/python/stl_iterator.hpp>
 #include <boost/python/to_python_converter.hpp>
@@ -19,73 +18,6 @@ namespace crocoddyl {
 namespace python {
 
 namespace bp = boost::python;
-
-/// @note Registers converter from a provided type to the python
-///       iterable type to the.
-template <class T, bool NoProxy = true>
-struct vector_to_list {
-  static PyObject* convert(const std::vector<T>& vec) {
-    typedef typename std::vector<T>::const_iterator const_iter;
-    bp::list* l = new boost::python::list();
-    for (const_iter it = vec.begin(); it != vec.end(); ++it) {
-      if (NoProxy) {
-        l->append(boost::ref(*it));
-      } else {
-        l->append(*it);
-      }
-    }
-    return l->ptr();
-  }
-  static PyTypeObject const* get_pytype() { return &PyList_Type; }
-};
-
-/// @brief Type that allows for registration of conversions from
-///        python iterable types.
-struct list_to_vector {
-  /// @note Registers converter from a python iterable type to the
-  ///       provided type.
-  template <typename Container>
-  list_to_vector& from_python() {
-    boost::python::converter::registry::push_back(&list_to_vector::convertible, &list_to_vector::construct<Container>,
-                                                  boost::python::type_id<Container>());
-
-    // Support chaining.
-    return *this;
-  }
-
-  /// @brief Check if PyObject is iterable.
-  static void* convertible(PyObject* object) { return PyObject_GetIter(object) ? object : NULL; }
-
-  /// @brief Convert iterable PyObject to C++ container type.
-  ///
-  /// Container Concept requirements:
-  ///
-  ///   * Container::value_type is CopyConstructable.
-  ///   * Container can be constructed and populated with two iterators.
-  ///     I.e. Container(begin, end)
-  template <typename Container>
-  static void construct(PyObject* object, boost::python::converter::rvalue_from_python_stage1_data* data) {
-    namespace python = boost::python;
-    // Object is a borrowed reference, so create a handle indicting it is
-    // borrowed for proper reference counting.
-    python::handle<> handle(python::borrowed(object));
-
-    // Obtain a handle to the memory block that the converter has allocated
-    // for the C++ type.
-    typedef python::converter::rvalue_from_python_storage<Container> storage_type;
-    void* storage = reinterpret_cast<storage_type*>(data)->storage.bytes;
-
-    typedef python::stl_input_iterator<typename Container::value_type> iterator;
-
-    // Allocate the C++ type into the converter's memory block, and assign
-    // its handle to the converter's convertible variable.  The C++
-    // container is populated by passing the begin and end iterators of
-    // the python object to the container's constructor.
-    new (storage) Container(iterator(python::object(handle)),  // begin
-                            iterator());                       // end
-    data->convertible = storage;
-  }
-};
 
 /// @note Registers converter from a provided type to the python
 ///       iterable type to the.
@@ -171,21 +103,4 @@ struct dict_to_map {
 }  // namespace python
 }  // namespace crocoddyl
 
-namespace crocoddyl {
-namespace python {
-namespace bp = boost::python;
-
-///
-/// \brief Set the Python method __str__ and __repr__ to use the overloading operator<<.
-///
-template <class C>
-struct PrintableVisitor : public bp::def_visitor<PrintableVisitor<C> > {
-  template <class PyClass>
-  void visit(PyClass& cl) const {
-    cl.def(bp::self_ns::str(bp::self_ns::self)).def(bp::self_ns::repr(bp::self_ns::self));
-  }
-};
-}  // namespace python
-}  // namespace crocoddyl
-
-#endif  // BINDINGS_PYTHON_CROCODDYL_UTILS_HPP_
+#endif  // BINDINGS_PYTHON_CROCODDYL_UTILS_MAP_CONVERTER_HPP_

--- a/bindings/python/crocoddyl/utils/printable.hpp
+++ b/bindings/python/crocoddyl/utils/printable.hpp
@@ -1,0 +1,32 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2018-2020, University of Edinburgh
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef BINDINGS_PYTHON_CROCODDYL_UTILS_PRINTABLE_HPP_
+#define BINDINGS_PYTHON_CROCODDYL_UTILS_PRINTABLE_HPP_
+
+#include <boost/python.hpp>
+
+namespace crocoddyl {
+namespace python {
+namespace bp = boost::python;
+
+///
+/// \brief Set the Python method __str__ and __repr__ to use the overloading operator<<.
+///
+template <class C>
+struct PrintableVisitor : public bp::def_visitor<PrintableVisitor<C> > {
+  template <class PyClass>
+  void visit(PyClass& cl) const {
+    cl.def(bp::self_ns::str(bp::self_ns::self)).def(bp::self_ns::repr(bp::self_ns::self));
+  }
+};
+
+}  // namespace python
+}  // namespace crocoddyl
+
+#endif  // BINDINGS_PYTHON_CROCODDYL_UTILS_PRINTABLE_HPP_

--- a/bindings/python/crocoddyl/utils/vector-converter.hpp
+++ b/bindings/python/crocoddyl/utils/vector-converter.hpp
@@ -1,0 +1,92 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2018-2020, LAAS-CNRS, University of Edinburgh
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef BINDINGS_PYTHON_CROCODDYL_UTILS_VECTOR_CONVERTER_HPP_
+#define BINDINGS_PYTHON_CROCODDYL_UTILS_VECTOR_CONVERTER_HPP_
+
+#include <Eigen/Dense>
+#include <vector>
+#include <boost/python/stl_iterator.hpp>
+#include <boost/python/to_python_converter.hpp>
+
+namespace crocoddyl {
+namespace python {
+
+namespace bp = boost::python;
+
+/// @note Registers converter from a provided type to the python
+///       iterable type to the.
+template <class T, bool NoProxy = true>
+struct vector_to_list {
+  static PyObject* convert(const std::vector<T>& vec) {
+    typedef typename std::vector<T>::const_iterator const_iter;
+    bp::list* l = new boost::python::list();
+    for (const_iter it = vec.begin(); it != vec.end(); ++it) {
+      if (NoProxy) {
+        l->append(boost::ref(*it));
+      } else {
+        l->append(*it);
+      }
+    }
+    return l->ptr();
+  }
+  static PyTypeObject const* get_pytype() { return &PyList_Type; }
+};
+
+/// @brief Type that allows for registration of conversions from
+///        python iterable types.
+struct list_to_vector {
+  /// @note Registers converter from a python iterable type to the
+  ///       provided type.
+  template <typename Container>
+  list_to_vector& from_python() {
+    boost::python::converter::registry::push_back(&list_to_vector::convertible, &list_to_vector::construct<Container>,
+                                                  boost::python::type_id<Container>());
+
+    // Support chaining.
+    return *this;
+  }
+
+  /// @brief Check if PyObject is iterable.
+  static void* convertible(PyObject* object) { return PyObject_GetIter(object) ? object : NULL; }
+
+  /// @brief Convert iterable PyObject to C++ container type.
+  ///
+  /// Container Concept requirements:
+  ///
+  ///   * Container::value_type is CopyConstructable.
+  ///   * Container can be constructed and populated with two iterators.
+  ///     I.e. Container(begin, end)
+  template <typename Container>
+  static void construct(PyObject* object, boost::python::converter::rvalue_from_python_stage1_data* data) {
+    namespace python = boost::python;
+    // Object is a borrowed reference, so create a handle indicting it is
+    // borrowed for proper reference counting.
+    python::handle<> handle(python::borrowed(object));
+
+    // Obtain a handle to the memory block that the converter has allocated
+    // for the C++ type.
+    typedef python::converter::rvalue_from_python_storage<Container> storage_type;
+    void* storage = reinterpret_cast<storage_type*>(data)->storage.bytes;
+
+    typedef python::stl_input_iterator<typename Container::value_type> iterator;
+
+    // Allocate the C++ type into the converter's memory block, and assign
+    // its handle to the converter's convertible variable.  The C++
+    // container is populated by passing the begin and end iterators of
+    // the python object to the container's constructor.
+    new (storage) Container(iterator(python::object(handle)),  // begin
+                            iterator());                       // end
+    data->convertible = storage;
+  }
+};
+
+}  // namespace python
+}  // namespace crocoddyl
+
+#endif  // BINDINGS_PYTHON_CROCODDYL_UTILS_VECTOR_CONVERTER_HPP_

--- a/examples/arm_manipulation.py
+++ b/examples/arm_manipulation.py
@@ -65,13 +65,11 @@ problem = crocoddyl.ShootingProblem(x0, [runningModel] * T, terminalModel)
 ddp = crocoddyl.SolverDDP(problem)
 cameraTF = [2., 2.68, 0.54, 0.2, 0.62, 0.72, 0.22]
 if WITHDISPLAY and WITHPLOT:
-    ddp.setCallbacks([
-        crocoddyl.CallbackLogger(),
-        crocoddyl.CallbackVerbose(),
-        crocoddyl.CallbackDisplay(talos_arm, 4, 4, cameraTF)
-    ])
+    display = crocoddyl.GepettoDisplay(talos_arm, 4, 4, cameraTF)
+    ddp.setCallbacks([crocoddyl.CallbackLogger(), crocoddyl.CallbackVerbose(), crocoddyl.CallbackDisplay(display)])
 elif WITHDISPLAY:
-    ddp.setCallbacks([crocoddyl.CallbackVerbose(), crocoddyl.CallbackDisplay(talos_arm, 4, 4, cameraTF)])
+    display = crocoddyl.GepettoDisplay(talos_arm, 4, 4, cameraTF)
+    ddp.setCallbacks([crocoddyl.CallbackVerbose(), crocoddyl.CallbackDisplay(display)])
 elif WITHPLOT:
     ddp.setCallbacks([
         crocoddyl.CallbackLogger(),
@@ -97,4 +95,5 @@ if WITHPLOT:
 
 # Visualizing the solution in gepetto-viewer
 if WITHDISPLAY:
-    crocoddyl.displayTrajectory(talos_arm, ddp.xs, runningModel.dt)
+    display = crocoddyl.GepettoDisplay(talos_arm, 4, 4, cameraTF)
+    display.display(talos_arm, ddp.xs, None, runningModel.dt)

--- a/examples/bipedal_walk.py
+++ b/examples/bipedal_walk.py
@@ -50,13 +50,13 @@ for i, phase in enumerate(GAITPHASES):
     # Added the callback functions
     print('*** SOLVE ' + key + ' ***')
     if WITHDISPLAY and WITHPLOT:
-        display = crocoddyl.GepettoDisplay(talos_legs, 4, 4, cameraTF)
+        display = crocoddyl.GepettoDisplay(talos_legs, 4, 4, cameraTF, frameNames=[rightFoot, leftFoot])
         ddp[i].setCallbacks(
             [crocoddyl.CallbackLogger(),
              crocoddyl.CallbackVerbose(),
              crocoddyl.CallbackDisplay(display)])
     elif WITHDISPLAY:
-        display = crocoddyl.GepettoDisplay(talos_legs, 4, 4, cameraTF)
+        display = crocoddyl.GepettoDisplay(talos_legs, 4, 4, cameraTF, frameNames=[rightFoot, leftFoot])
         ddp[i].setCallbacks([crocoddyl.CallbackVerbose(), crocoddyl.CallbackDisplay(display)])
     elif WITHPLOT:
         ddp[i].setCallbacks([
@@ -77,7 +77,7 @@ for i, phase in enumerate(GAITPHASES):
 
 # Display the entire motion
 if WITHDISPLAY:
-    display = crocoddyl.GepettoDisplay(talos_legs)
+    display = crocoddyl.GepettoDisplay(talos_legs, frameNames=[rightFoot, leftFoot])
     for i, phase in enumerate(GAITPHASES):
         display.displayFromSolver(ddp[i])
 

--- a/examples/bipedal_walk.py
+++ b/examples/bipedal_walk.py
@@ -79,7 +79,7 @@ for i, phase in enumerate(GAITPHASES):
 if WITHDISPLAY:
     display = crocoddyl.GepettoDisplay(talos_legs)
     for i, phase in enumerate(GAITPHASES):
-        display.display(ddp[i].xs, None, ddp[i].models()[0].dt)
+        display.displayFromSolver(ddp[i])
 
 # Plotting the entire motion
 if WITHPLOT:

--- a/examples/bipedal_walk.py
+++ b/examples/bipedal_walk.py
@@ -50,13 +50,14 @@ for i, phase in enumerate(GAITPHASES):
     # Added the callback functions
     print('*** SOLVE ' + key + ' ***')
     if WITHDISPLAY and WITHPLOT:
-        ddp[i].setCallbacks([
-            crocoddyl.CallbackLogger(),
-            crocoddyl.CallbackVerbose(),
-            crocoddyl.CallbackDisplay(talos_legs, 4, 4, cameraTF)
-        ])
+        display = crocoddyl.GepettoDisplay(talos_legs, 4, 4, cameraTF)
+        ddp[i].setCallbacks(
+            [crocoddyl.CallbackLogger(),
+             crocoddyl.CallbackVerbose(),
+             crocoddyl.CallbackDisplay(display)])
     elif WITHDISPLAY:
-        ddp[i].setCallbacks([crocoddyl.CallbackVerbose(), crocoddyl.CallbackDisplay(talos_legs, 4, 4, cameraTF)])
+        display = crocoddyl.GepettoDisplay(talos_legs, 4, 4, cameraTF)
+        ddp[i].setCallbacks([crocoddyl.CallbackVerbose(), crocoddyl.CallbackDisplay(display)])
     elif WITHPLOT:
         ddp[i].setCallbacks([
             crocoddyl.CallbackLogger(),
@@ -76,8 +77,9 @@ for i, phase in enumerate(GAITPHASES):
 
 # Display the entire motion
 if WITHDISPLAY:
+    display = crocoddyl.GepettoDisplay(talos_legs)
     for i, phase in enumerate(GAITPHASES):
-        crocoddyl.displayTrajectory(talos_legs, ddp[i].xs, ddp[i].models()[0].dt)
+        display.display(ddp[i].xs, None, ddp[i].models()[0].dt)
 
 # Plotting the entire motion
 if WITHPLOT:

--- a/examples/double_pendulum.py
+++ b/examples/double_pendulum.py
@@ -51,6 +51,8 @@ if WITHDISPLAY and WITHPLOT:
     ])
 elif WITHDISPLAY:
     fddp.setCallbacks([crocoddyl.CallbackVerbose(), crocoddyl.CallbackDisplay(robot, 4, 4, cameraTF, False)])
+elif WITHPLOT:
+    fddp.setCallbacks([crocoddyl.CallbackLogger(), crocoddyl.CallbackVerbose()])
 else:
     fddp.setCallbacks([crocoddyl.CallbackVerbose()])
 

--- a/examples/double_pendulum.py
+++ b/examples/double_pendulum.py
@@ -44,13 +44,11 @@ fddp = crocoddyl.SolverFDDP(problem)
 
 cameraTF = [1.4, 0., 0.2, 0.5, 0.5, 0.5, 0.5]
 if WITHDISPLAY and WITHPLOT:
-    fddp.setCallbacks([
-        crocoddyl.CallbackLogger(),
-        crocoddyl.CallbackVerbose(),
-        crocoddyl.CallbackDisplay(robot, 4, 4, cameraTF, False)
-    ])
+    display = crocoddyl.GepettoDisplay(robot, 4, 4, cameraTF)
+    fddp.setCallbacks([crocoddyl.CallbackLogger(), crocoddyl.CallbackVerbose(), crocoddyl.CallbackDisplay(display)])
 elif WITHDISPLAY:
-    fddp.setCallbacks([crocoddyl.CallbackVerbose(), crocoddyl.CallbackDisplay(robot, 4, 4, cameraTF, False)])
+    display = crocoddyl.GepettoDisplay(robot, 4, 4, cameraTF)
+    fddp.setCallbacks([crocoddyl.CallbackVerbose(), crocoddyl.CallbackDisplay(display)])
 elif WITHPLOT:
     fddp.setCallbacks([crocoddyl.CallbackLogger(), crocoddyl.CallbackVerbose()])
 else:
@@ -73,4 +71,5 @@ if WITHPLOT:
 
 # Display the entire motion
 if WITHDISPLAY:
-    crocoddyl.displayTrajectory(robot, fddp.xs, dt, False)
+    display = crocoddyl.GepettoDisplay(robot)
+    display.display(robot, fddp.xs, None, dt, False)

--- a/examples/double_pendulum.py
+++ b/examples/double_pendulum.py
@@ -44,10 +44,10 @@ fddp = crocoddyl.SolverFDDP(problem)
 
 cameraTF = [1.4, 0., 0.2, 0.5, 0.5, 0.5, 0.5]
 if WITHDISPLAY and WITHPLOT:
-    display = crocoddyl.GepettoDisplay(robot, 4, 4, cameraTF)
+    display = crocoddyl.GepettoDisplay(robot, 4, 4, cameraTF, False)
     fddp.setCallbacks([crocoddyl.CallbackLogger(), crocoddyl.CallbackVerbose(), crocoddyl.CallbackDisplay(display)])
 elif WITHDISPLAY:
-    display = crocoddyl.GepettoDisplay(robot, 4, 4, cameraTF)
+    display = crocoddyl.GepettoDisplay(robot, 4, 4, cameraTF, False)
     fddp.setCallbacks([crocoddyl.CallbackVerbose(), crocoddyl.CallbackDisplay(display)])
 elif WITHPLOT:
     fddp.setCallbacks([crocoddyl.CallbackLogger(), crocoddyl.CallbackVerbose()])
@@ -71,5 +71,5 @@ if WITHPLOT:
 
 # Display the entire motion
 if WITHDISPLAY:
-    display = crocoddyl.GepettoDisplay(robot)
-    display.display(robot, fddp.xs, None, dt, False)
+    display = crocoddyl.GepettoDisplay(robot, floor=False)
+    display.displayFromSolver(fddp)

--- a/examples/quadrotor.py
+++ b/examples/quadrotor.py
@@ -69,6 +69,8 @@ if WITHDISPLAY and WITHPLOT:
     ])
 elif WITHDISPLAY:
     fddp.setCallbacks([crocoddyl.CallbackVerbose(), crocoddyl.CallbackDisplay(hector, 4, 4, cameraTF, False)])
+elif WITHPLOT:
+    fddp.setCallbacks([crocoddyl.CallbackLogger(), crocoddyl.CallbackVerbose()])
 else:
     fddp.setCallbacks([crocoddyl.CallbackVerbose()])
 

--- a/examples/quadrotor.py
+++ b/examples/quadrotor.py
@@ -65,7 +65,7 @@ if WITHDISPLAY and WITHPLOT:
     display = crocoddyl.GepettoDisplay(hector, 4, 4, cameraTF)
     fddp.setCallbacks([crocoddyl.CallbackLogger(), crocoddyl.CallbackVerbose(), crocoddyl.CallbackDisplay(display)])
 elif WITHDISPLAY:
-    display = crocoddyl.GepettoDisplay(robot, 4, 4, cameraTF)
+    display = crocoddyl.GepettoDisplay(hector, 4, 4, cameraTF)
     fddp.setCallbacks([crocoddyl.CallbackVerbose(), crocoddyl.CallbackDisplay(display)])
 elif WITHPLOT:
     fddp.setCallbacks([crocoddyl.CallbackLogger(), crocoddyl.CallbackVerbose()])
@@ -95,4 +95,4 @@ if WITHDISPLAY:
         'world/wp',
         target_pos.tolist() + [target_quat[0], target_quat[1], target_quat[2], target_quat[3]])
 
-    display.display(hector, fddp.xs, None, dt, False)
+    display.displayFromSolver(fddp)

--- a/examples/quadrotor.py
+++ b/examples/quadrotor.py
@@ -62,13 +62,11 @@ fddp.setCallbacks([crocoddyl.CallbackLogger(), crocoddyl.CallbackVerbose()])
 
 cameraTF = [-0.03, 4.4, 2.3, -0.02, 0.56, 0.83, -0.03]
 if WITHDISPLAY and WITHPLOT:
-    fddp.setCallbacks([
-        crocoddyl.CallbackLogger(),
-        crocoddyl.CallbackVerbose(),
-        crocoddyl.CallbackDisplay(hector, 4, 4, cameraTF, False)
-    ])
+    display = crocoddyl.GepettoDisplay(hector, 4, 4, cameraTF)
+    fddp.setCallbacks([crocoddyl.CallbackLogger(), crocoddyl.CallbackVerbose(), crocoddyl.CallbackDisplay(display)])
 elif WITHDISPLAY:
-    fddp.setCallbacks([crocoddyl.CallbackVerbose(), crocoddyl.CallbackDisplay(hector, 4, 4, cameraTF, False)])
+    display = crocoddyl.GepettoDisplay(robot, 4, 4, cameraTF)
+    fddp.setCallbacks([crocoddyl.CallbackVerbose(), crocoddyl.CallbackDisplay(display)])
 elif WITHPLOT:
     fddp.setCallbacks([crocoddyl.CallbackLogger(), crocoddyl.CallbackVerbose()])
 else:
@@ -91,9 +89,10 @@ if WITHPLOT:
 
 # Display the entire motion
 if WITHDISPLAY:
+    display = crocoddyl.GepettoDisplay(hector)
     hector.viewer.gui.addXYZaxis('world/wp', [1., 0., 0., 1.], .03, 0.5)
     hector.viewer.gui.applyConfiguration(
         'world/wp',
         target_pos.tolist() + [target_quat[0], target_quat[1], target_quat[2], target_quat[3]])
 
-    crocoddyl.displayTrajectory(hector, fddp.xs, dt, False)
+    display.display(hector, fddp.xs, None, dt, False)

--- a/examples/quadrupedal_gaits.py
+++ b/examples/quadrupedal_gaits.py
@@ -101,13 +101,15 @@ for i, phase in enumerate(GAITPHASES):
     # Added the callback functions
     print('*** SOLVE ' + key + ' ***')
     if WITHDISPLAY and WITHPLOT:
+        display = crocoddyl.GepettoDisplay(anymal, 4, 4, cameraTF)
         ddp[i].setCallbacks([
             crocoddyl.CallbackLogger(),
             crocoddyl.CallbackVerbose(),
-            crocoddyl.CallbackDisplay(anymal, 4, 4, cameraTF)
+            crocoddyl.CallbackDisplay(display)
         ])
     elif WITHDISPLAY:
-        ddp[i].setCallbacks([crocoddyl.CallbackVerbose(), crocoddyl.CallbackDisplay(anymal, 4, 4, cameraTF)])
+        display = crocoddyl.GepettoDisplay(anymal, 4, 4, cameraTF)
+        ddp[i].setCallbacks([crocoddyl.CallbackVerbose(), crocoddyl.CallbackDisplay(display)])
     elif WITHPLOT:
         ddp[i].setCallbacks([
             crocoddyl.CallbackLogger(),
@@ -126,8 +128,9 @@ for i, phase in enumerate(GAITPHASES):
 
 # Display the entire motion
 if WITHDISPLAY:
+    display = crocoddyl.GepettoDisplay(anymal)
     for i, phase in enumerate(GAITPHASES):
-        crocoddyl.displayTrajectory(anymal, ddp[i].xs, ddp[i].models()[0].dt)
+        display.display(ddp[i].xs, None, ddp[i].models()[0].dt)
 
 # Plotting the entire motion
 if WITHPLOT:

--- a/examples/quadrupedal_gaits.py
+++ b/examples/quadrupedal_gaits.py
@@ -129,7 +129,7 @@ for i, phase in enumerate(GAITPHASES):
 if WITHDISPLAY:
     display = crocoddyl.GepettoDisplay(anymal)
     for i, phase in enumerate(GAITPHASES):
-        display.display(ddp[i].xs, None, ddp[i].models()[0].dt)
+        display.displayFromSolver(ddp[i])
 
 # Plotting the entire motion
 if WITHPLOT:

--- a/examples/quadrupedal_gaits.py
+++ b/examples/quadrupedal_gaits.py
@@ -101,13 +101,13 @@ for i, phase in enumerate(GAITPHASES):
     # Added the callback functions
     print('*** SOLVE ' + key + ' ***')
     if WITHDISPLAY and WITHPLOT:
-        display = crocoddyl.GepettoDisplay(anymal, 4, 4, cameraTF)
+        display = crocoddyl.GepettoDisplay(anymal, 4, 4, cameraTF, frameNames=[lfFoot, rfFoot, lhFoot, rhFoot])
         ddp[i].setCallbacks(
             [crocoddyl.CallbackLogger(),
              crocoddyl.CallbackVerbose(),
              crocoddyl.CallbackDisplay(display)])
     elif WITHDISPLAY:
-        display = crocoddyl.GepettoDisplay(anymal, 4, 4, cameraTF)
+        display = crocoddyl.GepettoDisplay(anymal, 4, 4, cameraTF, frameNames=[lfFoot, rfFoot, lhFoot, rhFoot])
         ddp[i].setCallbacks([crocoddyl.CallbackVerbose(), crocoddyl.CallbackDisplay(display)])
     elif WITHPLOT:
         ddp[i].setCallbacks([
@@ -127,7 +127,7 @@ for i, phase in enumerate(GAITPHASES):
 
 # Display the entire motion
 if WITHDISPLAY:
-    display = crocoddyl.GepettoDisplay(anymal)
+    display = crocoddyl.GepettoDisplay(anymal, frameNames=[lfFoot, rfFoot, lhFoot, rhFoot])
     for i, phase in enumerate(GAITPHASES):
         display.displayFromSolver(ddp[i])
 

--- a/examples/quadrupedal_gaits.py
+++ b/examples/quadrupedal_gaits.py
@@ -102,11 +102,10 @@ for i, phase in enumerate(GAITPHASES):
     print('*** SOLVE ' + key + ' ***')
     if WITHDISPLAY and WITHPLOT:
         display = crocoddyl.GepettoDisplay(anymal, 4, 4, cameraTF)
-        ddp[i].setCallbacks([
-            crocoddyl.CallbackLogger(),
-            crocoddyl.CallbackVerbose(),
-            crocoddyl.CallbackDisplay(display)
-        ])
+        ddp[i].setCallbacks(
+            [crocoddyl.CallbackLogger(),
+             crocoddyl.CallbackVerbose(),
+             crocoddyl.CallbackDisplay(display)])
     elif WITHDISPLAY:
         display = crocoddyl.GepettoDisplay(anymal, 4, 4, cameraTF)
         ddp[i].setCallbacks([crocoddyl.CallbackVerbose(), crocoddyl.CallbackDisplay(display)])

--- a/include/crocoddyl/multibody/contact-base.hpp
+++ b/include/crocoddyl/multibody/contact-base.hpp
@@ -62,6 +62,8 @@ struct ContactDataAbstract {
   ContactDataAbstract(Model* const model, pinocchio::Data* const data)
       : pinocchio(data),
         joint(0),
+        jMf(pinocchio::SE3::Identity()),
+        fXj(jMf.inverse().toActionMatrix()),
         Jc(model->get_nc(), model->get_state()->get_nv()),
         a0(model->get_nc()),
         da0_dx(model->get_nc(), model->get_state()->get_ndx()),
@@ -80,6 +82,8 @@ struct ContactDataAbstract {
 
   pinocchio::Data* pinocchio;
   pinocchio::JointIndex joint;
+  pinocchio::SE3 jMf;
+  pinocchio::SE3::ActionMatrixType fXj;
   Eigen::MatrixXd Jc;
   Eigen::VectorXd a0;
   Eigen::MatrixXd da0_dx;

--- a/include/crocoddyl/multibody/contact-base.hpp
+++ b/include/crocoddyl/multibody/contact-base.hpp
@@ -69,14 +69,12 @@ struct ContactDataAbstract {
         da0_dx(model->get_nc(), model->get_state()->get_ndx()),
         df_dx(model->get_nc(), model->get_state()->get_ndx()),
         df_du(model->get_nc(), model->get_nu()),
-        f(pinocchio::Force::Zero()),
-        frame_force(model->get_nc()) {
+        f(pinocchio::Force::Zero()) {
     Jc.fill(0);
     a0.fill(0);
     da0_dx.fill(0);
     df_dx.fill(0);
     df_du.fill(0);
-    frame_force.fill(0);
   }
   virtual ~ContactDataAbstract() {}
 
@@ -90,7 +88,6 @@ struct ContactDataAbstract {
   Eigen::MatrixXd df_dx;
   Eigen::MatrixXd df_du;
   pinocchio::Force f;
-  Eigen::VectorXd frame_force;
 };
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/multibody/contacts/contact-3d.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-3d.hpp
@@ -44,8 +44,6 @@ struct ContactData3D : public ContactDataAbstract {
   template <typename Model>
   ContactData3D(Model* const model, pinocchio::Data* const data)
       : ContactDataAbstract(model, data),
-        jMf(model->get_state()->get_pinocchio().frames[model->get_xref().frame].placement),
-        fXj(jMf.inverse().toActionMatrix()),
         fJf(6, model->get_state()->get_nv()),
         v_partial_dq(6, model->get_state()->get_nv()),
         a_partial_dq(6, model->get_state()->get_nv()),
@@ -55,6 +53,8 @@ struct ContactData3D : public ContactDataAbstract {
         fXjda_dq(6, model->get_state()->get_nv()),
         fXjda_dv(6, model->get_state()->get_nv()) {
     joint = model->get_state()->get_pinocchio().frames[model->get_xref().frame].parent;
+    jMf = model->get_state()->get_pinocchio().frames[model->get_xref().frame].placement;
+    fXj = jMf.inverse().toActionMatrix();
     fJf.fill(0);
     v_partial_dq.fill(0);
     a_partial_dq.fill(0);
@@ -70,8 +70,6 @@ struct ContactData3D : public ContactDataAbstract {
     oRf.fill(0);
   }
 
-  pinocchio::SE3 jMf;
-  pinocchio::SE3::ActionMatrixType fXj;
   pinocchio::Motion v;
   pinocchio::Motion a;
   pinocchio::Data::Matrix6x fJf;

--- a/include/crocoddyl/multibody/contacts/contact-6d.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-6d.hpp
@@ -44,23 +44,22 @@ struct ContactData6D : public ContactDataAbstract {
   template <typename Model>
   ContactData6D(Model* const model, pinocchio::Data* const data)
       : ContactDataAbstract(model, data),
-        jMf(model->get_state()->get_pinocchio().frames[model->get_Mref().frame].placement),
         rMf(pinocchio::SE3::Identity()),
-        fXj(jMf.inverse().toActionMatrix()),
         v_partial_dq(6, model->get_state()->get_nv()),
         a_partial_dq(6, model->get_state()->get_nv()),
         a_partial_dv(6, model->get_state()->get_nv()),
         a_partial_da(6, model->get_state()->get_nv()) {
     joint = model->get_state()->get_pinocchio().frames[model->get_Mref().frame].parent;
+    jMf = model->get_state()->get_pinocchio().frames[model->get_Mref().frame].placement;
+    fXj = jMf.inverse().toActionMatrix();
     v_partial_dq.fill(0);
     a_partial_dq.fill(0);
     a_partial_dv.fill(0);
     a_partial_da.fill(0);
     rMf_Jlog6.fill(0);
   }
-  pinocchio::SE3 jMf;
+
   pinocchio::SE3 rMf;
-  pinocchio::SE3::ActionMatrixType fXj;
   pinocchio::Motion v;
   pinocchio::Motion a;
   pinocchio::Data::Matrix6x v_partial_dq;

--- a/include/crocoddyl/multibody/costs/contact-force.hpp
+++ b/include/crocoddyl/multibody/costs/contact-force.hpp
@@ -11,20 +11,18 @@
 
 #include "crocoddyl/multibody/cost-base.hpp"
 #include "crocoddyl/multibody/contact-base.hpp"
+#include "crocoddyl/multibody/frames.hpp"
 
 namespace crocoddyl {
 
 class CostModelContactForce : public CostModelAbstract {
  public:
   CostModelContactForce(boost::shared_ptr<StateMultibody> state, boost::shared_ptr<ActivationModelAbstract> activation,
-                        boost::shared_ptr<ContactModelAbstract> contact, const Eigen::VectorXd& fref,
-                        const std::size_t& nu);
+                        const FrameForce& fref, const std::size_t& nu);
   CostModelContactForce(boost::shared_ptr<StateMultibody> state, boost::shared_ptr<ActivationModelAbstract> activation,
-                        boost::shared_ptr<ContactModelAbstract> contact, const Eigen::VectorXd& fref);
-  CostModelContactForce(boost::shared_ptr<StateMultibody> state, boost::shared_ptr<ContactModelAbstract> contact,
-                        const Eigen::VectorXd& fref, const std::size_t& nu);
-  CostModelContactForce(boost::shared_ptr<StateMultibody> state, boost::shared_ptr<ContactModelAbstract> contact,
-                        const Eigen::VectorXd& fref);
+                        const FrameForce& fref);
+  CostModelContactForce(boost::shared_ptr<StateMultibody> state, const FrameForce& fref, const std::size_t& nu);
+  CostModelContactForce(boost::shared_ptr<StateMultibody> state, const FrameForce& fref);
   ~CostModelContactForce();
 
   void calc(const boost::shared_ptr<CostDataAbstract>& data, const Eigen::Ref<const Eigen::VectorXd>& x,
@@ -33,11 +31,10 @@ class CostModelContactForce : public CostModelAbstract {
                 const Eigen::Ref<const Eigen::VectorXd>& u, const bool& recalc = true);
   boost::shared_ptr<CostDataAbstract> createData(pinocchio::Data* const data);
 
-  const Eigen::VectorXd& get_fref() const { return fref_; };
+  const FrameForce& get_fref() const;
 
  protected:
-  boost::shared_ptr<ContactModelAbstract> contact_;
-  Eigen::VectorXd fref_;
+  FrameForce fref_;
 };
 
 struct CostDataContactForce : public CostDataAbstract {

--- a/include/crocoddyl/multibody/frames.hpp
+++ b/include/crocoddyl/multibody/frames.hpp
@@ -21,30 +21,55 @@ typedef std::size_t FrameIndex;
 
 struct FrameTranslation {
   FrameTranslation(const FrameIndex& frame, const Eigen::Vector3d& oxf) : frame(frame), oxf(oxf) {}
+  friend std::ostream& operator<<(std::ostream& os, const FrameTranslation& X) {
+    os << "      frame: " << X.frame << std::endl << "translation: " << std::endl << X.oxf.transpose() << std::endl;
+    return os;
+  }
+
   FrameIndex frame;
   Eigen::Vector3d oxf;
 };
 
 struct FrameRotation {
   FrameRotation(const FrameIndex& frame, const Eigen::Matrix3d& oRf) : frame(frame), oRf(oRf) {}
+  friend std::ostream& operator<<(std::ostream& os, const FrameRotation& X) {
+    os << "   frame: " << X.frame << std::endl << "rotation: " << std::endl << X.oRf << std::endl;
+    return os;
+  }
+
   FrameIndex frame;
   Eigen::Matrix3d oRf;
 };
 
 struct FramePlacement {
   FramePlacement(const FrameIndex& frame, const pinocchio::SE3& oMf) : frame(frame), oMf(oMf) {}
+  friend std::ostream& operator<<(std::ostream& os, const FramePlacement& X) {
+    os << "    frame: " << X.frame << std::endl << "placement: " << std::endl << X.oMf << std::endl;
+    return os;
+  }
+
   FrameIndex frame;
   pinocchio::SE3 oMf;
 };
 
 struct FrameMotion {
   FrameMotion(const FrameIndex& frame, const pinocchio::Motion& oMf) : frame(frame), oMf(oMf) {}
+  friend std::ostream& operator<<(std::ostream& os, const FrameMotion& X) {
+    os << " frame: " << X.frame << std::endl << "motion: " << std::endl << X.oMf << std::endl;
+    return os;
+  }
+
   FrameIndex frame;
   pinocchio::Motion oMf;
 };
 
 struct FrameForce {
-  FrameForce(const FrameIndex& frame, const pinocchio::Force& oFf) :  frame(frame), oFf(oFf) {}
+  FrameForce(const FrameIndex& frame, const pinocchio::Force& oFf) : frame(frame), oFf(oFf) {}
+  friend std::ostream& operator<<(std::ostream& os, const FrameForce& X) {
+    os << "frame: " << X.frame << std::endl << "force: " << std::endl << X.oFf << std::endl;
+    return os;
+  }
+
   FrameIndex frame;
   pinocchio::Force oFf;
 };

--- a/include/crocoddyl/multibody/frames.hpp
+++ b/include/crocoddyl/multibody/frames.hpp
@@ -13,6 +13,7 @@
 #include <Eigen/Dense>
 #include <pinocchio/spatial/se3.hpp>
 #include <pinocchio/spatial/motion.hpp>
+#include <pinocchio/spatial/force.hpp>
 
 namespace crocoddyl {
 
@@ -40,6 +41,12 @@ struct FrameMotion {
   FrameMotion(const FrameIndex& frame, const pinocchio::Motion& oMf) : frame(frame), oMf(oMf) {}
   FrameIndex frame;
   pinocchio::Motion oMf;
+};
+
+struct FrameForce {
+  FrameForce(const FrameIndex& frame, const pinocchio::Force& oFf) :  frame(frame), oFf(oFf) {}
+  FrameIndex frame;
+  pinocchio::Force oFf;
 };
 
 }  // namespace crocoddyl

--- a/src/multibody/contacts/contact-3d.cpp
+++ b/src/multibody/contacts/contact-3d.cpp
@@ -76,7 +76,6 @@ void ContactModel3D::calcDiff(const boost::shared_ptr<ContactDataAbstract>& data
 void ContactModel3D::updateForce(const boost::shared_ptr<ContactDataAbstract>& data, const Eigen::VectorXd& force) {
   assert(force.size() == 3 && "lambda has wrong dimension, it should be 3d vector");
   ContactData3D* d = static_cast<ContactData3D*>(data.get());
-  d->frame_force = force;
   data->f = d->jMf.act(pinocchio::Force(force, Eigen::Vector3d::Zero()));
 }
 

--- a/src/multibody/contacts/contact-6d.cpp
+++ b/src/multibody/contacts/contact-6d.cpp
@@ -68,7 +68,6 @@ void ContactModel6D::calcDiff(const boost::shared_ptr<ContactDataAbstract>& data
 void ContactModel6D::updateForce(const boost::shared_ptr<ContactDataAbstract>& data, const Eigen::VectorXd& force) {
   assert(force.size() == 6 && "force has wrong dimension, it should be 6d vector");
   ContactData6D* d = static_cast<ContactData6D*>(data.get());
-  d->frame_force = force;
   data->f = d->jMf.act(pinocchio::Force(force));
 }
 

--- a/unittest/bindings/test_force_cost.py
+++ b/unittest/bindings/test_force_cost.py
@@ -15,10 +15,13 @@ CONTACT_6D = crocoddyl.ContactModel6D(
     ROBOT_STATE, crocoddyl.FramePlacement(ROBOT_MODEL.getFrameId('r_sole'), pinocchio.SE3.Random()), ACTUATION.nu,
     pinocchio.utils.rand(2))
 CONTACTS.addContact("r_sole_contact", CONTACT_6D)
-costs = crocoddyl.CostModelSum(ROBOT_STATE, ACTUATION.nu, False)
-costs.addCost("force", crocoddyl.CostModelContactForce(ROBOT_STATE, CONTACT_6D, pinocchio.utils.rand(6), ACTUATION.nu),
-              1.)
-MODEL = crocoddyl.DifferentialActionModelContactFwdDynamics(ROBOT_STATE, ACTUATION, CONTACTS, costs, 0., True)
+COSTS = crocoddyl.CostModelSum(ROBOT_STATE, ACTUATION.nu, False)
+COSTS.addCost(
+    "force",
+    crocoddyl.CostModelContactForce(ROBOT_STATE,
+                                    crocoddyl.FrameForce(ROBOT_MODEL.getFrameId('r_sole'), pinocchio.Force.Random()),
+                                    ACTUATION.nu), 1.)
+MODEL = crocoddyl.DifferentialActionModelContactFwdDynamics(ROBOT_STATE, ACTUATION, CONTACTS, COSTS, 0., True)
 DATA = MODEL.createData()
 DATA.costs.costs["force"].contact = DATA.contacts.contacts["r_sole_contact"]
 
@@ -35,7 +38,7 @@ x = ROBOT_STATE.rand()
 u = pinocchio.utils.rand(ACTUATION.nu)
 MODEL.calcDiff(DATA, x, u)
 MODEL_ND.calcDiff(dnum, x, u)
-np.allclose(DATA.Fx, dnum.Fx, atol=1e6 * MODEL_ND.disturbance)
-np.allclose(DATA.Fu, dnum.Fu, atol=1e6 * MODEL_ND.disturbance)
-np.allclose(DATA.Lx, dnum.Lx, atol=1e6 * MODEL_ND.disturbance)
-np.allclose(DATA.Lu, dnum.Lu, atol=1e6 * MODEL_ND.disturbance)
+np.allclose(DATA.Fx, dnum.Fx, atol=MODEL_ND.disturbance)
+np.allclose(DATA.Fu, dnum.Fu, atol=MODEL_ND.disturbance)
+np.allclose(DATA.Lx, dnum.Lx, atol=MODEL_ND.disturbance)
+np.allclose(DATA.Lu, dnum.Lu, atol=MODEL_ND.disturbance)

--- a/unittest/python/test_dynamic_derivatives.py
+++ b/unittest/python/test_dynamic_derivatives.py
@@ -107,7 +107,7 @@ assertNumDiff(D, -data.ddq_dq, NUMDIFF_MODIFIER * h)  # threshold was 1e-3, is n
 # ---- ABA AND RNEA with forces
 
 # Set forces container
-fs = pinocchio.StdVect_Force()
+fs = pinocchio.StdVec_Force()
 for i in range(model.njoints):
     fs.append(pinocchio.Force.Random())
 


### PR DESCRIPTION
This PR improves functionalities regarding the contact forces. Now it is possible to display those forces plus desired frame trajectories in Gepetto viewer. For that, the PR proposes an encapsulation of display classes called GepettoDisplay, with this approach, we could add in future other viewers such as MeshCat.

Additionally, I improved the contact models in such a way that removes the needed of frame_force (duplication data). The force-cost API has been also changed to match frame-costs. It required to define a FrameForce object and included its Python bindings. Note the the force cost is still under developed since it does not produce any effect inside the contact action model.

Finally, the PR reorganizes the utils code for Python bindings.

It solves loco-3d#292