### PR TITLE
[efficiency] remove redundant calls to update all frames. only update…

### DIFF
--- a/src/core/solvers/ddp.cpp
+++ b/src/core/solvers/ddp.cpp
@@ -247,7 +247,9 @@ void SolverDDP::forwardPass(const double& steplength) {
     const boost::shared_ptr<ActionDataAbstract>& d = problem_->get_runningDatas()[t];
 
     m->get_state()->diff(xs_[t], xs_try_[t], dx_[t]);
-    us_try_[t].noalias() = us_[t] - k_[t] * steplength - K_[t] * dx_[t];
+    us_try_[t].noalias() = us_[t];
+    us_try_[t].noalias() -= k_[t] * steplength;
+    us_try_[t].noalias()-= K_[t] * dx_[t];
     m->calc(d, xs_try_[t], us_try_[t]);
     xs_try_[t + 1] = d->xnext;
     cost_try_ += d->cost;

--- a/src/multibody/actions/contact-fwddyn.cpp
+++ b/src/multibody/actions/contact-fwddyn.cpp
@@ -68,7 +68,6 @@ void DifferentialActionModelContactFwdDynamics::calc(const boost::shared_ptr<Dif
 
   // Computing the forward dynamics with the holonomic constraints defined by the contact model
   pinocchio::computeAllTerms(pinocchio_, d->pinocchio, q, v);
-  pinocchio::updateFramePlacements(pinocchio_, d->pinocchio);
   pinocchio::computeCentroidalMomentum(pinocchio_, d->pinocchio);
 
   if (!with_armature_) {

--- a/src/multibody/actions/free-fwddyn.cpp
+++ b/src/multibody/actions/free-fwddyn.cpp
@@ -99,10 +99,8 @@ void DifferentialActionModelFreeFwdDynamics::calcDiff(const boost::shared_ptr<Di
 
   // Computing the dynamics derivatives
   if (with_armature_) {
-    pinocchio::computeABADerivatives(pinocchio_, d->pinocchio, q, v, d->multibody.actuation->tau);
-    d->Fx.leftCols(nv) = d->pinocchio.ddq_dq;
-    d->Fx.rightCols(nv) = d->pinocchio.ddq_dv;
-    d->Fx += d->pinocchio.Minv * d->multibody.actuation->dtau_dx;
+    pinocchio::computeABADerivatives(pinocchio_, d->pinocchio, q, v, d->multibody.actuation->tau, d->Fx.leftCols(nv), d->Fx.rightCols(nv), d->pinocchio.Minv);
+    d->Fx.noalias() += d->pinocchio.Minv * d->multibody.actuation->dtau_dx;
     d->Fu.noalias() = d->pinocchio.Minv * d->multibody.actuation->dtau_du;
   } else {
     pinocchio::computeRNEADerivatives(pinocchio_, d->pinocchio, q, v, d->xout);

--- a/src/multibody/actions/free-fwddyn.cpp
+++ b/src/multibody/actions/free-fwddyn.cpp
@@ -69,7 +69,6 @@ void DifferentialActionModelFreeFwdDynamics::calc(const boost::shared_ptr<Differ
   }
 
   // Computing the cost value and residuals
-  pinocchio::updateFramePlacements(pinocchio_, d->pinocchio);
   costs_->calc(d->costs, x, u);
   d->cost = d->costs->cost;
 }

--- a/src/multibody/contacts/contact-3d.cpp
+++ b/src/multibody/contacts/contact-3d.cpp
@@ -26,6 +26,7 @@ ContactModel3D::~ContactModel3D() {}
 void ContactModel3D::calc(const boost::shared_ptr<ContactDataAbstract>& data,
                           const Eigen::Ref<const Eigen::VectorXd>&) {
   ContactData3D* d = static_cast<ContactData3D*>(data.get());
+  pinocchio::updateFramePlacement(state_->get_pinocchio(), *d->pinocchio, xref_.frame);
   d->v = pinocchio::getFrameVelocity(state_->get_pinocchio(), *d->pinocchio, xref_.frame);
   d->vw = d->v.angular();
   d->vv = d->v.linear();

--- a/src/multibody/contacts/contact-6d.cpp
+++ b/src/multibody/contacts/contact-6d.cpp
@@ -27,7 +27,7 @@ ContactModel6D::~ContactModel6D() {}
 void ContactModel6D::calc(const boost::shared_ptr<ContactDataAbstract>& data,
                           const Eigen::Ref<const Eigen::VectorXd>&) {
   ContactData6D* d = static_cast<ContactData6D*>(data.get());
-
+  pinocchio::updateFramePlacement(state_->get_pinocchio(), *d->pinocchio, Mref_.frame);
   pinocchio::getFrameJacobian(state_->get_pinocchio(), *d->pinocchio, Mref_.frame, pinocchio::LOCAL, d->Jc);
 
   d->a = pinocchio::getFrameAcceleration(state_->get_pinocchio(), *d->pinocchio, Mref_.frame);

--- a/src/multibody/costs/frame-placement.cpp
+++ b/src/multibody/costs/frame-placement.cpp
@@ -47,6 +47,7 @@ void CostModelFramePlacement::calc(const boost::shared_ptr<CostDataAbstract>& da
   CostDataFramePlacement* d = static_cast<CostDataFramePlacement*>(data.get());
 
   // Compute the frame placement w.r.t. the reference frame
+  pinocchio::updateFramePlacement(state_->get_pinocchio(), *d->pinocchio,Mref_.frame);
   d->rMf = oMf_inv_ * d->pinocchio->oMf[Mref_.frame];
   d->r = pinocchio::log6(d->rMf);
   data->r = d->r;  // this is needed because we overwrite it

--- a/src/multibody/costs/frame-rotation.cpp
+++ b/src/multibody/costs/frame-rotation.cpp
@@ -46,6 +46,7 @@ void CostModelFrameRotation::calc(const boost::shared_ptr<CostDataAbstract>& dat
   CostDataFrameRotation* d = static_cast<CostDataFrameRotation*>(data.get());
 
   // Compute the frame placement w.r.t. the reference frame
+  pinocchio::updateFramePlacement(state_->get_pinocchio(), *d->pinocchio,Rref_.frame);
   d->rRf.noalias() = oRf_inv_ * d->pinocchio->oMf[Rref_.frame].rotation();
   d->r = pinocchio::log3(d->rRf);
   data->r = d->r;  // this is needed because we overwrite it

--- a/src/multibody/costs/frame-translation.cpp
+++ b/src/multibody/costs/frame-translation.cpp
@@ -47,6 +47,7 @@ void CostModelFrameTranslation::calc(const boost::shared_ptr<CostDataAbstract>& 
                                      const Eigen::Ref<const Eigen::VectorXd>&) {
   // Compute the frame translation w.r.t. the reference frame
   CostDataFrameTranslation* d = static_cast<CostDataFrameTranslation*>(data.get());
+  pinocchio::updateFramePlacement(state_->get_pinocchio(), *d->pinocchio,xref_.frame);
   data->r = d->pinocchio->oMf[xref_.frame].translation() - xref_.oxf;
 
   // Compute the cost


### PR DESCRIPTION
… the ones that are required

This reduces the time used by calc (100 nodes) by about 100us.