### PR TITLE
Big difference in examples log for Box ddp solver

### DIFF
--- a/examples/bipedal_walk.py
+++ b/examples/bipedal_walk.py
@@ -86,7 +86,7 @@ if WITHPLOT:
     plotSolution(ddp, bounds=False, figIndex=1, show=False)
 
     for i, phase in enumerate(GAITPHASES):
-        title = phase.keys()[0] + " (phase " + str(i) + ")"
+        title = list(phase.keys())[0] + " (phase " + str(i) + ")"
         log = ddp[i].getCallbacks()[0]
         crocoddyl.plotConvergence(log.costs,
                                   log.u_regs,

--- a/examples/bipedal_walk_ubound.py
+++ b/examples/bipedal_walk_ubound.py
@@ -89,7 +89,7 @@ if WITHPLOT:
     plotSolution(ddp, bounds=False, figIndex=1, show=False)
 
     for i, phase in enumerate(GAITPHASES):
-        title = phase.keys()[0] + " (phase " + str(i) + ")"
+        title = list(phase.keys())[0] + " (phase " + str(i) + ")"
         log = ddp[i].getCallbacks()[0]
         crocoddyl.plotConvergence(log.costs,
                                   log.u_regs,

--- a/examples/quadrupedal_gaits.py
+++ b/examples/quadrupedal_gaits.py
@@ -138,7 +138,7 @@ if WITHPLOT:
     plotSolution(ddp, figIndex=1, show=False)
 
     for i, phase in enumerate(GAITPHASES):
-        title = phase.keys()[0] + " (phase " + str(i) + ")"
+        title = list(phase.keys())[0] + " (phase " + str(i) + ")"
         log = ddp[i].getCallbacks()[0]
         crocoddyl.plotConvergence(log.costs,
                                   log.u_regs,


### PR DESCRIPTION
When comparing the logs to make sure that modifications don't produce a divergence in the output of DDP, it seems normal to expect some difference in numerical outputs because of floating point operations. However, when comparing the logs for the current devel in my system, there is a big difference in the cost outputs of the BoxDDP, which should not be there.

My system is `Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz`, and I have `Ubuntu 16.04.6 LTS` and all the system dependencies that come with it.

This PR is not to be merged, this is simply to discuss this issue and to provide a diff between the two computations.