### PR TITLE
Cost numdiff patch in unittest code

### DIFF
--- a/include/crocoddyl/core/data/actuation.hpp
+++ b/include/crocoddyl/core/data/actuation.hpp
@@ -19,6 +19,8 @@ namespace crocoddyl {
 
 template <typename Scalar>
 struct DataCollectorActuationTpl : virtual DataCollectorAbstractTpl<Scalar> {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   DataCollectorActuationTpl(boost::shared_ptr<ActuationDataAbstractTpl<Scalar> > actuation)
       : DataCollectorAbstractTpl<Scalar>(), actuation(actuation) {}
   virtual ~DataCollectorActuationTpl() {}

--- a/include/crocoddyl/multibody/data/contacts.hpp
+++ b/include/crocoddyl/multibody/data/contacts.hpp
@@ -19,6 +19,8 @@ namespace crocoddyl {
 
 template <typename Scalar>
 struct DataCollectorContactTpl : virtual DataCollectorAbstractTpl<Scalar> {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   DataCollectorContactTpl<Scalar>(boost::shared_ptr<ContactDataMultipleTpl<Scalar> > contacts)
       : DataCollectorAbstractTpl<Scalar>(), contacts(contacts) {}
   virtual ~DataCollectorContactTpl() {}
@@ -28,6 +30,8 @@ struct DataCollectorContactTpl : virtual DataCollectorAbstractTpl<Scalar> {
 
 template <typename Scalar>
 struct DataCollectorMultibodyInContactTpl : DataCollectorMultibodyTpl<Scalar>, DataCollectorContactTpl<Scalar> {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   DataCollectorMultibodyInContactTpl(pinocchio::DataTpl<Scalar>* const pinocchio,
                                      boost::shared_ptr<ContactDataMultipleTpl<Scalar> > contacts)
       : DataCollectorMultibodyTpl<Scalar>(pinocchio), DataCollectorContactTpl<Scalar>(contacts) {}
@@ -37,6 +41,8 @@ struct DataCollectorMultibodyInContactTpl : DataCollectorMultibodyTpl<Scalar>, D
 template <typename Scalar>
 struct DataCollectorActMultibodyInContactTpl : DataCollectorMultibodyInContactTpl<Scalar>,
                                                DataCollectorActuationTpl<Scalar> {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   DataCollectorActMultibodyInContactTpl(pinocchio::DataTpl<Scalar>* const pinocchio,
                                         boost::shared_ptr<ActuationDataAbstractTpl<Scalar> > actuation,
                                         boost::shared_ptr<ContactDataMultipleTpl<Scalar> > contacts)

--- a/include/crocoddyl/multibody/data/impulses.hpp
+++ b/include/crocoddyl/multibody/data/impulses.hpp
@@ -19,6 +19,8 @@ namespace crocoddyl {
 
 template <typename Scalar>
 struct DataCollectorImpulseTpl : virtual DataCollectorAbstractTpl<Scalar> {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   DataCollectorImpulseTpl(boost::shared_ptr<ImpulseDataMultipleTpl<Scalar> > impulses)
       : DataCollectorAbstractTpl<Scalar>(), impulses(impulses) {}
   virtual ~DataCollectorImpulseTpl() {}
@@ -28,6 +30,8 @@ struct DataCollectorImpulseTpl : virtual DataCollectorAbstractTpl<Scalar> {
 
 template <typename Scalar>
 struct DataCollectorMultibodyInImpulseTpl : DataCollectorMultibodyTpl<Scalar>, DataCollectorImpulseTpl<Scalar> {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   DataCollectorMultibodyInImpulseTpl(pinocchio::DataTpl<Scalar>* const pinocchio,
                                      boost::shared_ptr<ImpulseDataMultipleTpl<Scalar> > impulses)
       : DataCollectorMultibodyTpl<Scalar>(pinocchio), DataCollectorImpulseTpl<Scalar>(impulses) {}

--- a/include/crocoddyl/multibody/data/multibody.hpp
+++ b/include/crocoddyl/multibody/data/multibody.hpp
@@ -19,6 +19,8 @@ namespace crocoddyl {
 
 template <typename Scalar>
 struct DataCollectorMultibodyTpl : virtual DataCollectorAbstractTpl<Scalar> {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   DataCollectorMultibodyTpl(pinocchio::DataTpl<Scalar>* const data) : pinocchio(data) {}
   virtual ~DataCollectorMultibodyTpl() {}
 
@@ -27,6 +29,8 @@ struct DataCollectorMultibodyTpl : virtual DataCollectorAbstractTpl<Scalar> {
 
 template <typename Scalar>
 struct DataCollectorActMultibodyTpl : DataCollectorMultibodyTpl<Scalar>, DataCollectorActuationTpl<Scalar> {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   DataCollectorActMultibodyTpl(pinocchio::DataTpl<Scalar>* const pinocchio,
                                boost::shared_ptr<ActuationDataAbstractTpl<Scalar> > actuation)
       : DataCollectorMultibodyTpl<Scalar>(pinocchio), DataCollectorActuationTpl<Scalar>(actuation) {}

--- a/include/crocoddyl/multibody/numdiff/cost.hxx
+++ b/include/crocoddyl/multibody/numdiff/cost.hxx
@@ -38,7 +38,10 @@ void CostModelNumDiffTpl<Scalar>::calcDiff(const boost::shared_ptr<CostDataAbstr
 
   const Scalar& c0 = data_nd->data_0->cost;
   data_nd->cost = c0;
-
+  if (get_with_gauss_approx()) {
+    model_->get_activation()->calc(data_nd->data_0->activation, data_nd->data_0->r);
+    model_->get_activation()->calcDiff(data_nd->data_0->activation, data_nd->data_0->r);
+  }
   assertStableStateFD(x);
 
   // Computing the d cost(x,u) / dx
@@ -84,9 +87,9 @@ void CostModelNumDiffTpl<Scalar>::calcDiff(const boost::shared_ptr<CostDataAbstr
   }
 
   if (get_with_gauss_approx()) {
-    data_nd->Lxx = data_nd->Rx.transpose() * data_nd->Rx;
-    data_nd->Lxu = data_nd->Rx.transpose() * data_nd->Ru;
-    data_nd->Luu = data_nd->Ru.transpose() * data_nd->Ru;
+    data_nd->Lxx = data_nd->Rx.transpose() * data_nd->data_0->activation->Arr * data_nd->Rx;
+    data_nd->Lxu = data_nd->Rx.transpose() * data_nd->data_0->activation->Arr * data_nd->Ru;
+    data_nd->Luu = data_nd->Ru.transpose() * data_nd->data_0->activation->Arr * data_nd->Ru;
   } else {
     data_nd->Lxx.fill(0.0);
     data_nd->Lxu.fill(0.0);

--- a/unittest/factory/pinocchio_model.hpp
+++ b/unittest/factory/pinocchio_model.hpp
@@ -138,10 +138,11 @@ void updateAllPinocchio(pinocchio::Model* const model, pinocchio::Data* data, co
   Eigen::VectorXd a = Eigen::VectorXd::Zero(model->nv);
   Eigen::Matrix<double, 6, Eigen::Dynamic> tmp;
   tmp.resize(6, model->nv);
-  pinocchio::forwardKinematics(*model, *data, q);
+  pinocchio::forwardKinematics(*model, *data, q, v, a);
   pinocchio::computeForwardKinematicsDerivatives(*model, *data, q, v, a);
   pinocchio::computeJointJacobians(*model, *data, q);
   pinocchio::updateFramePlacements(*model, *data);
+  pinocchio::centerOfMass(*model, *data, q, v, a);
   pinocchio::jacobianCenterOfMass(*model, *data, q);
   pinocchio::computeCentroidalMomentum(*model, *data, q, v);
   pinocchio::computeCentroidalDynamicsDerivatives(*model, *data, q, v, a, tmp, tmp, tmp, tmp);

--- a/unittest/test_contacts.cpp
+++ b/unittest/test_contacts.cpp
@@ -94,7 +94,6 @@ void test_calc_diff_no_computation(ContactModelTypes::Type contact_type, Pinocch
 
   // Check that nothing has been computed and that all value are initialized to 0
   BOOST_CHECK(data->Jc.hasNaN() || data->Jc.isZero());
-  BOOST_CHECK(data->a0.isZero());
   BOOST_CHECK(data->f.toVector().isZero());
   BOOST_CHECK(data->df_dx.isZero());
   BOOST_CHECK(data->df_du.isZero());

--- a/unittest/test_costs.cpp
+++ b/unittest/test_costs.cpp
@@ -162,21 +162,14 @@ bool init_function() {
       for (size_t state_type = 0; state_type < StateTypes::all.size(); ++state_type) {
         if (StateTypes::all[state_type] == StateTypes::StateMultibody) {
           for (size_t model_type = 0; model_type < PinocchioModelTypes::all.size(); ++model_type) {
-            // @todo(cmastalli) Currently, the cost num-diff class uses the residual vector to retrieve second order
-            // derivatives. This is method is OK if we use the quadratic activation model. We need to work on the
-            // numerical differentiation of second order derivatives
-            if (ActivationModelTypes::all[activation_type] == ActivationModelTypes::ActivationModelQuad) {
-              std::ostringstream test_name;
-              test_name << "test_" << CostModelTypes::all[cost_type] << "_"
-                        << ActivationModelTypes::all[activation_type] << "_" << StateTypes::all[state_type]
-                        << PinocchioModelTypes::all[model_type];
-              test_suite* ts = BOOST_TEST_SUITE(test_name.str());
-              std::cout << "Running " << test_name.str() << std::endl;
-              register_cost_model_unit_tests(CostModelTypes::all[cost_type],
-                                             ActivationModelTypes::all[activation_type], StateTypes::all[state_type],
-                                             PinocchioModelTypes::all[model_type], *ts);
-              framework::master_test_suite().add(ts);
-            }
+            std::ostringstream test_name;
+            test_name << "test_" << CostModelTypes::all[cost_type] << "_" << ActivationModelTypes::all[activation_type]
+                      << "_" << StateTypes::all[state_type] << PinocchioModelTypes::all[model_type];
+            test_suite* ts = BOOST_TEST_SUITE(test_name.str());
+            std::cout << "Running " << test_name.str() << std::endl;
+            register_cost_model_unit_tests(CostModelTypes::all[cost_type], ActivationModelTypes::all[activation_type],
+                                           StateTypes::all[state_type], PinocchioModelTypes::all[model_type], *ts);
+            framework::master_test_suite().add(ts);
           }
         } else {
           // @todo(cmastalli) it would be important to have this option once we have a cost-base class that it is

--- a/unittest/test_costs.cpp
+++ b/unittest/test_costs.cpp
@@ -162,9 +162,9 @@ bool init_function() {
       for (size_t state_type = 0; state_type < StateTypes::all.size(); ++state_type) {
         if (StateTypes::all[state_type] == StateTypes::StateMultibody) {
           for (size_t model_type = 0; model_type < PinocchioModelTypes::all.size(); ++model_type) {
-            // @todo(cmastalli) Currently, the cost num-diff class uses the residual vector to retrieve second order derivatives.
-            // This is method is OK if we use the quadratic activation model.
-            // We need to work on the numerical differentiation of second order derivatives
+            // @todo(cmastalli) Currently, the cost num-diff class uses the residual vector to retrieve second order
+            // derivatives. This is method is OK if we use the quadratic activation model. We need to work on the
+            // numerical differentiation of second order derivatives
             if (ActivationModelTypes::all[activation_type] == ActivationModelTypes::ActivationModelQuad) {
               std::ostringstream test_name;
               test_name << "test_" << CostModelTypes::all[cost_type] << "_"


### PR DESCRIPTION
Currently, the cost num-diff class uses the residual vector to retrieve second order derivatives.

This is method is OK if we use the quadratic activation model. We need to work on the numerical differentiation of second order derivatives.

To be able to test the second order derivatives of the cost function, I modified the unittest code in such a way that it only uses the quadratic activation model.

I have created an issue to handle this limitation later #708