### PR TITLE
Run examples as tests

### DIFF
--- a/.travis/build-and-test.sh
+++ b/.travis/build-and-test.sh
@@ -14,19 +14,3 @@ fi
 
 make -j1
 make test
-
-# Run the examples in Release mode
-if [ $CMAKE_BUILD_TYPE == "Release" ]
-then
-  # Examples
-  make -s examples-double_pendulum
-  make -s examples-quadrotor
-  make -s examples-quadrotor_ubound
-  make -s examples-arm_manipulation
-  make -s examples-bipedal_walk
-  make -s examples-bipedal_walk_ubound
-  make -s examples-quadrupedal_gaits
-  make -s examples-quadrupedal_walk_ubound
-  make -s examples-humanoid_manipulation
-  make -s examples-humanoid_manipulation_ubound
-fi

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -16,5 +16,9 @@ FOREACH(examples ${${PROJECT_NAME}_EXAMPLES_PYTHON})
   ADD_CUSTOM_TARGET("examples-${examples}"
     ${CMAKE_COMMAND} -E env PYTHONPATH=$ENV{PYTHONPATH}:${PROJECT_BINARY_DIR}/bindings/python
     ${PYTHON_EXECUTABLE} -c "import ${examples}" \${INPUT})
-  ADD_PYTHON_UNIT_TEST("example-python-${examples}" "examples/${examples}.py" bindings/python)
+
+  # examples are too slow in Debug mode to be used as tests
+  IF(CMAKE_BUILD_TYPE STREQUAL "Release")
+    ADD_PYTHON_UNIT_TEST("example-python-${examples}" "examples/${examples}.py" bindings/python)
+  ENDIF(CMAKE_BUILD_TYPE STREQUAL "Release")
 ENDFOREACH(examples ${${PROJECT_NAME}_EXAMPLES_PYTHON})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -16,4 +16,5 @@ FOREACH(examples ${${PROJECT_NAME}_EXAMPLES_PYTHON})
   ADD_CUSTOM_TARGET("examples-${examples}"
     ${CMAKE_COMMAND} -E env PYTHONPATH=$ENV{PYTHONPATH}:${PROJECT_BINARY_DIR}/bindings/python
     ${PYTHON_EXECUTABLE} -c "import ${examples}" \${INPUT})
+  ADD_PYTHON_UNIT_TEST("example-python-${examples}" "examples/${examples}.py" bindings/python)
 ENDFOREACH(examples ${${PROJECT_NAME}_EXAMPLES_PYTHON})


### PR DESCRIPTION
Follows #660 

While here, I saw that other python files in `examples/notebook/*.py` ; shouldn't we also run those as tests ?
@imaroger had issues with `cartpole_swing_up.py`.