### PR TITLE
Revert "[CMake] sync submodule"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ INCLUDE(cmake/apple.cmake)
 
 # Print initial message
 MESSAGE("${PROJECT_DESCRIPTION}, version ${PROJECT_VERSION}")
-MESSAGE("Copyright (C) 2018-2020 CNRS-LAAS")
+MESSAGE("Copyright (C) 2018-2019 CNRS-LAAS")
 MESSAGE("Copyright (C) 2019-2020 University of Edinburgh")
 MESSAGE("All rights reserved.")
 MESSAGE("Released under the BSD 3-Clause License.")


### PR DESCRIPTION
This fixes CI. Until upstream CMake is fixed we need to block any further syncing of the CMake submodule. This also warrants a new patch release.

cc: @nim65s @proyan 

This reverts commit cf179f7bcd676cc8a489add1e83f4c031c9f09d0.