### PR TITLE
FDDP: Fix expectedImprovement for terminalModel

### DIFF
--- a/src/core/solvers/fddp.cpp
+++ b/src/core/solvers/fddp.cpp
@@ -108,7 +108,7 @@ const Eigen::Vector2d& SolverFDDP::expectedImprovement() {
   dv_ = 0;
   const std::size_t& T = this->problem_->get_T();
   if (!is_feasible_) {
-    problem_->get_runningModels().back()->get_state()->diff(xs_try_.back(), xs_.back(), dx_.back());
+    problem_->get_terminalModel()->get_state()->diff(xs_try_.back(), xs_.back(), dx_.back());
     fTVxx_p_.noalias() = Vxx_.back() * dx_.back();
     dv_ -= fs_.back().dot(fTVxx_p_);
     for (std::size_t t = 0; t < T; ++t) {


### PR DESCRIPTION
I believe this should be `terminalModel` as the running models all get updated with the for-loop below.

I checked with the biped and quadruped examples and there was no difference in the logs for convergence. In practice, I don't believe this to have too much of an impact but this should be the correct behaviour.