### PR TITLE
update the unittests of the solver using a solver factory

### DIFF
--- a/unittest/solver_factory.hpp
+++ b/unittest/solver_factory.hpp
@@ -1,7 +1,8 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2018-2019, LAAS-CNRS
+// Copyright (C) 2018-2020, LAAS-CNRS, New York University,
+//                          Max Planck Gesellschaft, University of Edinburgh
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////

--- a/unittest/solver_factory.hpp
+++ b/unittest/solver_factory.hpp
@@ -1,0 +1,90 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2018-2019, LAAS-CNRS
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#include "crocoddyl/core/solver-base.hpp"
+#include "crocoddyl/core/solvers/kkt.hpp"
+#include "crocoddyl/core/solvers/ddp.hpp"
+#include "crocoddyl/core/solvers/fddp.hpp"
+
+#include "action_factory.hpp"
+
+#ifndef CROCODDYL_STATE_FACTORY_HPP_
+#define CROCODDYL_STATE_FACTORY_HPP_
+
+namespace crocoddyl_unit_test {
+
+struct SolverTypes {
+  enum Type {
+    SolverKKT,
+    SolverDDP,
+    SolverFDDP,
+    SolverBoxDDP,
+    NbSolverTypes
+  };
+  static std::vector<Type> init_all() {
+    std::vector<Type> v;
+    v.clear();
+    for (int i = 0; i < NbSolverTypes; ++i) {
+      v.push_back((Type)i);
+    }
+    return v;
+  }
+  static const std::vector<Type> all;
+};
+const std::vector<SolverTypes::Type> SolverTypes::all(SolverTypes::init_all());
+
+class SolverFactory {
+ public:
+  SolverFactory(SolverTypes::Type solver_type, ActionModelTypes::Type action_type,
+                size_t nb_running_models) {
+    // default initialization
+    solver_type_ = solver_type;
+    action_factory_ = boost::make_shared<ActionModelFactory>(action_type);
+    nb_running_models_ = nb_running_models;
+
+    running_models_.resize(nb_running_models_, action_factory_->get_action_model());
+    problem_ = boost::make_shared<crocoddyl::ShootingProblem>(
+        action_factory_->get_action_model()->get_state()->zero(),
+        running_models_,
+        action_factory_->get_action_model());
+
+    switch (solver_type_) {
+      case SolverTypes::SolverKKT:
+        solver_ = boost::make_shared<crocoddyl::SolverKKT>(problem_);
+        break;
+      case SolverTypes::SolverDDP:
+        solver_ = boost::make_shared<crocoddyl::SolverDDP>(problem_);
+        break;
+      case SolverTypes::SolverFDDP:
+        solver_ = boost::make_shared<crocoddyl::SolverFDDP>(problem_);
+        break;
+      case SolverTypes::SolverBoxDDP:
+        solver_ = boost::make_shared<crocoddyl::SolverFDDP>(problem_);
+        break;
+      default:
+        throw std::runtime_error(__FILE__ ": Wrong SolverTypes::Type given");
+        break;
+    }
+  }
+
+  ~SolverFactory() {}
+
+  boost::shared_ptr<crocoddyl::SolverAbstract> get_solver() { return solver_; }
+
+ private:
+  size_t nb_running_models_; //!< This is the number of models in the shooting problem.
+  SolverTypes::Type solver_type_; //!< The current type to test
+  boost::shared_ptr<crocoddyl::SolverAbstract> solver_; //!< The pointer to the solver in testing
+  boost::shared_ptr<ActionModelFactory> action_factory_; //!< The pointer to the action_model in testing
+  std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstract> > running_models_; //!< The list of models in the shooting problem
+  boost::shared_ptr<crocoddyl::ShootingProblem> problem_; //!< The pointer to the shooting problem in testing
+};
+
+}  // namespace crocoddyl_unit_test
+
+#endif  // CROCODDYL_STATE_FACTORY_HPP_

