### PR TITLE
[DAMFreefwddyn] remove redundant forwardKin call

### DIFF
--- a/src/multibody/actions/free-fwddyn.cpp
+++ b/src/multibody/actions/free-fwddyn.cpp
@@ -57,6 +57,7 @@ void DifferentialActionModelFreeFwdDynamics::calc(const boost::shared_ptr<Differ
   // Computing the dynamics using ABA or manually for armature case
   if (with_armature_) {
     d->xout = pinocchio::aba(pinocchio_, d->pinocchio, q, v, d->multibody.actuation->tau);
+    pinocchio::updateGlobalPlacements(pinocchio_, d->pinocchio);
   } else {
     pinocchio::computeAllTerms(pinocchio_, d->pinocchio, q, v);
     d->pinocchio.M.diagonal() += armature_;
@@ -68,7 +69,6 @@ void DifferentialActionModelFreeFwdDynamics::calc(const boost::shared_ptr<Differ
   }
 
   // Computing the cost value and residuals
-  pinocchio::forwardKinematics(pinocchio_, d->pinocchio, q, v);
   pinocchio::updateFramePlacements(pinocchio_, d->pinocchio);
   costs_->calc(d->costs, x, u);
   d->cost = d->costs->cost;


### PR DESCRIPTION
ForwardKin is not needed after aba or computeAllTerms