### PR TITLE
Fix bug, add unittest for floating-base DifferentialFwdDynamicsDerived

### DIFF
--- a/bindings/python/crocoddyl/utils/__init__.py
+++ b/bindings/python/crocoddyl/utils/__init__.py
@@ -305,7 +305,7 @@ class DifferentialFreeFwdDynamicsDerived(crocoddyl.DifferentialActionModelAbstra
 
     def calcDiff(self, data, x, u=None, recalc=True):
         self.costsData.shareMemory(data)
-        nq, nv = self.state.nv, self.state.nq
+        nq, nv = self.state.nq, self.state.nv
         q, v = x[:nq], x[-nv:]
         self.actuation.calcDiff(self.actuationData, x, u)
 

--- a/bindings/python/crocoddyl/utils/__init__.py
+++ b/bindings/python/crocoddyl/utils/__init__.py
@@ -288,7 +288,7 @@ class DifferentialFreeFwdDynamicsDerived(crocoddyl.DifferentialActionModelAbstra
 
         # Computing the dynamics using ABA or manually for armature case
         if self.enable_force:
-            data.xout = pinocchio.aba(self.state.pinocchio, self.pinocchioData, q, v, u)
+            data.xout = pinocchio.aba(self.state.pinocchio, self.pinocchioData, q, v, tau)
         else:
             pinocchio.computeAllTerms(self.state.pinocchio, self.pinocchioData, q, v)
             data.M = self.pinocchioData.M
@@ -308,6 +308,7 @@ class DifferentialFreeFwdDynamicsDerived(crocoddyl.DifferentialActionModelAbstra
         nq, nv = self.state.nq, self.state.nv
         q, v = x[:nq], x[-nv:]
         self.actuation.calcDiff(self.actuationData, x, u)
+        tau = self.actuationData.tau
 
         if u is None:
             u = self.unone
@@ -316,7 +317,7 @@ class DifferentialFreeFwdDynamicsDerived(crocoddyl.DifferentialActionModelAbstra
             pinocchio.computeJointJacobians(self.state.pinocchio, self.pinocchioData, q)
         # Computing the dynamics derivatives
         if self.enable_force:
-            pinocchio.computeABADerivatives(self.state.pinocchio, self.pinocchioData, q, v, u)
+            pinocchio.computeABADerivatives(self.state.pinocchio, self.pinocchioData, q, v, tau)
             ddq_dq = self.pinocchioData.ddq_dq
             ddq_dv = self.pinocchioData.ddq_dv
             data.Fx = np.hstack([ddq_dq, ddq_dv]) + self.pinocchioData.Minv * self.actuationData.dtau_dx

--- a/examples/arm_manipulation.py
+++ b/examples/arm_manipulation.py
@@ -96,4 +96,4 @@ if WITHPLOT:
 # Visualizing the solution in gepetto-viewer
 if WITHDISPLAY:
     display = crocoddyl.GepettoDisplay(talos_arm, 4, 4, cameraTF)
-    display.display(talos_arm, ddp.xs, None, runningModel.dt)
+    display.displayFromSolver(ddp)

--- a/src/multibody/contacts/multiple-contacts.cpp
+++ b/src/multibody/contacts/multiple-contacts.cpp
@@ -22,7 +22,7 @@ ContactModelMultiple::~ContactModelMultiple() {}
 void ContactModelMultiple::addContact(const std::string& name, boost::shared_ptr<ContactModelAbstract> contact) {
   if (contact->get_nu() != nu_) {
     throw_pretty("Invalid argument: "
-                 << "contact item doesn't have the the same control dimension (" + std::to_string(nu_) + ")");
+                 << "contact item doesn't have the same control dimension (" + std::to_string(nu_) + ")");
   }
   std::pair<ContactModelContainer::iterator, bool> ret =
       contacts_.insert(std::make_pair(name, ContactItem(name, contact)));

--- a/unittest/bindings/test_actions.py
+++ b/unittest/bindings/test_actions.py
@@ -115,10 +115,21 @@ class TalosArmFreeFwdDynamicsWithArmatureTest(ActionModelAbstractTestCase):
     MODEL_DER.set_armature(0.1 * np.matrix(np.ones(ROBOT_MODEL.nv)).T)
 
 
+class AnymalFreeFwdDynamicsTest(ActionModelAbstractTestCase):
+    ROBOT_MODEL = example_robot_data.loadANYmal().model
+    STATE = crocoddyl.StateMultibody(ROBOT_MODEL)
+    ACTUATION = crocoddyl.ActuationModelFloatingBase(STATE)
+    COST_SUM = crocoddyl.CostModelSum(STATE, ACTUATION.nu)
+    COST_SUM.addCost("xReg", crocoddyl.CostModelState(STATE, ACTUATION.nu), 1e-7)
+    COST_SUM.addCost("uReg", crocoddyl.CostModelControl(STATE, ACTUATION.nu), 1e-7)
+    MODEL = crocoddyl.DifferentialActionModelFreeFwdDynamics(STATE, ACTUATION, COST_SUM)
+    MODEL_DER = DifferentialFreeFwdDynamicsDerived(STATE, ACTUATION, COST_SUM)
+
+
 if __name__ == '__main__':
     test_classes_to_run = [
         UnicycleTest, LQRTest, DifferentialLQRTest, TalosArmFreeFwdDynamicsTest,
-        TalosArmFreeFwdDynamicsWithArmatureTest
+        TalosArmFreeFwdDynamicsWithArmatureTest, AnymalFreeFwdDynamicsTest,
     ]
     loader = unittest.TestLoader()
     suites_list = []

--- a/unittest/bindings/test_actions.py
+++ b/unittest/bindings/test_actions.py
@@ -128,8 +128,12 @@ class AnymalFreeFwdDynamicsTest(ActionModelAbstractTestCase):
 
 if __name__ == '__main__':
     test_classes_to_run = [
-        UnicycleTest, LQRTest, DifferentialLQRTest, TalosArmFreeFwdDynamicsTest,
-        TalosArmFreeFwdDynamicsWithArmatureTest, AnymalFreeFwdDynamicsTest,
+        UnicycleTest,
+        LQRTest,
+        DifferentialLQRTest,
+        TalosArmFreeFwdDynamicsTest,
+        TalosArmFreeFwdDynamicsWithArmatureTest,
+        AnymalFreeFwdDynamicsTest,
     ]
     loader = unittest.TestLoader()
     suites_list = []


### PR DESCRIPTION
This PR fixes a couple issues when working with floating-base systems based on `DifferentialFwdDynamicsDerived` and adds a unit test for it.

- Fixes a bug related to `nq`,`nv` (swapped; difference when the floating base uses quaternion)
- Uses the correct `tau` vector to pass to ABA (the actuation->tau should be passed rather than the raw control vector)
- Adds a unit test with the Anymal robot using a floating base
- Fixes the arm_manipulation example visualisation
- Minor typos