--- a/unittest/solver_factory.hpp
+++ b/unittest/solver_factory.hpp
@@ -19,13 +19,7 @@
 namespace crocoddyl_unit_test {
 
 struct SolverTypes {
-  enum Type {
-    SolverKKT,
-    SolverDDP,
-    SolverFDDP,
-    SolverBoxDDP,
-    NbSolverTypes
-  };
+  enum Type { SolverKKT, SolverDDP, SolverFDDP, SolverBoxDDP, NbSolverTypes };
   static std::vector<Type> init_all() {
     std::vector<Type> v;
     v.clear();
@@ -40,18 +34,15 @@ const std::vector<SolverTypes::Type> SolverTypes::all(SolverTypes::init_all());
 
 class SolverFactory {
  public:
-  SolverFactory(SolverTypes::Type solver_type, ActionModelTypes::Type action_type,
-                size_t nb_running_models) {
+  SolverFactory(SolverTypes::Type solver_type, ActionModelTypes::Type action_type, size_t nb_running_models) {
     // default initialization
     solver_type_ = solver_type;
     action_factory_ = boost::make_shared<ActionModelFactory>(action_type);
     nb_running_models_ = nb_running_models;
 
     running_models_.resize(nb_running_models_, action_factory_->get_action_model());
-    problem_ = boost::make_shared<crocoddyl::ShootingProblem>(
-        action_factory_->get_action_model()->get_state()->zero(),
-        running_models_,
-        action_factory_->get_action_model());
+    problem_ = boost::make_shared<crocoddyl::ShootingProblem>(action_factory_->get_action_model()->get_state()->zero(),
+                                                              running_models_, action_factory_->get_action_model());
 
     switch (solver_type_) {
       case SolverTypes::SolverKKT:
@@ -77,12 +68,13 @@ class SolverFactory {
   boost::shared_ptr<crocoddyl::SolverAbstract> get_solver() { return solver_; }
 
  private:
-  size_t nb_running_models_; //!< This is the number of models in the shooting problem.
-  SolverTypes::Type solver_type_; //!< The current type to test
-  boost::shared_ptr<crocoddyl::SolverAbstract> solver_; //!< The pointer to the solver in testing
-  boost::shared_ptr<ActionModelFactory> action_factory_; //!< The pointer to the action_model in testing
-  std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstract> > running_models_; //!< The list of models in the shooting problem
-  boost::shared_ptr<crocoddyl::ShootingProblem> problem_; //!< The pointer to the shooting problem in testing
+  size_t nb_running_models_;                              //!< This is the number of models in the shooting problem.
+  SolverTypes::Type solver_type_;                         //!< The current type to test
+  boost::shared_ptr<crocoddyl::SolverAbstract> solver_;   //!< The pointer to the solver in testing
+  boost::shared_ptr<ActionModelFactory> action_factory_;  //!< The pointer to the action_model in testing
+  std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstract> >
+      running_models_;                                     //!< The list of models in the shooting problem
+  boost::shared_ptr<crocoddyl::ShootingProblem> problem_;  //!< The pointer to the shooting problem in testing
 };
 
 }  // namespace crocoddyl_unit_test

--- a/unittest/test_solvers.cpp
+++ b/unittest/test_solvers.cpp
@@ -1,8 +1,8 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2018-2020, University of Edinburgh, New York University,
-//                          Max Planck Gesellschaft
+// Copyright (C) 2018-2020, LAAS-CNRS, New York University,
+//                          Max Planck Gesellschaft, University of Edinburgh
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////

--- a/unittest/test_solvers.cpp
+++ b/unittest/test_solvers.cpp
@@ -19,8 +19,7 @@ using namespace crocoddyl_unit_test;
 void test_kkt_dimension(ActionModelTypes::Type action_type, size_t nb_running_models) {
   // Create the kkt solver
   SolverFactory factory(SolverTypes::SolverKKT, action_type, nb_running_models);
-  boost::shared_ptr<crocoddyl::SolverKKT> kkt =
-    boost::static_pointer_cast<crocoddyl::SolverKKT>(factory.get_solver());
+  boost::shared_ptr<crocoddyl::SolverKKT> kkt = boost::static_pointer_cast<crocoddyl::SolverKKT>(factory.get_solver());
 
   // define some aliases
   const std::size_t& T = kkt->get_problem()->get_T();
@@ -41,8 +40,7 @@ void test_kkt_dimension(ActionModelTypes::Type action_type, size_t nb_running_mo
 void test_kkt_search_direction(ActionModelTypes::Type action_type, size_t nb_running_models) {
   // Create the kkt solver
   SolverFactory factory(SolverTypes::SolverKKT, action_type, nb_running_models);
-  boost::shared_ptr<crocoddyl::SolverKKT> kkt =
-    boost::static_pointer_cast<crocoddyl::SolverKKT>(factory.get_solver());
+  boost::shared_ptr<crocoddyl::SolverKKT> kkt = boost::static_pointer_cast<crocoddyl::SolverKKT>(factory.get_solver());
 
   // Compute the search direction
   kkt->computeDirection();
@@ -57,17 +55,17 @@ void test_kkt_search_direction(ActionModelTypes::Type action_type, size_t nb_run
   BOOST_CHECK((hess - hess.transpose()).isMuchSmallerThan(1.0, 1e-9));
 
   // Check initial state
-  BOOST_CHECK((kkt->get_dxs()[0] - kkt->get_problem()->get_x0()).
-      isMuchSmallerThan(1.0, 1e-9));
+  BOOST_CHECK((kkt->get_dxs()[0] - kkt->get_problem()->get_x0()).isMuchSmallerThan(1.0, 1e-9));
 }
 
 //____________________________________________________________________________//
 
-void test_solver_against_kkt_solver(SolverTypes::Type solver_type, ActionModelTypes::Type action_type, size_t nb_running_models) {
+void test_solver_against_kkt_solver(SolverTypes::Type solver_type, ActionModelTypes::Type action_type,
+                                    size_t nb_running_models) {
   // Create the solver
   SolverFactory solver_factory(solver_type, action_type, nb_running_models);
   boost::shared_ptr<crocoddyl::SolverAbstract> solver =
-    boost::static_pointer_cast<crocoddyl::SolverKKT>(solver_factory.get_solver());
+      boost::static_pointer_cast<crocoddyl::SolverKKT>(solver_factory.get_solver());
 
   // Get the pointer to the problem so we can create the equivalent kkt solver.
   const boost::shared_ptr<crocoddyl::ShootingProblem>& problem = solver->get_problem();
@@ -116,18 +114,19 @@ void test_solver_against_kkt_solver(SolverTypes::Type solver_type, ActionModelTy
 bool init_function() {
   size_t nb_running_models = 10;
 
-  for(size_t action_type = 0 ; action_type < ActionModelTypes::all.size() ; ++action_type)
-  {
-    framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_kkt_dimension, ActionModelTypes::all[action_type], nb_running_models)));
-    framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_kkt_search_direction, ActionModelTypes::all[action_type], nb_running_models)));
+  for (size_t action_type = 0; action_type < ActionModelTypes::all.size(); ++action_type) {
+    framework::master_test_suite().add(
+        BOOST_TEST_CASE(boost::bind(&test_kkt_dimension, ActionModelTypes::all[action_type], nb_running_models)));
+    framework::master_test_suite().add(BOOST_TEST_CASE(
+        boost::bind(&test_kkt_search_direction, ActionModelTypes::all[action_type], nb_running_models)));
   }
-  
+
   // We start from 1 as 0 is the kkt solver
-  for(size_t solver_type = 1 ; solver_type < SolverTypes::all.size() ; ++solver_type)
-  {
-    for(size_t action_type = 0 ; action_type < ActionModelTypes::all.size() ; ++action_type)
-    {
-      framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_solver_against_kkt_solver, SolverTypes::all[solver_type], ActionModelTypes::all[action_type], nb_running_models)));
+  for (size_t solver_type = 1; solver_type < SolverTypes::all.size(); ++solver_type) {
+    for (size_t action_type = 0; action_type < ActionModelTypes::all.size(); ++action_type) {
+      framework::master_test_suite().add(
+          BOOST_TEST_CASE(boost::bind(&test_solver_against_kkt_solver, SolverTypes::all[solver_type],
+                                      ActionModelTypes::all[action_type], nb_running_models)));
     }
   }
   return true;

--- a/unittest/test_solvers.cpp
+++ b/unittest/test_solvers.cpp
@@ -7,62 +7,76 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#define BOOST_TEST_NO_MAIN
-#define BOOST_TEST_ALTERNATIVE_INIT_API
-
-#include <Eigen/Dense>
-#include <boost/test/included/unit_test.hpp>
-#include <boost/bind.hpp>
-#include "action_factory.hpp"
 #include "crocoddyl/core/utils/callbacks.hpp"
-#include "crocoddyl/core/solvers/kkt.hpp"
-#include "crocoddyl/core/solvers/ddp.hpp"
-#include "crocoddyl/core/solvers/fddp.hpp"
+#include "solver_factory.hpp"
+#include "unittest_common.hpp"
 
 using namespace boost::unit_test;
 using namespace crocoddyl_unit_test;
 
 //____________________________________________________________________________//
 
-void test_kkt_dimension(const boost::shared_ptr<crocoddyl::ShootingProblem>& problem) {
-  crocoddyl::SolverKKT kkt(problem);
-  const std::size_t& T = problem->get_T();
-  const std::size_t& ndx = kkt.get_ndx();
-  const std::size_t& nu = kkt.get_nu();
-  BOOST_CHECK_EQUAL(kkt.get_kkt().rows(), 2 * ndx + nu);
-  BOOST_CHECK_EQUAL(kkt.get_kkt().cols(), 2 * ndx + nu);
-  BOOST_CHECK_EQUAL(kkt.get_kktref().size(), 2 * ndx + nu);
-  BOOST_CHECK_EQUAL(kkt.get_primaldual().size(), 2 * ndx + nu);
-  BOOST_CHECK_EQUAL(kkt.get_us().size(), T);
-  BOOST_CHECK_EQUAL(kkt.get_xs().size(), T + 1);
+void test_kkt_dimension(ActionModelTypes::Type action_type, size_t nb_running_models) {
+  // Create the kkt solver
+  SolverFactory factory(SolverTypes::SolverKKT, action_type, nb_running_models);
+  boost::shared_ptr<crocoddyl::SolverKKT> kkt =
+    boost::static_pointer_cast<crocoddyl::SolverKKT>(factory.get_solver());
+
+  // define some aliases
+  const std::size_t& T = kkt->get_problem()->get_T();
+  const std::size_t& ndx = kkt->get_ndx();
+  const std::size_t& nu = kkt->get_nu();
+
+  // Test the different matrix sizes
+  BOOST_CHECK_EQUAL(kkt->get_kkt().rows(), 2 * ndx + nu);
+  BOOST_CHECK_EQUAL(kkt->get_kkt().cols(), 2 * ndx + nu);
+  BOOST_CHECK_EQUAL(kkt->get_kktref().size(), 2 * ndx + nu);
+  BOOST_CHECK_EQUAL(kkt->get_primaldual().size(), 2 * ndx + nu);
+  BOOST_CHECK_EQUAL(kkt->get_us().size(), T);
+  BOOST_CHECK_EQUAL(kkt->get_xs().size(), T + 1);
 }
 
 //____________________________________________________________________________//
 
-void test_kkt_search_direction(const boost::shared_ptr<crocoddyl::ShootingProblem>& problem) {
-  crocoddyl::SolverKKT kkt(problem);
-  kkt.computeDirection();
+void test_kkt_search_direction(ActionModelTypes::Type action_type, size_t nb_running_models) {
+  // Create the kkt solver
+  SolverFactory factory(SolverTypes::SolverKKT, action_type, nb_running_models);
+  boost::shared_ptr<crocoddyl::SolverKKT> kkt =
+    boost::static_pointer_cast<crocoddyl::SolverKKT>(factory.get_solver());
 
-  const std::size_t& ndx = kkt.get_ndx();
-  const std::size_t& nu = kkt.get_nu();
-  Eigen::MatrixXd kkt_mat = kkt.get_kkt();
+  // Compute the search direction
+  kkt->computeDirection();
+
+  // define some aliases
+  const std::size_t& ndx = kkt->get_ndx();
+  const std::size_t& nu = kkt->get_nu();
+  Eigen::MatrixXd kkt_mat = kkt->get_kkt();
   Eigen::Block<Eigen::MatrixXd> hess = kkt_mat.block(0, 0, ndx + nu, ndx + nu);
 
   // Checking the symmetricity of the Hessian
   BOOST_CHECK((hess - hess.transpose()).isMuchSmallerThan(1.0, 1e-9));
 
   // Check initial state
-  BOOST_CHECK((kkt.get_dxs()[0] - problem->get_x0()).isMuchSmallerThan(1.0, 1e-9));
+  BOOST_CHECK((kkt->get_dxs()[0] - kkt->get_problem()->get_x0()).
+      isMuchSmallerThan(1.0, 1e-9));
 }
 
 //____________________________________________________________________________//
 
-void test_solver_against_kkt_solver(const boost::shared_ptr<crocoddyl::SolverAbstract>& solver) {
+void test_solver_against_kkt_solver(SolverTypes::Type solver_type, ActionModelTypes::Type action_type, size_t nb_running_models) {
+  // Create the solver
+  SolverFactory solver_factory(solver_type, action_type, nb_running_models);
+  boost::shared_ptr<crocoddyl::SolverAbstract> solver =
+    boost::static_pointer_cast<crocoddyl::SolverKKT>(solver_factory.get_solver());
+
+  // Get the pointer to the problem so we can create the equivalent kkt solver.
   const boost::shared_ptr<crocoddyl::ShootingProblem>& problem = solver->get_problem();
 
+  // Define the callback function
   std::vector<boost::shared_ptr<crocoddyl::CallbackAbstract> > cbs;
   cbs.push_back(boost::make_shared<crocoddyl::CallbackVerbose>());
 
+  // Genreate the different state along the trajectory
   const std::size_t& T = problem->get_T();
   std::vector<Eigen::VectorXd> xs;
   std::vector<Eigen::VectorXd> us;
@@ -73,10 +87,12 @@ void test_solver_against_kkt_solver(const boost::shared_ptr<crocoddyl::SolverAbs
   }
   xs.push_back(problem->get_x0());
 
+  // Solve the problem using the KKT solver
   crocoddyl::SolverKKT kkt(problem);
   kkt.setCallbacks(cbs);
   kkt.solve(xs, us, 100);
 
+  // Solve the problem using the solver in testing
   solver->setCallbacks(cbs);
   solver->solve(xs, us, 100);
 
@@ -97,57 +113,23 @@ void test_solver_against_kkt_solver(const boost::shared_ptr<crocoddyl::SolverAbs
 
 //____________________________________________________________________________//
 
-void register_kkt_unit_tests(std::size_t T, ActionModelTypes::Type action_type) {
-  ActionModelFactory factory(action_type);
-  const boost::shared_ptr<crocoddyl::ActionModelAbstract>& model = factory.get_action_model();
-
-  std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstract> > runningModels(T, model);
-  boost::shared_ptr<crocoddyl::ShootingProblem> problem =
-      boost::make_shared<crocoddyl::ShootingProblem>(model->get_state()->zero(), runningModels, model);
-
-  framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_kkt_dimension, problem)));
-  framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_kkt_search_direction, problem)));
-}
-
-//____________________________________________________________________________//
-
-void register_ddp_unit_tests(std::size_t T, ActionModelTypes::Type action_type) {
-  ActionModelFactory factory(action_type);
-  const boost::shared_ptr<crocoddyl::ActionModelAbstract>& model = factory.get_action_model();
-
-  std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstract> > runningModels(T, model);
-  boost::shared_ptr<crocoddyl::ShootingProblem> problem =
-      boost::make_shared<crocoddyl::ShootingProblem>(model->get_state()->zero(), runningModels, model);
-
-  boost::shared_ptr<crocoddyl::SolverAbstract> ddp = boost::make_shared<crocoddyl::SolverDDP>(problem);
-  framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_solver_against_kkt_solver, ddp)));
-}
-
-//____________________________________________________________________________//
-
-void register_fddp_unit_tests(std::size_t T, ActionModelTypes::Type action_type) {
-  ActionModelFactory factory(action_type);
-  const boost::shared_ptr<crocoddyl::ActionModelAbstract>& model = factory.get_action_model();
-
-  std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstract> > runningModels(T, model);
-  boost::shared_ptr<crocoddyl::ShootingProblem> problem =
-      boost::make_shared<crocoddyl::ShootingProblem>(model->get_state()->zero(), runningModels, model);
-
-  boost::shared_ptr<crocoddyl::SolverAbstract> ddp = boost::make_shared<crocoddyl::SolverFDDP>(problem);
-  framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_solver_against_kkt_solver, ddp)));
-}
-
-//____________________________________________________________________________//
-
 bool init_function() {
-  register_kkt_unit_tests(10, ActionModelTypes::ActionModelLQR);
-  register_kkt_unit_tests(10, ActionModelTypes::ActionModelUnicycle);
+  size_t nb_running_models = 10;
 
-  register_ddp_unit_tests(10, ActionModelTypes::ActionModelLQR);
-  register_ddp_unit_tests(10, ActionModelTypes::ActionModelUnicycle);
-
-  register_fddp_unit_tests(10, ActionModelTypes::ActionModelLQR);
-  register_fddp_unit_tests(10, ActionModelTypes::ActionModelUnicycle);
+  for(size_t action_type = 0 ; action_type < ActionModelTypes::all.size() ; ++action_type)
+  {
+    framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_kkt_dimension, ActionModelTypes::all[action_type], nb_running_models)));
+    framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_kkt_search_direction, ActionModelTypes::all[action_type], nb_running_models)));
+  }
+  
+  // We start from 1 as 0 is the kkt solver
+  for(size_t solver_type = 1 ; solver_type < SolverTypes::all.size() ; ++solver_type)
+  {
+    for(size_t action_type = 0 ; action_type < ActionModelTypes::all.size() ; ++action_type)
+    {
+      framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_solver_against_kkt_solver, SolverTypes::all[solver_type], ActionModelTypes::all[action_type], nb_running_models)));
+    }
+  }
   return true;
 }
 


### PR DESCRIPTION
## What changed?

- creation of a solver factory for all the available solvers.
- update the test_solvers.cpp using the factory, this should remove the segfault from the gepgitlab build farm.