### PR TITLE
Added getter and setter functions for solvers + improved Python bindings

### DIFF
--- a/bindings/python/crocoddyl/core/integrator/euler.hpp
+++ b/bindings/python/crocoddyl/core/integrator/euler.hpp
@@ -77,9 +77,9 @@ void exposeIntegratedActionEuler() {
           "differential",
           bp::make_getter(&IntegratedActionDataEuler::differential, bp::return_value_policy<bp::return_by_value>()),
           "differential action data")
-      .add_property(
-          "dx", bp::make_getter(&IntegratedActionDataEuler::ddx_dx, bp::return_value_policy<bp::return_by_value>()),
-          "state rate.")
+      .add_property("dx",
+                    bp::make_getter(&IntegratedActionDataEuler::dx, bp::return_value_policy<bp::return_by_value>()),
+                    "state rate.")
       .add_property(
           "ddx_dx",
           bp::make_getter(&IntegratedActionDataEuler::ddx_dx, bp::return_value_policy<bp::return_by_value>()),

--- a/bindings/python/crocoddyl/core/solver-base.hpp
+++ b/bindings/python/crocoddyl/core/solver-base.hpp
@@ -21,6 +21,11 @@ namespace bp = boost::python;
 
 class SolverAbstract_wrap : public SolverAbstract, public bp::wrapper<SolverAbstract> {
  public:
+  using SolverAbstract::cost_;
+  using SolverAbstract::is_feasible_;
+  using SolverAbstract::iter_;
+  using SolverAbstract::steplength_;
+
   explicit SolverAbstract_wrap(boost::shared_ptr<ShootingProblem> problem)
       : SolverAbstract(problem), bp::wrapper<SolverAbstract>() {}
   ~SolverAbstract_wrap() {}
@@ -165,14 +170,8 @@ void exposeSolverAbstract() {
       .add_property(
           "us", bp::make_function(&SolverAbstract_wrap::get_us, bp::return_value_policy<bp::copy_const_reference>()),
           bp::make_function(&SolverAbstract_wrap::set_us), "control sequence")
-      .add_property("isFeasible",
-                    bp::make_function(&SolverAbstract_wrap::get_is_feasible,
-                                      bp::return_value_policy<bp::copy_const_reference>()),
-                    "feasible (xs,us)")
-      .add_property(
-          "cost",
-          bp::make_function(&SolverAbstract_wrap::get_cost, bp::return_value_policy<bp::copy_const_reference>()),
-          "total cost")
+      .def_readwrite("isFeasible", &SolverAbstract_wrap::is_feasible_, "feasible (xs,us)")
+      .def_readwrite("cost", &SolverAbstract_wrap::cost_, "total cost")
       .add_property(
           "x_reg",
           bp::make_function(&SolverAbstract_wrap::get_xreg, bp::return_value_policy<bp::copy_const_reference>()),
@@ -181,11 +180,7 @@ void exposeSolverAbstract() {
           "u_reg",
           bp::make_function(&SolverAbstract_wrap::get_ureg, bp::return_value_policy<bp::copy_const_reference>()),
           bp::make_function(&SolverAbstract_wrap::set_ureg), "control regularization")
-      .add_property(
-          "stepLength",
-          bp::make_function(&SolverAbstract_wrap::get_steplength, bp::return_value_policy<bp::copy_const_reference>()),
-          "applied step length")
-      .add_property("th_acceptStep",
+      .def_readwrite("stepLength", &SolverAbstract_wrap::steplength_, "applied step length")      .add_property("th_acceptStep",
                     bp::make_function(&SolverAbstract_wrap::get_th_acceptstep,
                                       bp::return_value_policy<bp::copy_const_reference>()),
                     bp::make_function(&SolverAbstract_wrap::set_th_acceptstep), "threshold for step acceptance")
@@ -193,10 +188,7 @@ void exposeSolverAbstract() {
           "th_stop",
           bp::make_function(&SolverAbstract_wrap::get_th_stop, bp::return_value_policy<bp::copy_const_reference>()),
           bp::make_function(&SolverAbstract_wrap::set_th_stop), "threshold for stopping criteria")
-      .add_property(
-          "iter",
-          bp::make_function(&SolverAbstract_wrap::get_iter, bp::return_value_policy<bp::copy_const_reference>()),
-          "number of iterations runned in solve()");
+      .def_readwrite("iter", &SolverAbstract_wrap::iter_, "number of iterations runned in solve()");
 
   bp::class_<CallbackAbstract_wrap, boost::noncopyable>(
       "CallbackAbstract",

--- a/bindings/python/crocoddyl/core/solver-base.hpp
+++ b/bindings/python/crocoddyl/core/solver-base.hpp
@@ -21,18 +21,6 @@ namespace bp = boost::python;
 
 class SolverAbstract_wrap : public SolverAbstract, public bp::wrapper<SolverAbstract> {
  public:
-  using SolverAbstract::cost_;
-  using SolverAbstract::is_feasible_;
-  using SolverAbstract::iter_;
-  using SolverAbstract::problem_;
-  using SolverAbstract::steplength_;
-  using SolverAbstract::th_acceptstep_;
-  using SolverAbstract::th_stop_;
-  using SolverAbstract::ureg_;
-  using SolverAbstract::us_;
-  using SolverAbstract::xreg_;
-  using SolverAbstract::xs_;
-
   explicit SolverAbstract_wrap(boost::shared_ptr<ShootingProblem> problem)
       : SolverAbstract(problem), bp::wrapper<SolverAbstract>() {}
   ~SolverAbstract_wrap() {}
@@ -171,20 +159,44 @@ void exposeSolverAbstract() {
           "shooting problem")
       .def("models", &SolverAbstract_wrap::get_models, bp::return_value_policy<bp::return_by_value>(), "models")
       .def("datas", &SolverAbstract_wrap::get_datas, bp::return_value_policy<bp::return_by_value>(), "datas")
-      .add_property("xs", bp::make_getter(&SolverAbstract_wrap::xs_, bp::return_value_policy<bp::return_by_value>()),
-                    bp::make_setter(&SolverAbstract_wrap::xs_, bp::return_value_policy<bp::return_by_value>()),
-                    "state trajectory")
-      .add_property("us", bp::make_getter(&SolverAbstract_wrap::us_, bp::return_value_policy<bp::return_by_value>()),
-                    bp::make_setter(&SolverAbstract_wrap::us_, bp::return_value_policy<bp::return_by_value>()),
-                    "control sequence")
-      .def_readwrite("isFeasible", &SolverAbstract_wrap::is_feasible_, "feasible (xs,us)")
-      .def_readwrite("cost", &SolverAbstract_wrap::cost_, "total cost")
-      .def_readwrite("x_reg", &SolverAbstract_wrap::xreg_, "state regularization")
-      .def_readwrite("u_reg", &SolverAbstract_wrap::ureg_, "control regularization")
-      .def_readwrite("stepLength", &SolverAbstract_wrap::steplength_, "applied step length")
-      .def_readwrite("th_acceptStep", &SolverAbstract_wrap::th_acceptstep_, "threshold for step acceptance")
-      .def_readwrite("th_stop", &SolverAbstract_wrap::th_stop_, "threshold for stopping criteria")
-      .def_readwrite("iter", &SolverAbstract_wrap::iter_, "number of iterations runned in solve()");
+      .add_property("xs",
+                    bp::make_function(&SolverAbstract_wrap::get_xs, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_function(&SolverAbstract_wrap::set_xs), "state trajectory")
+      .add_property("us",
+                    bp::make_function(&SolverAbstract_wrap::get_us, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_function(&SolverAbstract_wrap::set_us), "control sequence")
+      .add_property("isFeasible",
+                    bp::make_function(&SolverAbstract_wrap::get_is_feasible,
+                                      bp::return_value_policy<bp::copy_const_reference>()),
+                    "feasible (xs,us)")
+      .add_property(
+          "cost",
+          bp::make_function(&SolverAbstract_wrap::get_cost, bp::return_value_policy<bp::copy_const_reference>()),
+          "total cost")
+      .add_property(
+          "x_reg",
+          bp::make_function(&SolverAbstract_wrap::get_xreg, bp::return_value_policy<bp::copy_const_reference>()),
+          bp::make_function(&SolverAbstract_wrap::set_xreg), "state regularization")
+      .add_property(
+          "u_reg",
+          bp::make_function(&SolverAbstract_wrap::get_ureg, bp::return_value_policy<bp::copy_const_reference>()),
+          bp::make_function(&SolverAbstract_wrap::set_ureg), "control regularization")
+      .add_property(
+          "stepLength",
+          bp::make_function(&SolverAbstract_wrap::get_steplength, bp::return_value_policy<bp::copy_const_reference>()),
+          "applied step length")
+      .add_property("th_acceptStep",
+                    bp::make_function(&SolverAbstract_wrap::get_th_acceptstep,
+                                      bp::return_value_policy<bp::copy_const_reference>()),
+                    bp::make_function(&SolverAbstract_wrap::set_th_acceptstep), "threshold for step acceptance")
+      .add_property(
+          "th_stop",
+          bp::make_function(&SolverAbstract_wrap::get_th_stop, bp::return_value_policy<bp::copy_const_reference>()),
+          bp::make_function(&SolverAbstract_wrap::set_th_stop), "threshold for stopping criteria")
+      .add_property(
+          "iter",
+          bp::make_function(&SolverAbstract_wrap::get_iter, bp::return_value_policy<bp::copy_const_reference>()),
+          "number of iterations runned in solve()");
 
   bp::class_<CallbackAbstract_wrap, boost::noncopyable>(
       "CallbackAbstract",

--- a/bindings/python/crocoddyl/core/solver-base.hpp
+++ b/bindings/python/crocoddyl/core/solver-base.hpp
@@ -149,21 +149,21 @@ void exposeSolverAbstract() {
            "Each iteration, the solver calls these set of functions in order to\n"
            "allowed user the diagnostic of the solver's performance.\n"
            ":param callbacks: set of callback functions.")
-      .def("getCallbacks", &SolverAbstract_wrap::getCallbacks, bp::return_value_policy<bp::return_by_value>(),
+      .def("getCallbacks", &SolverAbstract_wrap::getCallbacks, bp::return_value_policy<bp::copy_const_reference>(),
            bp::args("self"),
            "Return the list of callback functions using for diagnostic.\n\n"
            ":return set of callback functions.")
       .add_property(
           "problem",
-          bp::make_function(&SolverAbstract_wrap::get_problem, bp::return_value_policy<bp::return_by_value>()),
+          bp::make_function(&SolverAbstract_wrap::get_problem, bp::return_value_policy<bp::copy_const_reference>()),
           "shooting problem")
-      .def("models", &SolverAbstract_wrap::get_models, bp::return_value_policy<bp::return_by_value>(), "models")
-      .def("datas", &SolverAbstract_wrap::get_datas, bp::return_value_policy<bp::return_by_value>(), "datas")
+      .def("models", &SolverAbstract_wrap::get_models, bp::return_value_policy<bp::copy_const_reference>(), "models")
+      .def("datas", &SolverAbstract_wrap::get_datas, bp::return_value_policy<bp::copy_const_reference>(), "datas")
       .add_property("xs",
-                    bp::make_function(&SolverAbstract_wrap::get_xs, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_function(&SolverAbstract_wrap::get_xs, bp::return_value_policy<bp::copy_const_reference>()),
                     bp::make_function(&SolverAbstract_wrap::set_xs), "state trajectory")
       .add_property("us",
-                    bp::make_function(&SolverAbstract_wrap::get_us, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_function(&SolverAbstract_wrap::get_us, bp::return_value_policy<bp::copy_const_reference>()),
                     bp::make_function(&SolverAbstract_wrap::set_us), "control sequence")
       .add_property("isFeasible",
                     bp::make_function(&SolverAbstract_wrap::get_is_feasible,

--- a/bindings/python/crocoddyl/core/solver-base.hpp
+++ b/bindings/python/crocoddyl/core/solver-base.hpp
@@ -159,12 +159,12 @@ void exposeSolverAbstract() {
           "shooting problem")
       .def("models", &SolverAbstract_wrap::get_models, bp::return_value_policy<bp::copy_const_reference>(), "models")
       .def("datas", &SolverAbstract_wrap::get_datas, bp::return_value_policy<bp::copy_const_reference>(), "datas")
-      .add_property("xs",
-                    bp::make_function(&SolverAbstract_wrap::get_xs, bp::return_value_policy<bp::copy_const_reference>()),
-                    bp::make_function(&SolverAbstract_wrap::set_xs), "state trajectory")
-      .add_property("us",
-                    bp::make_function(&SolverAbstract_wrap::get_us, bp::return_value_policy<bp::copy_const_reference>()),
-                    bp::make_function(&SolverAbstract_wrap::set_us), "control sequence")
+      .add_property(
+          "xs", bp::make_function(&SolverAbstract_wrap::get_xs, bp::return_value_policy<bp::copy_const_reference>()),
+          bp::make_function(&SolverAbstract_wrap::set_xs), "state trajectory")
+      .add_property(
+          "us", bp::make_function(&SolverAbstract_wrap::get_us, bp::return_value_policy<bp::copy_const_reference>()),
+          bp::make_function(&SolverAbstract_wrap::set_us), "control sequence")
       .add_property("isFeasible",
                     bp::make_function(&SolverAbstract_wrap::get_is_feasible,
                                       bp::return_value_policy<bp::copy_const_reference>()),

--- a/include/crocoddyl/core/solver-base.hpp
+++ b/include/crocoddyl/core/solver-base.hpp
@@ -44,7 +44,6 @@ class SolverAbstract {
   const std::vector<Eigen::VectorXd>& get_xs() const;
   const std::vector<Eigen::VectorXd>& get_us() const;
   const bool& get_isFeasible() const;
-  const std::size_t& get_iter() const;
   const double& get_cost() const;
   const double& get_stop() const;
   const Eigen::Vector2d& get_d() const;
@@ -53,6 +52,9 @@ class SolverAbstract {
   const double& get_stepLength() const;
   const double& get_dV() const;
   const double& get_dVexp() const;
+  const double& get_th_acceptstep() const;
+  const double& get_th_stop() const;
+  const std::size_t& get_iter() const;
 
  protected:
   boost::shared_ptr<ShootingProblem> problem_;

--- a/include/crocoddyl/core/solver-base.hpp
+++ b/include/crocoddyl/core/solver-base.hpp
@@ -43,13 +43,13 @@ class SolverAbstract {
   const std::vector<boost::shared_ptr<ActionDataAbstract> >& get_datas() const;
   const std::vector<Eigen::VectorXd>& get_xs() const;
   const std::vector<Eigen::VectorXd>& get_us() const;
-  const bool& get_isFeasible() const;
+  const bool& get_is_feasible() const;
   const double& get_cost() const;
   const double& get_stop() const;
   const Eigen::Vector2d& get_d() const;
   const double& get_xreg() const;
   const double& get_ureg() const;
-  const double& get_stepLength() const;
+  const double& get_steplength() const;
   const double& get_dV() const;
   const double& get_dVexp() const;
   const double& get_th_acceptstep() const;

--- a/include/crocoddyl/core/solver-base.hpp
+++ b/include/crocoddyl/core/solver-base.hpp
@@ -56,6 +56,8 @@ class SolverAbstract {
   const double& get_th_stop() const;
   const std::size_t& get_iter() const;
 
+  void set_xs(const std::vector<Eigen::VectorXd>& xs);
+  void set_us(const std::vector<Eigen::VectorXd>& us);
   void set_xreg(const double& xreg);
   void set_ureg(const double& ureg);
   void set_th_acceptstep(const double& th_acceptstep);

--- a/include/crocoddyl/core/solver-base.hpp
+++ b/include/crocoddyl/core/solver-base.hpp
@@ -56,6 +56,11 @@ class SolverAbstract {
   const double& get_th_stop() const;
   const std::size_t& get_iter() const;
 
+  void set_xreg(const double& xreg);
+  void set_ureg(const double& ureg);
+  void set_th_acceptstep(const double& th_acceptstep);
+  void set_th_stop(const double& th_stop);
+
  protected:
   boost::shared_ptr<ShootingProblem> problem_;
   std::vector<boost::shared_ptr<ActionModelAbstract> > models_;

--- a/src/core/integrator/euler.cpp
+++ b/src/core/integrator/euler.cpp
@@ -64,7 +64,7 @@ void IntegratedActionModelEuler::calc(const boost::shared_ptr<ActionDataAbstract
   differential_->calc(d->differential, x, u);
 
   // Computing the next state (discrete time)
-  const Eigen::VectorXd& v = x.tail(differential_->get_state()->get_nv());
+  const Eigen::VectorBlock<const Eigen::Ref<const Eigen::VectorXd>, Eigen::Dynamic> v = x.tail(differential_->get_state()->get_nv());
   const Eigen::VectorXd& a = d->differential->xout;
   if (enable_integration_) {
     d->dx << v * time_step_ + a * time_step2_, a * time_step_;

--- a/src/core/integrator/euler.cpp
+++ b/src/core/integrator/euler.cpp
@@ -64,7 +64,8 @@ void IntegratedActionModelEuler::calc(const boost::shared_ptr<ActionDataAbstract
   differential_->calc(d->differential, x, u);
 
   // Computing the next state (discrete time)
-  const Eigen::VectorBlock<const Eigen::Ref<const Eigen::VectorXd>, Eigen::Dynamic> v = x.tail(differential_->get_state()->get_nv());
+  const Eigen::VectorBlock<const Eigen::Ref<const Eigen::VectorXd>, Eigen::Dynamic> v =
+      x.tail(differential_->get_state()->get_nv());
   const Eigen::VectorXd& a = d->differential->xout;
   if (enable_integration_) {
     d->dx << v * time_step_ + a * time_step2_, a * time_step_;

--- a/src/core/solver-base.cpp
+++ b/src/core/solver-base.cpp
@@ -132,7 +132,7 @@ void SolverAbstract::set_ureg(const double& ureg) {
 }
 
 void SolverAbstract::set_th_acceptstep(const double& th_acceptstep) {
-  if (0. >= th_acceptstep && th_acceptstep >= 1) {
+  if (0. >= th_acceptstep || th_acceptstep > 1) {
     throw_pretty("Invalid argument: "
                  << "th_acceptstep value should between 0 and 1.");
   }

--- a/src/core/solver-base.cpp
+++ b/src/core/solver-base.cpp
@@ -91,7 +91,7 @@ const std::vector<Eigen::VectorXd>& SolverAbstract::get_xs() const { return xs_;
 
 const std::vector<Eigen::VectorXd>& SolverAbstract::get_us() const { return us_; }
 
-const bool& SolverAbstract::get_isFeasible() const { return is_feasible_; }
+const bool& SolverAbstract::get_is_feasible() const { return is_feasible_; }
 
 const double& SolverAbstract::get_cost() const { return cost_; }
 
@@ -103,7 +103,7 @@ const double& SolverAbstract::get_xreg() const { return xreg_; }
 
 const double& SolverAbstract::get_ureg() const { return ureg_; }
 
-const double& SolverAbstract::get_stepLength() const { return steplength_; }
+const double& SolverAbstract::get_steplength() const { return steplength_; }
 
 const double& SolverAbstract::get_dV() const { return dV_; }
 

--- a/src/core/solver-base.cpp
+++ b/src/core/solver-base.cpp
@@ -93,7 +93,6 @@ const std::vector<Eigen::VectorXd>& SolverAbstract::get_us() const { return us_;
 
 const bool& SolverAbstract::get_isFeasible() const { return is_feasible_; }
 
-
 const double& SolverAbstract::get_cost() const { return cost_; }
 
 const double& SolverAbstract::get_stop() const { return stop_; }
@@ -115,6 +114,39 @@ const double& SolverAbstract::get_th_acceptstep() const { return th_acceptstep_;
 const double& SolverAbstract::get_th_stop() const { return th_stop_; }
 
 const std::size_t& SolverAbstract::get_iter() const { return iter_; }
+
+void SolverAbstract::set_xreg(const double& xreg) {
+  if (xreg < 0.) {
+    throw_pretty("Invalid argument: "
+                 << "xreg value has to be positive.");
+  }
+  xreg_ = xreg;
+}
+
+void SolverAbstract::set_ureg(const double& ureg) {
+  if (ureg < 0.) {
+    throw_pretty("Invalid argument: "
+                 << "ureg value has to be positive.");
+  }
+  ureg_ = ureg;
+}
+
+void SolverAbstract::set_th_acceptstep(const double& th_acceptstep) {
+  if (0. >= th_acceptstep && th_acceptstep >= 1) {
+    throw_pretty("Invalid argument: "
+                 << "th_acceptstep value should between 0 and 1.");
+  }
+  th_acceptstep_ = th_acceptstep;
+}
+
+void SolverAbstract::set_th_stop(const double& th_stop) {
+  if (th_stop <= 0.) {
+    throw_pretty("Invalid argument: "
+                 << "th_stop value has to higher than 0.");
+  }
+  th_stop_ = th_stop;
+}
+
 bool raiseIfNaN(const double& value) {
   if (std::isnan(value) || std::isinf(value) || value >= 1e30) {
     return true;

--- a/src/core/solver-base.cpp
+++ b/src/core/solver-base.cpp
@@ -115,6 +115,48 @@ const double& SolverAbstract::get_th_stop() const { return th_stop_; }
 
 const std::size_t& SolverAbstract::get_iter() const { return iter_; }
 
+void SolverAbstract::set_xs(const std::vector<Eigen::VectorXd>& xs) {
+  const std::size_t& T = problem_->get_T();
+  if (xs.size() != T + 1) {
+    throw_pretty("Invalid argument: "
+                 << "xs list has to be " + std::to_string(T + 1));
+  }
+
+  for (std::size_t t = 0; t < T; ++t) {
+    const boost::shared_ptr<ActionModelAbstract>& model = problem_->get_runningModels()[t];
+    const std::size_t& nx = model->get_state()->get_nx();
+    if (static_cast<std::size_t>(xs[t].size()) != nx) {
+      throw_pretty("Invalid argument: "
+                   << "xs[" + std::to_string(t) + "] has wrong dimension (it should be " + std::to_string(nx) + ")")
+    }
+  }
+  const boost::shared_ptr<ActionModelAbstract>& model = problem_->get_terminalModel();
+  const std::size_t& nx = model->get_state()->get_nx();
+  if (static_cast<std::size_t>(xs[T].size()) != nx) {
+    throw_pretty("Invalid argument: "
+                 << "xs[" + std::to_string(T) + "] has wrong dimension (it should be " + std::to_string(nx) + ")")
+  }
+  xs_ = xs;
+}
+
+void SolverAbstract::set_us(const std::vector<Eigen::VectorXd>& us) {
+  const std::size_t& T = problem_->get_T();
+  if (us.size() != T) {
+    throw_pretty("Invalid argument: "
+                 << "us list has to be " + std::to_string(T));
+  }
+
+  for (std::size_t t = 0; t < T; ++t) {
+    const boost::shared_ptr<ActionModelAbstract>& model = problem_->get_runningModels()[t];
+    const std::size_t& nu = model->get_nu();
+    if (static_cast<std::size_t>(us[t].size()) != nu && nu != 0) {
+      throw_pretty("Invalid argument: "
+                   << "us[" + std::to_string(t) + "] has wrong dimension (it should be " + std::to_string(nu) + ")")
+    }
+  }
+  us_ = us;
+}
+
 void SolverAbstract::set_xreg(const double& xreg) {
   if (xreg < 0.) {
     throw_pretty("Invalid argument: "

--- a/src/core/solver-base.cpp
+++ b/src/core/solver-base.cpp
@@ -93,7 +93,6 @@ const std::vector<Eigen::VectorXd>& SolverAbstract::get_us() const { return us_;
 
 const bool& SolverAbstract::get_isFeasible() const { return is_feasible_; }
 
-const std::size_t& SolverAbstract::get_iter() const { return iter_; }
 
 const double& SolverAbstract::get_cost() const { return cost_; }
 
@@ -111,6 +110,11 @@ const double& SolverAbstract::get_dV() const { return dV_; }
 
 const double& SolverAbstract::get_dVexp() const { return dVexp_; }
 
+const double& SolverAbstract::get_th_acceptstep() const { return th_acceptstep_; }
+
+const double& SolverAbstract::get_th_stop() const { return th_stop_; }
+
+const std::size_t& SolverAbstract::get_iter() const { return iter_; }
 bool raiseIfNaN(const double& value) {
   if (std::isnan(value) || std::isinf(value) || value >= 1e30) {
     return true;

--- a/src/core/solvers/ddp.cpp
+++ b/src/core/solvers/ddp.cpp
@@ -438,7 +438,7 @@ void SolverDDP::set_alphas(const std::vector<double>& alphas) {
 }
 
 void SolverDDP::set_th_stepdec(const double& th_stepdec) {
-  if (0. >= th_stepdec && th_stepdec >= 1.) {
+  if (0. >= th_stepdec || th_stepdec > 1.) {
     throw_pretty("Invalid argument: "
                  << "th_stepdec value should between 0 and 1.");
   }
@@ -446,7 +446,7 @@ void SolverDDP::set_th_stepdec(const double& th_stepdec) {
 }
 
 void SolverDDP::set_th_stepinc(const double& th_stepinc) {
-  if (0. >= th_stepinc && th_stepinc >= 1.) {
+  if (0. >= th_stepinc || th_stepinc > 1.) {
     throw_pretty("Invalid argument: "
                  << "th_stepinc value should between 0 and 1.");
   }

--- a/src/core/utils/callbacks.cpp
+++ b/src/core/utils/callbacks.cpp
@@ -40,8 +40,8 @@ void CallbackVerbose::operator()(SolverAbstract& solver) {
       std::cout << std::scientific << std::setprecision(5) << solver.get_cost() << "  ";
       std::cout << solver.get_stop() << "  " << -solver.get_d()[1] << "  ";
       std::cout << solver.get_xreg() << "  " << solver.get_ureg() << "   ";
-      std::cout << std::fixed << std::setprecision(4) << solver.get_stepLength() << "     ";
-      std::cout << solver.get_isFeasible() << '\n';
+      std::cout << std::fixed << std::setprecision(4) << solver.get_steplength() << "     ";
+      std::cout << solver.get_is_feasible() << '\n';
       break;
     }
     case _2: {
@@ -49,8 +49,8 @@ void CallbackVerbose::operator()(SolverAbstract& solver) {
       std::cout << std::scientific << std::setprecision(5) << solver.get_cost() << "  ";
       std::cout << solver.get_stop() << "  " << -solver.get_d()[1] << "  ";
       std::cout << solver.get_xreg() << "  " << solver.get_ureg() << "   ";
-      std::cout << std::fixed << std::setprecision(4) << solver.get_stepLength() << "     ";
-      std::cout << solver.get_isFeasible() << "  ";
+      std::cout << std::fixed << std::setprecision(4) << solver.get_steplength() << "     ";
+      std::cout << solver.get_is_feasible() << "  ";
       std::cout << std::scientific << std::setprecision(5) << solver.get_dV() << "  ";
       std::cout << solver.get_dVexp() << '\n';
       break;
@@ -60,8 +60,8 @@ void CallbackVerbose::operator()(SolverAbstract& solver) {
       std::cout << std::scientific << std::setprecision(5) << solver.get_cost() << "  ";
       std::cout << solver.get_stop() << "  " << -solver.get_d()[1] << "  ";
       std::cout << solver.get_xreg() << "  " << solver.get_ureg() << "   ";
-      std::cout << std::fixed << std::setprecision(4) << solver.get_stepLength() << "     ";
-      std::cout << solver.get_isFeasible() << '\n';
+      std::cout << std::fixed << std::setprecision(4) << solver.get_steplength() << "     ";
+      std::cout << solver.get_is_feasible() << '\n';
     }
   }
 }


### PR DESCRIPTION
This PR:
 1. defines getter and setter functions which are needed for c++ implementation,
 2. changes copy_const_reference instead of return_by_value (Python binding returned policy), 
 3. returns the const block in Euler integrator, and
 4. fixes an issue in the Euler python bindings (wrong returning of data.dx)

@PepMS thanks for reporting the needed of these getter functions
