### PR TITLE
Allowed Python users to write internal data of NumPy objects

### DIFF
--- a/bindings/python/crocoddyl/core/action-base.cpp
+++ b/bindings/python/crocoddyl/core/action-base.cpp
@@ -79,11 +79,11 @@ void exposeActionAbstract() {
                     "indicates whether problem has finite control limits")
       .add_property(
           "u_lb",
-          bp::make_function(&ActionModelAbstract_wrap::get_u_lb, bp::return_value_policy<bp::return_by_value>()),
+          bp::make_function(&ActionModelAbstract_wrap::get_u_lb, bp::return_internal_reference<>()),
           &ActionModelAbstract_wrap::set_u_lb, "lower control limits")
       .add_property(
           "u_ub",
-          bp::make_function(&ActionModelAbstract_wrap::get_u_ub, bp::return_value_policy<bp::return_by_value>()),
+          bp::make_function(&ActionModelAbstract_wrap::get_u_ub, bp::return_internal_reference<>()),
           &ActionModelAbstract_wrap::set_u_ub, "upper control limits");
 
   bp::register_ptr_to_python<boost::shared_ptr<ActionDataAbstract> >();

--- a/bindings/python/crocoddyl/core/action-base.cpp
+++ b/bindings/python/crocoddyl/core/action-base.cpp
@@ -102,23 +102,23 @@ void exposeActionAbstract() {
       .add_property("cost", bp::make_getter(&ActionDataAbstract::cost, bp::return_value_policy<bp::return_by_value>()),
                     bp::make_setter(&ActionDataAbstract::cost), "cost value")
       .add_property("xnext",
-                    bp::make_getter(&ActionDataAbstract::xnext, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&ActionDataAbstract::xnext, bp::return_internal_reference<>()),
                     bp::make_setter(&ActionDataAbstract::xnext), "next state")
-      .add_property("r", bp::make_getter(&ActionDataAbstract::r, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("r", bp::make_getter(&ActionDataAbstract::r, bp::return_internal_reference<>()),
                     bp::make_setter(&ActionDataAbstract::r), "cost residual")
-      .add_property("Fx", bp::make_getter(&ActionDataAbstract::Fx, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("Fx", bp::make_getter(&ActionDataAbstract::Fx, bp::return_internal_reference<>()),
                     bp::make_setter(&ActionDataAbstract::Fx), "Jacobian of the dynamics")
-      .add_property("Fu", bp::make_getter(&ActionDataAbstract::Fu, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("Fu", bp::make_getter(&ActionDataAbstract::Fu, bp::return_internal_reference<>()),
                     bp::make_setter(&ActionDataAbstract::Fu), "Jacobian of the dynamics")
-      .add_property("Lx", bp::make_getter(&ActionDataAbstract::Lx, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("Lx", bp::make_getter(&ActionDataAbstract::Lx, bp::return_internal_reference<>()),
                     bp::make_setter(&ActionDataAbstract::Lx), "Jacobian of the cost")
-      .add_property("Lu", bp::make_getter(&ActionDataAbstract::Lu, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("Lu", bp::make_getter(&ActionDataAbstract::Lu, bp::return_internal_reference<>()),
                     bp::make_setter(&ActionDataAbstract::Lu), "Jacobian of the cost")
-      .add_property("Lxx", bp::make_getter(&ActionDataAbstract::Lxx, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("Lxx", bp::make_getter(&ActionDataAbstract::Lxx, bp::return_internal_reference<>()),
                     bp::make_setter(&ActionDataAbstract::Lxx), "Hessian of the cost")
-      .add_property("Lxu", bp::make_getter(&ActionDataAbstract::Lxu, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("Lxu", bp::make_getter(&ActionDataAbstract::Lxu, bp::return_internal_reference<>()),
                     bp::make_setter(&ActionDataAbstract::Lxu), "Hessian of the cost")
-      .add_property("Luu", bp::make_getter(&ActionDataAbstract::Luu, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("Luu", bp::make_getter(&ActionDataAbstract::Luu, bp::return_internal_reference<>()),
                     bp::make_setter(&ActionDataAbstract::Luu), "Hessian of the cost");
 }
 

--- a/bindings/python/crocoddyl/core/action-base.cpp
+++ b/bindings/python/crocoddyl/core/action-base.cpp
@@ -77,14 +77,10 @@ void exposeActionAbstract() {
                     bp::make_function(&ActionModelAbstract_wrap::get_has_control_limits,
                                       bp::return_value_policy<bp::return_by_value>()),
                     "indicates whether problem has finite control limits")
-      .add_property(
-          "u_lb",
-          bp::make_function(&ActionModelAbstract_wrap::get_u_lb, bp::return_internal_reference<>()),
-          &ActionModelAbstract_wrap::set_u_lb, "lower control limits")
-      .add_property(
-          "u_ub",
-          bp::make_function(&ActionModelAbstract_wrap::get_u_ub, bp::return_internal_reference<>()),
-          &ActionModelAbstract_wrap::set_u_ub, "upper control limits");
+      .add_property("u_lb", bp::make_function(&ActionModelAbstract_wrap::get_u_lb, bp::return_internal_reference<>()),
+                    &ActionModelAbstract_wrap::set_u_lb, "lower control limits")
+      .add_property("u_ub", bp::make_function(&ActionModelAbstract_wrap::get_u_ub, bp::return_internal_reference<>()),
+                    &ActionModelAbstract_wrap::set_u_ub, "upper control limits");
 
   bp::register_ptr_to_python<boost::shared_ptr<ActionDataAbstract> >();
 
@@ -101,8 +97,7 @@ void exposeActionAbstract() {
                                      ":param model: action model"))
       .add_property("cost", bp::make_getter(&ActionDataAbstract::cost, bp::return_value_policy<bp::return_by_value>()),
                     bp::make_setter(&ActionDataAbstract::cost), "cost value")
-      .add_property("xnext",
-                    bp::make_getter(&ActionDataAbstract::xnext, bp::return_internal_reference<>()),
+      .add_property("xnext", bp::make_getter(&ActionDataAbstract::xnext, bp::return_internal_reference<>()),
                     bp::make_setter(&ActionDataAbstract::xnext), "next state")
       .add_property("r", bp::make_getter(&ActionDataAbstract::r, bp::return_internal_reference<>()),
                     bp::make_setter(&ActionDataAbstract::r), "cost residual")

--- a/bindings/python/crocoddyl/core/actions/diff-lqr.cpp
+++ b/bindings/python/crocoddyl/core/actions/diff-lqr.cpp
@@ -59,30 +59,30 @@ void exposeDifferentialActionLQR() {
       .def("createData", &DifferentialActionModelLQR::createData, bp::args("self"),
            "Create the differential LQR action data.")
       .add_property(
-          "Fq", bp::make_function(&DifferentialActionModelLQR::get_Fq, bp::return_value_policy<bp::return_by_value>()),
+          "Fq", bp::make_function(&DifferentialActionModelLQR::get_Fq, bp::return_internal_reference<>()),
           &DifferentialActionModelLQR::set_Fq, "Jacobian of the dynamics")
       .add_property(
-          "Fv", bp::make_function(&DifferentialActionModelLQR::get_Fv, bp::return_value_policy<bp::return_by_value>()),
+          "Fv", bp::make_function(&DifferentialActionModelLQR::get_Fv, bp::return_internal_reference<>()),
           &DifferentialActionModelLQR::set_Fv, "Jacobian of the dynamics")
       .add_property(
-          "Fu", bp::make_function(&DifferentialActionModelLQR::get_Fu, bp::return_value_policy<bp::return_by_value>()),
+          "Fu", bp::make_function(&DifferentialActionModelLQR::get_Fu, bp::return_internal_reference<>()),
           &DifferentialActionModelLQR::set_Fu, "Jacobian of the dynamics")
       .add_property(
-          "f0", bp::make_function(&DifferentialActionModelLQR::get_f0, bp::return_value_policy<bp::return_by_value>()),
+          "f0", bp::make_function(&DifferentialActionModelLQR::get_f0, bp::return_internal_reference<>()),
           &DifferentialActionModelLQR::set_f0, "dynamics drift")
       .add_property(
-          "lx", bp::make_function(&DifferentialActionModelLQR::get_lx, bp::return_value_policy<bp::return_by_value>()),
+          "lx", bp::make_function(&DifferentialActionModelLQR::get_lx, bp::return_internal_reference<>()),
           &DifferentialActionModelLQR::set_lx, "Jacobian of the cost")
       .add_property(
-          "lu", bp::make_function(&DifferentialActionModelLQR::get_lu, bp::return_value_policy<bp::return_by_value>()),
+          "lu", bp::make_function(&DifferentialActionModelLQR::get_lu, bp::return_internal_reference<>()),
           &DifferentialActionModelLQR::set_lu, "Jacobian of the cost")
       .add_property(
           "Lxx",
-          bp::make_function(&DifferentialActionModelLQR::get_Lxx, bp::return_value_policy<bp::return_by_value>()),
+          bp::make_function(&DifferentialActionModelLQR::get_Lxx, bp::return_internal_reference<>()),
           &DifferentialActionModelLQR::set_Lxx, "Hessian of the cost")
       .add_property(
           "Lxu",
-          bp::make_function(&DifferentialActionModelLQR::get_Lxu, bp::return_value_policy<bp::return_by_value>()),
+          bp::make_function(&DifferentialActionModelLQR::get_Lxu, bp::return_internal_reference<>()),
           &DifferentialActionModelLQR::set_Lxu, "Hessian of the cost")
       .add_property(
           "Luu",

--- a/bindings/python/crocoddyl/core/actions/diff-lqr.cpp
+++ b/bindings/python/crocoddyl/core/actions/diff-lqr.cpp
@@ -58,32 +58,22 @@ void exposeDifferentialActionLQR() {
 
       .def("createData", &DifferentialActionModelLQR::createData, bp::args("self"),
            "Create the differential LQR action data.")
-      .add_property(
-          "Fq", bp::make_function(&DifferentialActionModelLQR::get_Fq, bp::return_internal_reference<>()),
-          &DifferentialActionModelLQR::set_Fq, "Jacobian of the dynamics")
-      .add_property(
-          "Fv", bp::make_function(&DifferentialActionModelLQR::get_Fv, bp::return_internal_reference<>()),
-          &DifferentialActionModelLQR::set_Fv, "Jacobian of the dynamics")
-      .add_property(
-          "Fu", bp::make_function(&DifferentialActionModelLQR::get_Fu, bp::return_internal_reference<>()),
-          &DifferentialActionModelLQR::set_Fu, "Jacobian of the dynamics")
-      .add_property(
-          "f0", bp::make_function(&DifferentialActionModelLQR::get_f0, bp::return_internal_reference<>()),
-          &DifferentialActionModelLQR::set_f0, "dynamics drift")
-      .add_property(
-          "lx", bp::make_function(&DifferentialActionModelLQR::get_lx, bp::return_internal_reference<>()),
-          &DifferentialActionModelLQR::set_lx, "Jacobian of the cost")
-      .add_property(
-          "lu", bp::make_function(&DifferentialActionModelLQR::get_lu, bp::return_internal_reference<>()),
-          &DifferentialActionModelLQR::set_lu, "Jacobian of the cost")
-      .add_property(
-          "Lxx",
-          bp::make_function(&DifferentialActionModelLQR::get_Lxx, bp::return_internal_reference<>()),
-          &DifferentialActionModelLQR::set_Lxx, "Hessian of the cost")
-      .add_property(
-          "Lxu",
-          bp::make_function(&DifferentialActionModelLQR::get_Lxu, bp::return_internal_reference<>()),
-          &DifferentialActionModelLQR::set_Lxu, "Hessian of the cost")
+      .add_property("Fq", bp::make_function(&DifferentialActionModelLQR::get_Fq, bp::return_internal_reference<>()),
+                    &DifferentialActionModelLQR::set_Fq, "Jacobian of the dynamics")
+      .add_property("Fv", bp::make_function(&DifferentialActionModelLQR::get_Fv, bp::return_internal_reference<>()),
+                    &DifferentialActionModelLQR::set_Fv, "Jacobian of the dynamics")
+      .add_property("Fu", bp::make_function(&DifferentialActionModelLQR::get_Fu, bp::return_internal_reference<>()),
+                    &DifferentialActionModelLQR::set_Fu, "Jacobian of the dynamics")
+      .add_property("f0", bp::make_function(&DifferentialActionModelLQR::get_f0, bp::return_internal_reference<>()),
+                    &DifferentialActionModelLQR::set_f0, "dynamics drift")
+      .add_property("lx", bp::make_function(&DifferentialActionModelLQR::get_lx, bp::return_internal_reference<>()),
+                    &DifferentialActionModelLQR::set_lx, "Jacobian of the cost")
+      .add_property("lu", bp::make_function(&DifferentialActionModelLQR::get_lu, bp::return_internal_reference<>()),
+                    &DifferentialActionModelLQR::set_lu, "Jacobian of the cost")
+      .add_property("Lxx", bp::make_function(&DifferentialActionModelLQR::get_Lxx, bp::return_internal_reference<>()),
+                    &DifferentialActionModelLQR::set_Lxx, "Hessian of the cost")
+      .add_property("Lxu", bp::make_function(&DifferentialActionModelLQR::get_Lxu, bp::return_internal_reference<>()),
+                    &DifferentialActionModelLQR::set_Lxu, "Hessian of the cost")
       .add_property(
           "Luu",
           bp::make_function(&DifferentialActionModelLQR::get_Luu, bp::return_value_policy<bp::return_by_value>()),

--- a/bindings/python/crocoddyl/core/actions/lqr.cpp
+++ b/bindings/python/crocoddyl/core/actions/lqr.cpp
@@ -49,21 +49,21 @@ void exposeActionLQR() {
       .def<void (ActionModelLQR::*)(const boost::shared_ptr<ActionDataAbstract>&, const Eigen::VectorXd&)>(
           "calcDiff", &ActionModelLQR::calcDiff_wrap, bp::args("self", "data", "x"))
       .def("createData", &ActionModelLQR::createData, bp::args("self"), "Create the LQR action data.")
-      .add_property("Fx", bp::make_function(&ActionModelLQR::get_Fx, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("Fx", bp::make_function(&ActionModelLQR::get_Fx, bp::return_internal_reference<>()),
                     &ActionModelLQR::set_Fx, "Jacobian of the dynamics")
-      .add_property("Fu", bp::make_function(&ActionModelLQR::get_Fu, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("Fu", bp::make_function(&ActionModelLQR::get_Fu, bp::return_internal_reference<>()),
                     &ActionModelLQR::set_Fu, "Jacobian of the dynamics")
-      .add_property("f0", bp::make_function(&ActionModelLQR::get_f0, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("f0", bp::make_function(&ActionModelLQR::get_f0, bp::return_internal_reference<>()),
                     &ActionModelLQR::set_f0, "dynamics drift")
-      .add_property("lx", bp::make_function(&ActionModelLQR::get_lx, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("lx", bp::make_function(&ActionModelLQR::get_lx, bp::return_internal_reference<>()),
                     &ActionModelLQR::set_lx, "Jacobian of the cost")
-      .add_property("lu", bp::make_function(&ActionModelLQR::get_lu, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("lu", bp::make_function(&ActionModelLQR::get_lu, bp::return_internal_reference<>()),
                     &ActionModelLQR::set_lu, "Jacobian of the cost")
-      .add_property("Lxx", bp::make_function(&ActionModelLQR::get_Lxx, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("Lxx", bp::make_function(&ActionModelLQR::get_Lxx, bp::return_internal_reference<>()),
                     &ActionModelLQR::set_Lxx, "Hessian of the cost")
-      .add_property("Lxu", bp::make_function(&ActionModelLQR::get_Lxu, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("Lxu", bp::make_function(&ActionModelLQR::get_Lxu, bp::return_internal_reference<>()),
                     &ActionModelLQR::set_Lxu, "Hessian of the cost")
-      .add_property("Luu", bp::make_function(&ActionModelLQR::get_Luu, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("Luu", bp::make_function(&ActionModelLQR::get_Luu, bp::return_internal_reference<>()),
                     &ActionModelLQR::set_Luu, "Hessian of the cost");
 
   boost::python::register_ptr_to_python<boost::shared_ptr<ActionDataLQR> >();

--- a/bindings/python/crocoddyl/core/actions/unicycle.cpp
+++ b/bindings/python/crocoddyl/core/actions/unicycle.cpp
@@ -50,7 +50,7 @@ void exposeActionUnicycle() {
       .def("createData", &ActionModelUnicycle::createData, bp::args("self"), "Create the unicycle action data.")
       .add_property(
           "costWeights",
-          bp::make_function(&ActionModelUnicycle::get_cost_weights, bp::return_value_policy<bp::return_by_value>()),
+          bp::make_function(&ActionModelUnicycle::get_cost_weights, bp::return_internal_reference<>()),
           bp::make_function(&ActionModelUnicycle::set_cost_weights), "cost weights");
 
   bp::register_ptr_to_python<boost::shared_ptr<ActionDataUnicycle> >();

--- a/bindings/python/crocoddyl/core/actions/unicycle.cpp
+++ b/bindings/python/crocoddyl/core/actions/unicycle.cpp
@@ -48,10 +48,9 @@ void exposeActionUnicycle() {
       .def<void (ActionModelUnicycle::*)(const boost::shared_ptr<ActionDataAbstract>&, const Eigen::VectorXd&)>(
           "calcDiff", &ActionModelUnicycle::calcDiff_wrap, bp::args("self", "data", "x"))
       .def("createData", &ActionModelUnicycle::createData, bp::args("self"), "Create the unicycle action data.")
-      .add_property(
-          "costWeights",
-          bp::make_function(&ActionModelUnicycle::get_cost_weights, bp::return_internal_reference<>()),
-          bp::make_function(&ActionModelUnicycle::set_cost_weights), "cost weights");
+      .add_property("costWeights",
+                    bp::make_function(&ActionModelUnicycle::get_cost_weights, bp::return_internal_reference<>()),
+                    bp::make_function(&ActionModelUnicycle::set_cost_weights), "cost weights");
 
   bp::register_ptr_to_python<boost::shared_ptr<ActionDataUnicycle> >();
 

--- a/bindings/python/crocoddyl/core/activation-base.cpp
+++ b/bindings/python/crocoddyl/core/activation-base.cpp
@@ -53,8 +53,7 @@ void exposeActivationAbstract() {
                     bp::make_setter(&ActivationDataAbstract::a_value), "cost value")
       .add_property("Ar", bp::make_getter(&ActivationDataAbstract::Ar, bp::return_internal_reference<>()),
                     bp::make_setter(&ActivationDataAbstract::Ar), "Jacobian of the residual")
-      .add_property("Arr",
-                    bp::make_getter(&ActivationDataAbstract::Arr, bp::return_internal_reference<>()),
+      .add_property("Arr", bp::make_getter(&ActivationDataAbstract::Arr, bp::return_internal_reference<>()),
                     bp::make_setter(&ActivationDataAbstract::Arr), "Hessian of the residual");
 }
 

--- a/bindings/python/crocoddyl/core/activation-base.cpp
+++ b/bindings/python/crocoddyl/core/activation-base.cpp
@@ -51,10 +51,10 @@ void exposeActivationAbstract() {
       .add_property("a",
                     bp::make_getter(&ActivationDataAbstract::a_value, bp::return_value_policy<bp::return_by_value>()),
                     bp::make_setter(&ActivationDataAbstract::a_value), "cost value")
-      .add_property("Ar", bp::make_getter(&ActivationDataAbstract::Ar, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("Ar", bp::make_getter(&ActivationDataAbstract::Ar, bp::return_internal_reference<>()),
                     bp::make_setter(&ActivationDataAbstract::Ar), "Jacobian of the residual")
       .add_property("Arr",
-                    bp::make_getter(&ActivationDataAbstract::Arr, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&ActivationDataAbstract::Arr, bp::return_internal_reference<>()),
                     bp::make_setter(&ActivationDataAbstract::Arr), "Hessian of the residual");
 }
 

--- a/bindings/python/crocoddyl/core/activations/quadratic-barrier.cpp
+++ b/bindings/python/crocoddyl/core/activations/quadratic-barrier.cpp
@@ -25,9 +25,9 @@ void exposeActivationQuadraticBarrier() {
                                    ":param lb: lower bounds\n"
                                    ":param ub: upper bounds\n"
                                    ":param beta: range of activation (between 0 to 1, default 1)"))
-      .add_property("lb", bp::make_getter(&ActivationBounds::lb, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("lb", bp::make_getter(&ActivationBounds::lb, bp::return_internal_reference<>()),
                     "lower bounds")
-      .add_property("ub", bp::make_getter(&ActivationBounds::ub, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("ub", bp::make_getter(&ActivationBounds::ub, bp::return_internal_reference<>()),
                     "upper bounds")
       .add_property("beta", &ActivationBounds::beta, "beta");
 

--- a/bindings/python/crocoddyl/core/activations/quadratic-barrier.cpp
+++ b/bindings/python/crocoddyl/core/activations/quadratic-barrier.cpp
@@ -25,10 +25,8 @@ void exposeActivationQuadraticBarrier() {
                                    ":param lb: lower bounds\n"
                                    ":param ub: upper bounds\n"
                                    ":param beta: range of activation (between 0 to 1, default 1)"))
-      .add_property("lb", bp::make_getter(&ActivationBounds::lb, bp::return_internal_reference<>()),
-                    "lower bounds")
-      .add_property("ub", bp::make_getter(&ActivationBounds::ub, bp::return_internal_reference<>()),
-                    "upper bounds")
+      .add_property("lb", bp::make_getter(&ActivationBounds::lb, bp::return_internal_reference<>()), "lower bounds")
+      .add_property("ub", bp::make_getter(&ActivationBounds::ub, bp::return_internal_reference<>()), "upper bounds")
       .add_property("beta", &ActivationBounds::beta, "beta");
 
   bp::class_<ActivationModelQuadraticBarrier, bp::bases<ActivationModelAbstract> >(

--- a/bindings/python/crocoddyl/core/activations/smooth-abs.cpp
+++ b/bindings/python/crocoddyl/core/activations/smooth-abs.cpp
@@ -29,7 +29,7 @@ void exposeActivationSmoothAbs() {
       .def<void (ActivationModelSmoothAbs::*)(const boost::shared_ptr<ActivationDataAbstract>&,
                                               const Eigen::VectorXd&)>(
           "calcDiff", &ActivationModelSmoothAbs::calcDiff_wrap, bp::args("self", "data", "r"),
-          "Compute the derivatives of a smoot-abs function.\n\n"
+          "Compute the derivatives of a smooth-abs function.\n\n"
           ":param data: activation data\n"
           ":param r: residual vector \n")
 

--- a/bindings/python/crocoddyl/core/activations/weighted-quadratic-barrier.cpp
+++ b/bindings/python/crocoddyl/core/activations/weighted-quadratic-barrier.cpp
@@ -47,7 +47,7 @@ void exposeActivationWeightedQuadraticBarrier() {
                     "bounds (beta, lower and upper bounds)")
       .add_property("weights",
                     bp::make_function(&ActivationModelWeightedQuadraticBarrier::get_weights,
-                                      bp::return_value_policy<bp::return_by_value>()),
+                                      bp::return_internal_reference<>()),
                     bp::make_function(&ActivationModelWeightedQuadraticBarrier::set_weights), "vector of weights");
 }
 

--- a/bindings/python/crocoddyl/core/activations/weighted-quadratic-barrier.cpp
+++ b/bindings/python/crocoddyl/core/activations/weighted-quadratic-barrier.cpp
@@ -45,10 +45,10 @@ void exposeActivationWeightedQuadraticBarrier() {
                                       bp::return_value_policy<bp::return_by_value>()),
                     bp::make_function(&ActivationModelWeightedQuadraticBarrier::set_bounds),
                     "bounds (beta, lower and upper bounds)")
-      .add_property("weights",
-                    bp::make_function(&ActivationModelWeightedQuadraticBarrier::get_weights,
-                                      bp::return_internal_reference<>()),
-                    bp::make_function(&ActivationModelWeightedQuadraticBarrier::set_weights), "vector of weights");
+      .add_property(
+          "weights",
+          bp::make_function(&ActivationModelWeightedQuadraticBarrier::get_weights, bp::return_internal_reference<>()),
+          bp::make_function(&ActivationModelWeightedQuadraticBarrier::set_weights), "vector of weights");
 }
 
 }  // namespace python

--- a/bindings/python/crocoddyl/core/activations/weighted-quadratic.cpp
+++ b/bindings/python/crocoddyl/core/activations/weighted-quadratic.cpp
@@ -35,10 +35,9 @@ void exposeActivationWeightedQuad() {
           ":param r: residual vector \n")
       .def("createData", &ActivationModelWeightedQuad::createData, bp::args("self"),
            "Create the weighted quadratic action data.")
-      .add_property(
-          "weights",
-          bp::make_function(&ActivationModelWeightedQuad::get_weights, bp::return_internal_reference<>()),
-          &ActivationModelWeightedQuad::set_weights, "weights of the quadratic term");
+      .add_property("weights",
+                    bp::make_function(&ActivationModelWeightedQuad::get_weights, bp::return_internal_reference<>()),
+                    &ActivationModelWeightedQuad::set_weights, "weights of the quadratic term");
 }
 
 }  // namespace python

--- a/bindings/python/crocoddyl/core/activations/weighted-quadratic.cpp
+++ b/bindings/python/crocoddyl/core/activations/weighted-quadratic.cpp
@@ -37,7 +37,7 @@ void exposeActivationWeightedQuad() {
            "Create the weighted quadratic action data.")
       .add_property(
           "weights",
-          bp::make_function(&ActivationModelWeightedQuad::get_weights, bp::return_value_policy<bp::return_by_value>()),
+          bp::make_function(&ActivationModelWeightedQuad::get_weights, bp::return_internal_reference<>()),
           &ActivationModelWeightedQuad::set_weights, "weights of the quadratic term");
 }
 

--- a/bindings/python/crocoddyl/core/actuation-base.cpp
+++ b/bindings/python/crocoddyl/core/actuation-base.cpp
@@ -65,14 +65,11 @@ void exposeActuationAbstract() {
                                         "Create common data shared between actuation models.\n\n"
                                         "The actuation data uses the model in order to first process it.\n"
                                         ":param model: actuation model"))
-      .add_property("tau",
-                    bp::make_getter(&ActuationDataAbstract::tau, bp::return_internal_reference<>()),
+      .add_property("tau", bp::make_getter(&ActuationDataAbstract::tau, bp::return_internal_reference<>()),
                     bp::make_setter(&ActuationDataAbstract::tau), "actuation-force signal")
-      .add_property("dtau_dx",
-                    bp::make_getter(&ActuationDataAbstract::dtau_dx, bp::return_internal_reference<>()),
+      .add_property("dtau_dx", bp::make_getter(&ActuationDataAbstract::dtau_dx, bp::return_internal_reference<>()),
                     bp::make_setter(&ActuationDataAbstract::dtau_dx), "Jacobian of the actuation model")
-      .add_property("dtau_du",
-                    bp::make_getter(&ActuationDataAbstract::dtau_du, bp::return_internal_reference<>()),
+      .add_property("dtau_du", bp::make_getter(&ActuationDataAbstract::dtau_du, bp::return_internal_reference<>()),
                     bp::make_setter(&ActuationDataAbstract::dtau_du), "Jacobian of the actuation model");
 }
 

--- a/bindings/python/crocoddyl/core/actuation-base.cpp
+++ b/bindings/python/crocoddyl/core/actuation-base.cpp
@@ -66,13 +66,13 @@ void exposeActuationAbstract() {
                                         "The actuation data uses the model in order to first process it.\n"
                                         ":param model: actuation model"))
       .add_property("tau",
-                    bp::make_getter(&ActuationDataAbstract::tau, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&ActuationDataAbstract::tau, bp::return_internal_reference<>()),
                     bp::make_setter(&ActuationDataAbstract::tau), "actuation-force signal")
       .add_property("dtau_dx",
-                    bp::make_getter(&ActuationDataAbstract::dtau_dx, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&ActuationDataAbstract::dtau_dx, bp::return_internal_reference<>()),
                     bp::make_setter(&ActuationDataAbstract::dtau_dx), "Jacobian of the actuation model")
       .add_property("dtau_du",
-                    bp::make_getter(&ActuationDataAbstract::dtau_du, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&ActuationDataAbstract::dtau_du, bp::return_internal_reference<>()),
                     bp::make_setter(&ActuationDataAbstract::dtau_du), "Jacobian of the actuation model");
 }
 

--- a/bindings/python/crocoddyl/core/diff-action-base.cpp
+++ b/bindings/python/crocoddyl/core/diff-action-base.cpp
@@ -99,34 +99,24 @@ void exposeDifferentialActionAbstract() {
           "cost",
           bp::make_getter(&DifferentialActionDataAbstract::cost, bp::return_value_policy<bp::return_by_value>()),
           bp::make_setter(&DifferentialActionDataAbstract::cost), "cost value")
-      .add_property(
-          "xout",
-          bp::make_getter(&DifferentialActionDataAbstract::xout, bp::return_internal_reference<>()),
-          bp::make_setter(&DifferentialActionDataAbstract::xout), "evolution state")
-      .add_property(
-          "r", bp::make_getter(&DifferentialActionDataAbstract::r, bp::return_internal_reference<>()),
-          bp::make_setter(&DifferentialActionDataAbstract::r), "cost residual")
-      .add_property(
-          "Fx", bp::make_getter(&DifferentialActionDataAbstract::Fx, bp::return_internal_reference<>()),
-          bp::make_setter(&DifferentialActionDataAbstract::Fx), "Jacobian of the dynamics")
-      .add_property(
-          "Fu", bp::make_getter(&DifferentialActionDataAbstract::Fu, bp::return_internal_reference<>()),
-          bp::make_setter(&DifferentialActionDataAbstract::Fu), "Jacobian of the dynamics")
-      .add_property(
-          "Lx", bp::make_getter(&DifferentialActionDataAbstract::Lx, bp::return_internal_reference<>()),
-          bp::make_setter(&DifferentialActionDataAbstract::Lx), "Jacobian of the cost")
-      .add_property(
-          "Lu", bp::make_getter(&DifferentialActionDataAbstract::Lu, bp::return_internal_reference<>()),
-          bp::make_setter(&DifferentialActionDataAbstract::Lu), "Jacobian of the cost")
-      .add_property(
-          "Lxx", bp::make_getter(&DifferentialActionDataAbstract::Lxx, bp::return_internal_reference<>()),
-          bp::make_setter(&DifferentialActionDataAbstract::Lxx), "Hessian of the cost")
-      .add_property(
-          "Lxu", bp::make_getter(&DifferentialActionDataAbstract::Lxu, bp::return_internal_reference<>()),
-          bp::make_setter(&DifferentialActionDataAbstract::Lxu), "Hessian of the cost")
-      .add_property(
-          "Luu", bp::make_getter(&DifferentialActionDataAbstract::Luu, bp::return_internal_reference<>()),
-          bp::make_setter(&DifferentialActionDataAbstract::Luu), "Hessian of the cost");
+      .add_property("xout", bp::make_getter(&DifferentialActionDataAbstract::xout, bp::return_internal_reference<>()),
+                    bp::make_setter(&DifferentialActionDataAbstract::xout), "evolution state")
+      .add_property("r", bp::make_getter(&DifferentialActionDataAbstract::r, bp::return_internal_reference<>()),
+                    bp::make_setter(&DifferentialActionDataAbstract::r), "cost residual")
+      .add_property("Fx", bp::make_getter(&DifferentialActionDataAbstract::Fx, bp::return_internal_reference<>()),
+                    bp::make_setter(&DifferentialActionDataAbstract::Fx), "Jacobian of the dynamics")
+      .add_property("Fu", bp::make_getter(&DifferentialActionDataAbstract::Fu, bp::return_internal_reference<>()),
+                    bp::make_setter(&DifferentialActionDataAbstract::Fu), "Jacobian of the dynamics")
+      .add_property("Lx", bp::make_getter(&DifferentialActionDataAbstract::Lx, bp::return_internal_reference<>()),
+                    bp::make_setter(&DifferentialActionDataAbstract::Lx), "Jacobian of the cost")
+      .add_property("Lu", bp::make_getter(&DifferentialActionDataAbstract::Lu, bp::return_internal_reference<>()),
+                    bp::make_setter(&DifferentialActionDataAbstract::Lu), "Jacobian of the cost")
+      .add_property("Lxx", bp::make_getter(&DifferentialActionDataAbstract::Lxx, bp::return_internal_reference<>()),
+                    bp::make_setter(&DifferentialActionDataAbstract::Lxx), "Hessian of the cost")
+      .add_property("Lxu", bp::make_getter(&DifferentialActionDataAbstract::Lxu, bp::return_internal_reference<>()),
+                    bp::make_setter(&DifferentialActionDataAbstract::Lxu), "Hessian of the cost")
+      .add_property("Luu", bp::make_getter(&DifferentialActionDataAbstract::Luu, bp::return_internal_reference<>()),
+                    bp::make_setter(&DifferentialActionDataAbstract::Luu), "Hessian of the cost");
 }
 
 }  // namespace python

--- a/bindings/python/crocoddyl/core/diff-action-base.cpp
+++ b/bindings/python/crocoddyl/core/diff-action-base.cpp
@@ -101,31 +101,31 @@ void exposeDifferentialActionAbstract() {
           bp::make_setter(&DifferentialActionDataAbstract::cost), "cost value")
       .add_property(
           "xout",
-          bp::make_getter(&DifferentialActionDataAbstract::xout, bp::return_value_policy<bp::return_by_value>()),
+          bp::make_getter(&DifferentialActionDataAbstract::xout, bp::return_internal_reference<>()),
           bp::make_setter(&DifferentialActionDataAbstract::xout), "evolution state")
       .add_property(
-          "r", bp::make_getter(&DifferentialActionDataAbstract::r, bp::return_value_policy<bp::return_by_value>()),
+          "r", bp::make_getter(&DifferentialActionDataAbstract::r, bp::return_internal_reference<>()),
           bp::make_setter(&DifferentialActionDataAbstract::r), "cost residual")
       .add_property(
-          "Fx", bp::make_getter(&DifferentialActionDataAbstract::Fx, bp::return_value_policy<bp::return_by_value>()),
+          "Fx", bp::make_getter(&DifferentialActionDataAbstract::Fx, bp::return_internal_reference<>()),
           bp::make_setter(&DifferentialActionDataAbstract::Fx), "Jacobian of the dynamics")
       .add_property(
-          "Fu", bp::make_getter(&DifferentialActionDataAbstract::Fu, bp::return_value_policy<bp::return_by_value>()),
+          "Fu", bp::make_getter(&DifferentialActionDataAbstract::Fu, bp::return_internal_reference<>()),
           bp::make_setter(&DifferentialActionDataAbstract::Fu), "Jacobian of the dynamics")
       .add_property(
-          "Lx", bp::make_getter(&DifferentialActionDataAbstract::Lx, bp::return_value_policy<bp::return_by_value>()),
+          "Lx", bp::make_getter(&DifferentialActionDataAbstract::Lx, bp::return_internal_reference<>()),
           bp::make_setter(&DifferentialActionDataAbstract::Lx), "Jacobian of the cost")
       .add_property(
-          "Lu", bp::make_getter(&DifferentialActionDataAbstract::Lu, bp::return_value_policy<bp::return_by_value>()),
+          "Lu", bp::make_getter(&DifferentialActionDataAbstract::Lu, bp::return_internal_reference<>()),
           bp::make_setter(&DifferentialActionDataAbstract::Lu), "Jacobian of the cost")
       .add_property(
-          "Lxx", bp::make_getter(&DifferentialActionDataAbstract::Lxx, bp::return_value_policy<bp::return_by_value>()),
+          "Lxx", bp::make_getter(&DifferentialActionDataAbstract::Lxx, bp::return_internal_reference<>()),
           bp::make_setter(&DifferentialActionDataAbstract::Lxx), "Hessian of the cost")
       .add_property(
-          "Lxu", bp::make_getter(&DifferentialActionDataAbstract::Lxu, bp::return_value_policy<bp::return_by_value>()),
+          "Lxu", bp::make_getter(&DifferentialActionDataAbstract::Lxu, bp::return_internal_reference<>()),
           bp::make_setter(&DifferentialActionDataAbstract::Lxu), "Hessian of the cost")
       .add_property(
-          "Luu", bp::make_getter(&DifferentialActionDataAbstract::Luu, bp::return_value_policy<bp::return_by_value>()),
+          "Luu", bp::make_getter(&DifferentialActionDataAbstract::Luu, bp::return_internal_reference<>()),
           bp::make_setter(&DifferentialActionDataAbstract::Luu), "Hessian of the cost");
 }
 

--- a/bindings/python/crocoddyl/core/integrator/euler.cpp
+++ b/bindings/python/crocoddyl/core/integrator/euler.cpp
@@ -69,25 +69,18 @@ void exposeIntegratedActionEuler() {
           "differential",
           bp::make_getter(&IntegratedActionDataEuler::differential, bp::return_value_policy<bp::return_by_value>()),
           "differential action data")
-      .add_property("dx",
-                    bp::make_getter(&IntegratedActionDataEuler::dx, bp::return_internal_reference<>()),
+      .add_property("dx", bp::make_getter(&IntegratedActionDataEuler::dx, bp::return_internal_reference<>()),
                     "state rate.")
-      .add_property(
-          "ddx_dx",
-          bp::make_getter(&IntegratedActionDataEuler::ddx_dx, bp::return_internal_reference<>()),
-          "Jacobian of the state rate with respect to the state.")
-      .add_property(
-          "ddx_du",
-          bp::make_getter(&IntegratedActionDataEuler::ddx_du, bp::return_internal_reference<>()),
-          "Jacobian of the state rate with respect to the control.")
-      .add_property(
-          "dxnext_dx",
-          bp::make_getter(&IntegratedActionDataEuler::dxnext_dx, bp::return_internal_reference<>()),
-          "Jacobian of the next state with respect to the state.")
-      .add_property(
-          "dxnext_ddx",
-          bp::make_getter(&IntegratedActionDataEuler::dxnext_ddx, bp::return_internal_reference<>()),
-          "Jacobian of the next state with respect to the state rate.");
+      .add_property("ddx_dx", bp::make_getter(&IntegratedActionDataEuler::ddx_dx, bp::return_internal_reference<>()),
+                    "Jacobian of the state rate with respect to the state.")
+      .add_property("ddx_du", bp::make_getter(&IntegratedActionDataEuler::ddx_du, bp::return_internal_reference<>()),
+                    "Jacobian of the state rate with respect to the control.")
+      .add_property("dxnext_dx",
+                    bp::make_getter(&IntegratedActionDataEuler::dxnext_dx, bp::return_internal_reference<>()),
+                    "Jacobian of the next state with respect to the state.")
+      .add_property("dxnext_ddx",
+                    bp::make_getter(&IntegratedActionDataEuler::dxnext_ddx, bp::return_internal_reference<>()),
+                    "Jacobian of the next state with respect to the state rate.");
 }
 
 }  // namespace python

--- a/bindings/python/crocoddyl/core/integrator/euler.cpp
+++ b/bindings/python/crocoddyl/core/integrator/euler.cpp
@@ -70,23 +70,23 @@ void exposeIntegratedActionEuler() {
           bp::make_getter(&IntegratedActionDataEuler::differential, bp::return_value_policy<bp::return_by_value>()),
           "differential action data")
       .add_property("dx",
-                    bp::make_getter(&IntegratedActionDataEuler::dx, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&IntegratedActionDataEuler::dx, bp::return_internal_reference<>()),
                     "state rate.")
       .add_property(
           "ddx_dx",
-          bp::make_getter(&IntegratedActionDataEuler::ddx_dx, bp::return_value_policy<bp::return_by_value>()),
+          bp::make_getter(&IntegratedActionDataEuler::ddx_dx, bp::return_internal_reference<>()),
           "Jacobian of the state rate with respect to the state.")
       .add_property(
           "ddx_du",
-          bp::make_getter(&IntegratedActionDataEuler::ddx_du, bp::return_value_policy<bp::return_by_value>()),
+          bp::make_getter(&IntegratedActionDataEuler::ddx_du, bp::return_internal_reference<>()),
           "Jacobian of the state rate with respect to the control.")
       .add_property(
           "dxnext_dx",
-          bp::make_getter(&IntegratedActionDataEuler::dxnext_dx, bp::return_value_policy<bp::return_by_value>()),
+          bp::make_getter(&IntegratedActionDataEuler::dxnext_dx, bp::return_internal_reference<>()),
           "Jacobian of the next state with respect to the state.")
       .add_property(
           "dxnext_ddx",
-          bp::make_getter(&IntegratedActionDataEuler::dxnext_ddx, bp::return_value_policy<bp::return_by_value>()),
+          bp::make_getter(&IntegratedActionDataEuler::dxnext_ddx, bp::return_internal_reference<>()),
           "Jacobian of the next state with respect to the state rate.");
 }
 

--- a/bindings/python/crocoddyl/core/numdiff/action.cpp
+++ b/bindings/python/crocoddyl/core/numdiff/action.cpp
@@ -61,13 +61,13 @@ void exposeActionNumDiff() {
       bp::init<ActionModelNumDiff*>(bp::args("self", "model"),
                                     "Create numerical differentiation action data.\n\n"
                                     ":param model: numdiff action model"))
-      .add_property("Rx", bp::make_getter(&ActionDataNumDiff::Rx, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("Rx", bp::make_getter(&ActionDataNumDiff::Rx, bp::return_internal_reference<>()),
                     "Jacobian of the cost residual.")
-      .add_property("Ru", bp::make_getter(&ActionDataNumDiff::Ru, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("Ru", bp::make_getter(&ActionDataNumDiff::Ru, bp::return_internal_reference<>()),
                     "Jacobian of the cost residual.")
-      .add_property("dx", bp::make_getter(&ActionDataNumDiff::dx, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("dx", bp::make_getter(&ActionDataNumDiff::dx, bp::return_internal_reference<>()),
                     "state disturbance.")
-      .add_property("du", bp::make_getter(&ActionDataNumDiff::du, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("du", bp::make_getter(&ActionDataNumDiff::du, bp::return_internal_reference<>()),
                     "control disturbance.")
       .add_property("data_0",
                     bp::make_getter(&ActionDataNumDiff::data_0, bp::return_value_policy<bp::return_by_value>()),

--- a/bindings/python/crocoddyl/core/numdiff/activation.cpp
+++ b/bindings/python/crocoddyl/core/numdiff/activation.cpp
@@ -52,9 +52,9 @@ void exposeActivationNumDiff() {
       bp::init<ActivationModelNumDiff*>(bp::args("self", "model"),
                                         "Create numerical differentiation activation data.\n\n"
                                         ":param model: numdiff activation model"))
-      .add_property("dr", bp::make_getter(&ActivationDataNumDiff::dr, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("dr", bp::make_getter(&ActivationDataNumDiff::dr, bp::return_internal_reference<>()),
                     "disturbance.")
-      .add_property("rp", bp::make_getter(&ActivationDataNumDiff::rp, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("rp", bp::make_getter(&ActivationDataNumDiff::rp, bp::return_internal_reference<>()),
                     "input plus the disturbance.")
       .add_property("data_0",
                     bp::make_getter(&ActivationDataNumDiff::data_0, bp::return_value_policy<bp::return_by_value>()),

--- a/bindings/python/crocoddyl/core/numdiff/diff-action.cpp
+++ b/bindings/python/crocoddyl/core/numdiff/diff-action.cpp
@@ -77,21 +77,16 @@ void exposeDifferentialActionNumDiff() {
       bp::init<DifferentialActionModelNumDiff*>(bp::args("self", "model"),
                                                 "Create numerical differentiation diff-action data.\n\n"
                                                 ":param model: numdiff diff-action model"))
-      .add_property(
-          "Rx", bp::make_getter(&DifferentialActionDataNumDiff::Rx, bp::return_internal_reference<>()),
-          "Jacobian of the cost residual.")
-      .add_property(
-          "Ru", bp::make_getter(&DifferentialActionDataNumDiff::Ru, bp::return_internal_reference<>()),
-          "Jacobian of the cost residual.")
-      .add_property(
-          "dx", bp::make_getter(&DifferentialActionDataNumDiff::dx, bp::return_internal_reference<>()),
-          "state disturbance.")
-      .add_property(
-          "du", bp::make_getter(&DifferentialActionDataNumDiff::du, bp::return_internal_reference<>()),
-          "control disturbance.")
-      .add_property(
-          "xp", bp::make_getter(&DifferentialActionDataNumDiff::xp, bp::return_internal_reference<>()),
-          "rate state after disturbance.")
+      .add_property("Rx", bp::make_getter(&DifferentialActionDataNumDiff::Rx, bp::return_internal_reference<>()),
+                    "Jacobian of the cost residual.")
+      .add_property("Ru", bp::make_getter(&DifferentialActionDataNumDiff::Ru, bp::return_internal_reference<>()),
+                    "Jacobian of the cost residual.")
+      .add_property("dx", bp::make_getter(&DifferentialActionDataNumDiff::dx, bp::return_internal_reference<>()),
+                    "state disturbance.")
+      .add_property("du", bp::make_getter(&DifferentialActionDataNumDiff::du, bp::return_internal_reference<>()),
+                    "control disturbance.")
+      .add_property("xp", bp::make_getter(&DifferentialActionDataNumDiff::xp, bp::return_internal_reference<>()),
+                    "rate state after disturbance.")
       .add_property(
           "data_0",
           bp::make_getter(&DifferentialActionDataNumDiff::data_0, bp::return_value_policy<bp::return_by_value>()),

--- a/bindings/python/crocoddyl/core/numdiff/diff-action.cpp
+++ b/bindings/python/crocoddyl/core/numdiff/diff-action.cpp
@@ -78,19 +78,19 @@ void exposeDifferentialActionNumDiff() {
                                                 "Create numerical differentiation diff-action data.\n\n"
                                                 ":param model: numdiff diff-action model"))
       .add_property(
-          "Rx", bp::make_getter(&DifferentialActionDataNumDiff::Rx, bp::return_value_policy<bp::return_by_value>()),
+          "Rx", bp::make_getter(&DifferentialActionDataNumDiff::Rx, bp::return_internal_reference<>()),
           "Jacobian of the cost residual.")
       .add_property(
-          "Ru", bp::make_getter(&DifferentialActionDataNumDiff::Ru, bp::return_value_policy<bp::return_by_value>()),
+          "Ru", bp::make_getter(&DifferentialActionDataNumDiff::Ru, bp::return_internal_reference<>()),
           "Jacobian of the cost residual.")
       .add_property(
-          "dx", bp::make_getter(&DifferentialActionDataNumDiff::dx, bp::return_value_policy<bp::return_by_value>()),
+          "dx", bp::make_getter(&DifferentialActionDataNumDiff::dx, bp::return_internal_reference<>()),
           "state disturbance.")
       .add_property(
-          "du", bp::make_getter(&DifferentialActionDataNumDiff::du, bp::return_value_policy<bp::return_by_value>()),
+          "du", bp::make_getter(&DifferentialActionDataNumDiff::du, bp::return_internal_reference<>()),
           "control disturbance.")
       .add_property(
-          "xp", bp::make_getter(&DifferentialActionDataNumDiff::du, bp::return_value_policy<bp::return_by_value>()),
+          "xp", bp::make_getter(&DifferentialActionDataNumDiff::xp, bp::return_internal_reference<>()),
           "rate state after disturbance.")
       .add_property(
           "data_0",

--- a/bindings/python/crocoddyl/core/optctrl/shooting.cpp
+++ b/bindings/python/crocoddyl/core/optctrl/shooting.cpp
@@ -61,7 +61,7 @@ void exposeShootingProblem() {
            ":param us: time-discrete control sequence")
       .add_property("T", bp::make_function(&ShootingProblem::get_T, bp::return_value_policy<bp::return_by_value>()),
                     "number of nodes")
-      .add_property("x0", bp::make_function(&ShootingProblem::get_x0, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("x0", bp::make_function(&ShootingProblem::get_x0, bp::return_internal_reference<>()),
                     &ShootingProblem::set_x0, "initial state")
       .add_property(
           "runningModels",

--- a/bindings/python/crocoddyl/core/solvers/box-ddp.cpp
+++ b/bindings/python/crocoddyl/core/solvers/box-ddp.cpp
@@ -20,8 +20,7 @@ void exposeSolverBoxDDP() {
       bp::init<boost::shared_ptr<ShootingProblem> >(bp::args("self", "problem"),
                                                     "Initialize the vector dimension.\n\n"
                                                     ":param problem: shooting problem."))
-      .add_property("Quu_inv",
-                    make_function(&SolverBoxDDP::get_Quu_inv, bp::return_internal_reference<>()),
+      .add_property("Quu_inv", make_function(&SolverBoxDDP::get_Quu_inv, bp::return_internal_reference<>()),
                     "inverse of the Quu computed by the box QP");
 }
 

--- a/bindings/python/crocoddyl/core/solvers/box-ddp.cpp
+++ b/bindings/python/crocoddyl/core/solvers/box-ddp.cpp
@@ -21,7 +21,7 @@ void exposeSolverBoxDDP() {
                                                     "Initialize the vector dimension.\n\n"
                                                     ":param problem: shooting problem."))
       .add_property("Quu_inv",
-                    make_function(&SolverBoxDDP::get_Quu_inv, bp::return_value_policy<bp::copy_const_reference>()),
+                    make_function(&SolverBoxDDP::get_Quu_inv, bp::return_internal_reference<>()),
                     "inverse of the Quu computed by the box QP");
 }
 

--- a/bindings/python/crocoddyl/core/solvers/box-fddp.cpp
+++ b/bindings/python/crocoddyl/core/solvers/box-fddp.cpp
@@ -21,7 +21,7 @@ void exposeSolverBoxFDDP() {
                                                     "Initialize the vector dimension.\n\n"
                                                     ":param problem: shooting problem."))
       .add_property("Quu_inv",
-                    make_function(&SolverBoxFDDP::get_Quu_inv, bp::return_value_policy<bp::copy_const_reference>()),
+                    make_function(&SolverBoxFDDP::get_Quu_inv, bp::return_internal_reference<>()),
                     "inverse of the Quu computed by the box QP");
 }
 

--- a/bindings/python/crocoddyl/core/solvers/box-fddp.cpp
+++ b/bindings/python/crocoddyl/core/solvers/box-fddp.cpp
@@ -20,8 +20,7 @@ void exposeSolverBoxFDDP() {
       bp::init<boost::shared_ptr<ShootingProblem> >(bp::args("self", "problem"),
                                                     "Initialize the vector dimension.\n\n"
                                                     ":param problem: shooting problem."))
-      .add_property("Quu_inv",
-                    make_function(&SolverBoxFDDP::get_Quu_inv, bp::return_internal_reference<>()),
+      .add_property("Quu_inv", make_function(&SolverBoxFDDP::get_Quu_inv, bp::return_internal_reference<>()),
                     "inverse of the Quu computed by the box QP");
 }
 

--- a/bindings/python/crocoddyl/core/solvers/box-qp.cpp
+++ b/bindings/python/crocoddyl/core/solvers/box-qp.cpp
@@ -22,9 +22,9 @@ void exposeSolverBoxQP() {
                                 ":param free_idx: free indexes\n"
                                 ":param clamped_idx: clamped indexes"))
       .add_property("Hff_inv",
-                    bp::make_getter(&BoxQPSolution::Hff_inv, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&BoxQPSolution::Hff_inv, bp::return_internal_reference<>()),
                     bp::make_setter(&BoxQPSolution::Hff_inv), "inverse of the free Hessian matrix")
-      .add_property("x", bp::make_getter(&BoxQPSolution::x, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("x", bp::make_getter(&BoxQPSolution::x, bp::return_internal_reference<>()),
                     bp::make_setter(&BoxQPSolution::x), "decision variable")
       .add_property("free_idx",
                     bp::make_getter(&BoxQPSolution::free_idx, bp::return_value_policy<bp::return_by_value>()),

--- a/bindings/python/crocoddyl/core/solvers/box-qp.cpp
+++ b/bindings/python/crocoddyl/core/solvers/box-qp.cpp
@@ -21,8 +21,7 @@ void exposeSolverBoxQP() {
                                 ":param x: decision variable\n"
                                 ":param free_idx: free indexes\n"
                                 ":param clamped_idx: clamped indexes"))
-      .add_property("Hff_inv",
-                    bp::make_getter(&BoxQPSolution::Hff_inv, bp::return_internal_reference<>()),
+      .add_property("Hff_inv", bp::make_getter(&BoxQPSolution::Hff_inv, bp::return_internal_reference<>()),
                     bp::make_setter(&BoxQPSolution::Hff_inv), "inverse of the free Hessian matrix")
       .add_property("x", bp::make_getter(&BoxQPSolution::x, bp::return_internal_reference<>()),
                     bp::make_setter(&BoxQPSolution::x), "decision variable")

--- a/bindings/python/crocoddyl/multibody/actions/contact-fwddyn.cpp
+++ b/bindings/python/crocoddyl/multibody/actions/contact-fwddyn.cpp
@@ -110,18 +110,17 @@ void exposeDifferentialActionContactFwdDynamics() {
                     bp::make_getter(&DifferentialActionDataContactFwdDynamics::costs,
                                     bp::return_value_policy<bp::return_by_value>()),
                     "total cost data")
-      .add_property("Kinv",
-                    bp::make_getter(&DifferentialActionDataContactFwdDynamics::Kinv,
-                                    bp::return_internal_reference<>()),
-                    "inverse of the KKT matrix")
-      .add_property("df_dx",
-                    bp::make_getter(&DifferentialActionDataContactFwdDynamics::df_dx,
-                                    bp::return_internal_reference<>()),
-                    "Jacobian of the contact force")
-      .add_property("df_du",
-                    bp::make_getter(&DifferentialActionDataContactFwdDynamics::df_du,
-                                    bp::return_internal_reference<>()),
-                    "Jacobian of the contact force");
+      .add_property(
+          "Kinv", bp::make_getter(&DifferentialActionDataContactFwdDynamics::Kinv, bp::return_internal_reference<>()),
+          "inverse of the KKT matrix")
+      .add_property(
+          "df_dx",
+          bp::make_getter(&DifferentialActionDataContactFwdDynamics::df_dx, bp::return_internal_reference<>()),
+          "Jacobian of the contact force")
+      .add_property(
+          "df_du",
+          bp::make_getter(&DifferentialActionDataContactFwdDynamics::df_du, bp::return_internal_reference<>()),
+          "Jacobian of the contact force");
 }
 
 }  // namespace python

--- a/bindings/python/crocoddyl/multibody/actions/contact-fwddyn.cpp
+++ b/bindings/python/crocoddyl/multibody/actions/contact-fwddyn.cpp
@@ -112,15 +112,15 @@ void exposeDifferentialActionContactFwdDynamics() {
                     "total cost data")
       .add_property("Kinv",
                     bp::make_getter(&DifferentialActionDataContactFwdDynamics::Kinv,
-                                    bp::return_value_policy<bp::return_by_value>()),
+                                    bp::return_internal_reference<>()),
                     "inverse of the KKT matrix")
       .add_property("df_dx",
                     bp::make_getter(&DifferentialActionDataContactFwdDynamics::df_dx,
-                                    bp::return_value_policy<bp::return_by_value>()),
+                                    bp::return_internal_reference<>()),
                     "Jacobian of the contact force")
       .add_property("df_du",
                     bp::make_getter(&DifferentialActionDataContactFwdDynamics::df_du,
-                                    bp::return_value_policy<bp::return_by_value>()),
+                                    bp::return_internal_reference<>()),
                     "Jacobian of the contact force");
 }
 

--- a/bindings/python/crocoddyl/multibody/actions/free-fwddyn.cpp
+++ b/bindings/python/crocoddyl/multibody/actions/free-fwddyn.cpp
@@ -92,11 +92,11 @@ void exposeDifferentialActionFreeFwdDynamics() {
                     "total cost data")
       .add_property("Minv",
                     bp::make_getter(&DifferentialActionDataFreeFwdDynamics::Minv,
-                                    bp::return_value_policy<bp::return_by_value>()),
+                                    bp::return_internal_reference<>()),
                     "inverse of the joint-space inertia matrix")
       .add_property("u_drift",
                     bp::make_getter(&DifferentialActionDataFreeFwdDynamics::u_drift,
-                                    bp::return_value_policy<bp::return_by_value>()),
+                                    bp::return_internal_reference<>()),
                     "force-bias vector that accounts for control, Coriolis and gravitational effects");
 }
 

--- a/bindings/python/crocoddyl/multibody/actions/free-fwddyn.cpp
+++ b/bindings/python/crocoddyl/multibody/actions/free-fwddyn.cpp
@@ -67,7 +67,7 @@ void exposeDifferentialActionFreeFwdDynamics() {
                     "total cost model")
       .add_property("armature",
                     bp::make_function(&DifferentialActionModelFreeFwdDynamics::get_armature,
-                                      bp::return_value_policy<bp::return_by_value>()),
+                                      bp::return_internal_reference<>()),
                     bp::make_function(&DifferentialActionModelFreeFwdDynamics::set_armature),
                     "set an armature mechanism in the joints");
 

--- a/bindings/python/crocoddyl/multibody/actions/free-fwddyn.cpp
+++ b/bindings/python/crocoddyl/multibody/actions/free-fwddyn.cpp
@@ -65,11 +65,11 @@ void exposeDifferentialActionFreeFwdDynamics() {
                     bp::make_function(&DifferentialActionModelFreeFwdDynamics::get_costs,
                                       bp::return_value_policy<bp::return_by_value>()),
                     "total cost model")
-      .add_property("armature",
-                    bp::make_function(&DifferentialActionModelFreeFwdDynamics::get_armature,
-                                      bp::return_internal_reference<>()),
-                    bp::make_function(&DifferentialActionModelFreeFwdDynamics::set_armature),
-                    "set an armature mechanism in the joints");
+      .add_property(
+          "armature",
+          bp::make_function(&DifferentialActionModelFreeFwdDynamics::get_armature, bp::return_internal_reference<>()),
+          bp::make_function(&DifferentialActionModelFreeFwdDynamics::set_armature),
+          "set an armature mechanism in the joints");
 
   bp::register_ptr_to_python<boost::shared_ptr<DifferentialActionDataFreeFwdDynamics> >();
 
@@ -91,13 +91,12 @@ void exposeDifferentialActionFreeFwdDynamics() {
                                     bp::return_value_policy<bp::return_by_value>()),
                     "total cost data")
       .add_property("Minv",
-                    bp::make_getter(&DifferentialActionDataFreeFwdDynamics::Minv,
-                                    bp::return_internal_reference<>()),
+                    bp::make_getter(&DifferentialActionDataFreeFwdDynamics::Minv, bp::return_internal_reference<>()),
                     "inverse of the joint-space inertia matrix")
-      .add_property("u_drift",
-                    bp::make_getter(&DifferentialActionDataFreeFwdDynamics::u_drift,
-                                    bp::return_internal_reference<>()),
-                    "force-bias vector that accounts for control, Coriolis and gravitational effects");
+      .add_property(
+          "u_drift",
+          bp::make_getter(&DifferentialActionDataFreeFwdDynamics::u_drift, bp::return_internal_reference<>()),
+          "force-bias vector that accounts for control, Coriolis and gravitational effects");
 }
 
 }  // namespace python

--- a/bindings/python/crocoddyl/multibody/actions/impulse-fwddyn.cpp
+++ b/bindings/python/crocoddyl/multibody/actions/impulse-fwddyn.cpp
@@ -109,11 +109,11 @@ void exposeActionImpulseFwdDynamics() {
           bp::make_getter(&ActionDataImpulseFwdDynamics::costs, bp::return_value_policy<bp::return_by_value>()),
           "total cost data")
       .add_property(
-          "Kinv", bp::make_getter(&ActionDataImpulseFwdDynamics::Kinv, bp::return_value_policy<bp::return_by_value>()),
+          "Kinv", bp::make_getter(&ActionDataImpulseFwdDynamics::Kinv, bp::return_internal_reference<>()),
           "inverse of the KKT matrix")
       .add_property(
           "df_dq",
-          bp::make_getter(&ActionDataImpulseFwdDynamics::df_dq, bp::return_value_policy<bp::return_by_value>()),
+          bp::make_getter(&ActionDataImpulseFwdDynamics::df_dq, bp::return_internal_reference<>()),
           "Jacobian of the impulse force");
 }
 

--- a/bindings/python/crocoddyl/multibody/actions/impulse-fwddyn.cpp
+++ b/bindings/python/crocoddyl/multibody/actions/impulse-fwddyn.cpp
@@ -76,8 +76,7 @@ void exposeActionImpulseFwdDynamics() {
           bp::make_function(&ActionModelImpulseFwdDynamics::get_costs, bp::return_value_policy<bp::return_by_value>()),
           "total cost model")
       .add_property("armature",
-                    bp::make_function(&ActionModelImpulseFwdDynamics::get_armature,
-                                      bp::return_internal_reference<>()),
+                    bp::make_function(&ActionModelImpulseFwdDynamics::get_armature, bp::return_internal_reference<>()),
                     bp::make_function(&ActionModelImpulseFwdDynamics::set_armature),
                     "set an armature mechanism in the joints")
       .add_property("r_coeff",
@@ -108,13 +107,10 @@ void exposeActionImpulseFwdDynamics() {
           "costs",
           bp::make_getter(&ActionDataImpulseFwdDynamics::costs, bp::return_value_policy<bp::return_by_value>()),
           "total cost data")
-      .add_property(
-          "Kinv", bp::make_getter(&ActionDataImpulseFwdDynamics::Kinv, bp::return_internal_reference<>()),
-          "inverse of the KKT matrix")
-      .add_property(
-          "df_dq",
-          bp::make_getter(&ActionDataImpulseFwdDynamics::df_dq, bp::return_internal_reference<>()),
-          "Jacobian of the impulse force");
+      .add_property("Kinv", bp::make_getter(&ActionDataImpulseFwdDynamics::Kinv, bp::return_internal_reference<>()),
+                    "inverse of the KKT matrix")
+      .add_property("df_dq", bp::make_getter(&ActionDataImpulseFwdDynamics::df_dq, bp::return_internal_reference<>()),
+                    "Jacobian of the impulse force");
 }
 
 }  // namespace python

--- a/bindings/python/crocoddyl/multibody/actions/impulse-fwddyn.cpp
+++ b/bindings/python/crocoddyl/multibody/actions/impulse-fwddyn.cpp
@@ -77,7 +77,7 @@ void exposeActionImpulseFwdDynamics() {
           "total cost model")
       .add_property("armature",
                     bp::make_function(&ActionModelImpulseFwdDynamics::get_armature,
-                                      bp::return_value_policy<bp::return_by_value>()),
+                                      bp::return_internal_reference<>()),
                     bp::make_function(&ActionModelImpulseFwdDynamics::set_armature),
                     "set an armature mechanism in the joints")
       .add_property("r_coeff",

--- a/bindings/python/crocoddyl/multibody/contact-base.cpp
+++ b/bindings/python/crocoddyl/multibody/contact-base.cpp
@@ -85,14 +85,11 @@ void exposeContactAbstract() {
                     bp::make_setter(&ContactDataAbstract::Jc), "contact Jacobian")
       .add_property("a0", bp::make_getter(&ContactDataAbstract::a0, bp::return_internal_reference<>()),
                     bp::make_setter(&ContactDataAbstract::a0), "desired contact acceleration")
-      .add_property("da0_dx",
-                    bp::make_getter(&ContactDataAbstract::da0_dx, bp::return_internal_reference<>()),
+      .add_property("da0_dx", bp::make_getter(&ContactDataAbstract::da0_dx, bp::return_internal_reference<>()),
                     bp::make_setter(&ContactDataAbstract::da0_dx), "Jacobian of the desired contact acceleration")
-      .add_property("df_dx",
-                    bp::make_getter(&ContactDataAbstract::df_dx, bp::return_internal_reference<>()),
+      .add_property("df_dx", bp::make_getter(&ContactDataAbstract::df_dx, bp::return_internal_reference<>()),
                     bp::make_setter(&ContactDataAbstract::df_dx), "Jacobian of the contact forces")
-      .add_property("df_du",
-                    bp::make_getter(&ContactDataAbstract::df_du, bp::return_internal_reference<>()),
+      .add_property("df_du", bp::make_getter(&ContactDataAbstract::df_du, bp::return_internal_reference<>()),
                     bp::make_setter(&ContactDataAbstract::df_du), "Jacobian of the contact forces")
       .def_readwrite("joint", &ContactDataAbstract::joint, "joint index of the contact frame")
       .def_readwrite("frame", &ContactDataAbstract::frame, "frame index of the contact frame")

--- a/bindings/python/crocoddyl/multibody/contact-base.cpp
+++ b/bindings/python/crocoddyl/multibody/contact-base.cpp
@@ -81,18 +81,18 @@ void exposeContactAbstract() {
                     "local frame placement of the contact frame")
       .add_property("fXj", bp::make_getter(&ContactDataAbstract::fXj, bp::return_value_policy<bp::return_by_value>()),
                     "action matrix from contact to local frames")
-      .add_property("Jc", bp::make_getter(&ContactDataAbstract::Jc, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("Jc", bp::make_getter(&ContactDataAbstract::Jc, bp::return_internal_reference<>()),
                     bp::make_setter(&ContactDataAbstract::Jc), "contact Jacobian")
-      .add_property("a0", bp::make_getter(&ContactDataAbstract::a0, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("a0", bp::make_getter(&ContactDataAbstract::a0, bp::return_internal_reference<>()),
                     bp::make_setter(&ContactDataAbstract::a0), "desired contact acceleration")
       .add_property("da0_dx",
-                    bp::make_getter(&ContactDataAbstract::da0_dx, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&ContactDataAbstract::da0_dx, bp::return_internal_reference<>()),
                     bp::make_setter(&ContactDataAbstract::da0_dx), "Jacobian of the desired contact acceleration")
       .add_property("df_dx",
-                    bp::make_getter(&ContactDataAbstract::df_dx, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&ContactDataAbstract::df_dx, bp::return_internal_reference<>()),
                     bp::make_setter(&ContactDataAbstract::df_dx), "Jacobian of the contact forces")
       .add_property("df_du",
-                    bp::make_getter(&ContactDataAbstract::df_du, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&ContactDataAbstract::df_du, bp::return_internal_reference<>()),
                     bp::make_setter(&ContactDataAbstract::df_du), "Jacobian of the contact forces")
       .def_readwrite("joint", &ContactDataAbstract::joint, "joint index of the contact frame")
       .def_readwrite("frame", &ContactDataAbstract::frame, "frame index of the contact frame")

--- a/bindings/python/crocoddyl/multibody/contacts/contact-3d.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/contact-3d.cpp
@@ -76,17 +76,13 @@ void exposeContact3D() {
                     "spatial acceleration of the contact body")
       .add_property("fJf", bp::make_getter(&ContactData3D::fJf, bp::return_internal_reference<>()),
                     "local Jacobian of the contact frame")
-      .add_property("v_partial_dq",
-                    bp::make_getter(&ContactData3D::v_partial_dq, bp::return_internal_reference<>()),
+      .add_property("v_partial_dq", bp::make_getter(&ContactData3D::v_partial_dq, bp::return_internal_reference<>()),
                     "Jacobian of the spatial body velocity")
-      .add_property("a_partial_dq",
-                    bp::make_getter(&ContactData3D::a_partial_dq, bp::return_internal_reference<>()),
+      .add_property("a_partial_dq", bp::make_getter(&ContactData3D::a_partial_dq, bp::return_internal_reference<>()),
                     "Jacobian of the spatial body acceleration")
-      .add_property("a_partial_dv",
-                    bp::make_getter(&ContactData3D::a_partial_dv, bp::return_internal_reference<>()),
+      .add_property("a_partial_dv", bp::make_getter(&ContactData3D::a_partial_dv, bp::return_internal_reference<>()),
                     "Jacobian of the spatial body acceleration")
-      .add_property("a_partial_da",
-                    bp::make_getter(&ContactData3D::a_partial_da, bp::return_internal_reference<>()),
+      .add_property("a_partial_da", bp::make_getter(&ContactData3D::a_partial_da, bp::return_internal_reference<>()),
                     "Jacobian of the spatial body acceleration")
       .add_property("oRf", bp::make_getter(&ContactData3D::oRf, bp::return_internal_reference<>()),
                     "Rotation matrix of the contact body expressed in the world frame");

--- a/bindings/python/crocoddyl/multibody/contacts/contact-3d.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/contact-3d.cpp
@@ -74,21 +74,21 @@ void exposeContact3D() {
                     "spatial velocity of the contact body")
       .add_property("a", bp::make_getter(&ContactData3D::a, bp::return_value_policy<bp::return_by_value>()),
                     "spatial acceleration of the contact body")
-      .add_property("fJf", bp::make_getter(&ContactData3D::fJf, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("fJf", bp::make_getter(&ContactData3D::fJf, bp::return_internal_reference<>()),
                     "local Jacobian of the contact frame")
       .add_property("v_partial_dq",
-                    bp::make_getter(&ContactData3D::v_partial_dq, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&ContactData3D::v_partial_dq, bp::return_internal_reference<>()),
                     "Jacobian of the spatial body velocity")
       .add_property("a_partial_dq",
-                    bp::make_getter(&ContactData3D::a_partial_dq, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&ContactData3D::a_partial_dq, bp::return_internal_reference<>()),
                     "Jacobian of the spatial body acceleration")
       .add_property("a_partial_dv",
-                    bp::make_getter(&ContactData3D::a_partial_dv, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&ContactData3D::a_partial_dv, bp::return_internal_reference<>()),
                     "Jacobian of the spatial body acceleration")
       .add_property("a_partial_da",
-                    bp::make_getter(&ContactData3D::a_partial_da, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&ContactData3D::a_partial_da, bp::return_internal_reference<>()),
                     "Jacobian of the spatial body acceleration")
-      .add_property("oRf", bp::make_getter(&ContactData3D::oRf, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("oRf", bp::make_getter(&ContactData3D::oRf, bp::return_internal_reference<>()),
                     "Rotation matrix of the contact body expressed in the world frame");
 }
 

--- a/bindings/python/crocoddyl/multibody/contacts/contact-6d.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/contact-6d.cpp
@@ -76,17 +76,13 @@ void exposeContact6D() {
                     "spatial velocity of the contact body")
       .add_property("a", bp::make_getter(&ContactData6D::a, bp::return_value_policy<bp::return_by_value>()),
                     "spatial acceleration of the contact body")
-      .add_property("v_partial_dq",
-                    bp::make_getter(&ContactData6D::v_partial_dq, bp::return_internal_reference<>()),
+      .add_property("v_partial_dq", bp::make_getter(&ContactData6D::v_partial_dq, bp::return_internal_reference<>()),
                     "Jacobian of the spatial body velocity")
-      .add_property("a_partial_dq",
-                    bp::make_getter(&ContactData6D::a_partial_dq, bp::return_internal_reference<>()),
+      .add_property("a_partial_dq", bp::make_getter(&ContactData6D::a_partial_dq, bp::return_internal_reference<>()),
                     "Jacobian of the spatial body acceleration")
-      .add_property("a_partial_dv",
-                    bp::make_getter(&ContactData6D::a_partial_dv, bp::return_internal_reference<>()),
+      .add_property("a_partial_dv", bp::make_getter(&ContactData6D::a_partial_dv, bp::return_internal_reference<>()),
                     "Jacobian of the spatial body acceleration")
-      .add_property("a_partial_da",
-                    bp::make_getter(&ContactData6D::a_partial_da, bp::return_internal_reference<>()),
+      .add_property("a_partial_da", bp::make_getter(&ContactData6D::a_partial_da, bp::return_internal_reference<>()),
                     "Jacobian of the spatial body acceleration");
 }
 

--- a/bindings/python/crocoddyl/multibody/contacts/contact-6d.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/contact-6d.cpp
@@ -77,16 +77,16 @@ void exposeContact6D() {
       .add_property("a", bp::make_getter(&ContactData6D::a, bp::return_value_policy<bp::return_by_value>()),
                     "spatial acceleration of the contact body")
       .add_property("v_partial_dq",
-                    bp::make_getter(&ContactData6D::v_partial_dq, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&ContactData6D::v_partial_dq, bp::return_internal_reference<>()),
                     "Jacobian of the spatial body velocity")
       .add_property("a_partial_dq",
-                    bp::make_getter(&ContactData6D::a_partial_dq, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&ContactData6D::a_partial_dq, bp::return_internal_reference<>()),
                     "Jacobian of the spatial body acceleration")
       .add_property("a_partial_dv",
-                    bp::make_getter(&ContactData6D::a_partial_dv, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&ContactData6D::a_partial_dv, bp::return_internal_reference<>()),
                     "Jacobian of the spatial body acceleration")
       .add_property("a_partial_da",
-                    bp::make_getter(&ContactData6D::a_partial_da, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&ContactData6D::a_partial_da, bp::return_internal_reference<>()),
                     "Jacobian of the spatial body acceleration");
 }
 

--- a/bindings/python/crocoddyl/multibody/contacts/multiple-contacts.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/multiple-contacts.cpp
@@ -108,8 +108,7 @@ void exposeContactMultiple() {
           ":param data: Pinocchio data")[bp::with_custodian_and_ward<1, 2, bp::with_custodian_and_ward<1, 3> >()])
       .add_property("dv", bp::make_getter(&ContactDataMultiple::dv, bp::return_internal_reference<>()),
                     bp::make_setter(&ContactDataMultiple::dv), "constrained acceleration in generalized coordinates")
-      .add_property("ddv_dx",
-                    bp::make_getter(&ContactDataMultiple::ddv_dx, bp::return_internal_reference<>()),
+      .add_property("ddv_dx", bp::make_getter(&ContactDataMultiple::ddv_dx, bp::return_internal_reference<>()),
                     bp::make_setter(&ContactDataMultiple::ddv_dx),
                     "Jacobian of the constrained acceleration in generalized coordinates")
       .add_property("contacts",

--- a/bindings/python/crocoddyl/multibody/contacts/multiple-contacts.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/multiple-contacts.cpp
@@ -106,10 +106,10 @@ void exposeContactMultiple() {
           "Create multicontact data.\n\n"
           ":param model: multicontact model\n"
           ":param data: Pinocchio data")[bp::with_custodian_and_ward<1, 2, bp::with_custodian_and_ward<1, 3> >()])
-      .add_property("dv", bp::make_getter(&ContactDataMultiple::dv, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("dv", bp::make_getter(&ContactDataMultiple::dv, bp::return_internal_reference<>()),
                     bp::make_setter(&ContactDataMultiple::dv), "constrained acceleration in generalized coordinates")
       .add_property("ddv_dx",
-                    bp::make_getter(&ContactDataMultiple::ddv_dx, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&ContactDataMultiple::ddv_dx, bp::return_internal_reference<>()),
                     bp::make_setter(&ContactDataMultiple::ddv_dx),
                     "Jacobian of the constrained acceleration in generalized coordinates")
       .add_property("contacts",

--- a/bindings/python/crocoddyl/multibody/cost-base.cpp
+++ b/bindings/python/crocoddyl/multibody/cost-base.cpp
@@ -89,21 +89,21 @@ void exposeCostAbstract() {
                     "terminal data")
       .add_property("cost", bp::make_getter(&CostDataAbstract::cost, bp::return_value_policy<bp::return_by_value>()),
                     bp::make_setter(&CostDataAbstract::cost), "cost value")
-      .add_property("Lx", bp::make_getter(&CostDataAbstract::Lx, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("Lx", bp::make_getter(&CostDataAbstract::Lx, bp::return_internal_reference<>()),
                     bp::make_setter(&CostDataAbstract::Lx), "Jacobian of the cost")
-      .add_property("Lu", bp::make_getter(&CostDataAbstract::Lu, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("Lu", bp::make_getter(&CostDataAbstract::Lu, bp::return_internal_reference<>()),
                     bp::make_setter(&CostDataAbstract::Lu), "Jacobian of the cost")
-      .add_property("Lxx", bp::make_getter(&CostDataAbstract::Lxx, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("Lxx", bp::make_getter(&CostDataAbstract::Lxx, bp::return_internal_reference<>()),
                     bp::make_setter(&CostDataAbstract::Lxx), "Hessian of the cost")
-      .add_property("Lxu", bp::make_getter(&CostDataAbstract::Lxu, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("Lxu", bp::make_getter(&CostDataAbstract::Lxu, bp::return_internal_reference<>()),
                     bp::make_setter(&CostDataAbstract::Lxu), "Hessian of the cost")
-      .add_property("Luu", bp::make_getter(&CostDataAbstract::Luu, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("Luu", bp::make_getter(&CostDataAbstract::Luu, bp::return_internal_reference<>()),
                     bp::make_setter(&CostDataAbstract::Luu), "Hessian of the cost")
-      .add_property("r", bp::make_getter(&CostDataAbstract::r, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("r", bp::make_getter(&CostDataAbstract::r, bp::return_internal_reference<>()),
                     bp::make_setter(&CostDataAbstract::r), "cost residual")
-      .add_property("Rx", bp::make_getter(&CostDataAbstract::Rx, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("Rx", bp::make_getter(&CostDataAbstract::Rx, bp::return_internal_reference<>()),
                     bp::make_setter(&CostDataAbstract::Rx), "Jacobian of the cost residual")
-      .add_property("Ru", bp::make_getter(&CostDataAbstract::Ru, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("Ru", bp::make_getter(&CostDataAbstract::Ru, bp::return_internal_reference<>()),
                     bp::make_setter(&CostDataAbstract::Ru), "Jacobian of the cost residual");
 }
 

--- a/bindings/python/crocoddyl/multibody/costs/centroidal-momentum.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/centroidal-momentum.cpp
@@ -84,11 +84,11 @@ void exposeCostCentroidalMomentum() {
           ":param data: shared data")[bp::with_custodian_and_ward<1, 2, bp::with_custodian_and_ward<1, 3> >()])
       .add_property(
           "dhd_dq",
-          bp::make_getter(&CostDataCentroidalMomentum::dhd_dq, bp::return_value_policy<bp::return_by_value>()),
+          bp::make_getter(&CostDataCentroidalMomentum::dhd_dq, bp::return_internal_reference<>()),
           "Jacobian of the centroidal momentum")
       .add_property(
           "dhd_dv",
-          bp::make_getter(&CostDataCentroidalMomentum::dhd_dv, bp::return_value_policy<bp::return_by_value>()),
+          bp::make_getter(&CostDataCentroidalMomentum::dhd_dv, bp::return_internal_reference<>()),
           "Jacobian of the centroidal momentum");
 }
 

--- a/bindings/python/crocoddyl/multibody/costs/centroidal-momentum.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/centroidal-momentum.cpp
@@ -82,14 +82,10 @@ void exposeCostCentroidalMomentum() {
           "Create centroidal momentum cost data.\n\n"
           ":param model: centroidal momentum cost model\n"
           ":param data: shared data")[bp::with_custodian_and_ward<1, 2, bp::with_custodian_and_ward<1, 3> >()])
-      .add_property(
-          "dhd_dq",
-          bp::make_getter(&CostDataCentroidalMomentum::dhd_dq, bp::return_internal_reference<>()),
-          "Jacobian of the centroidal momentum")
-      .add_property(
-          "dhd_dv",
-          bp::make_getter(&CostDataCentroidalMomentum::dhd_dv, bp::return_internal_reference<>()),
-          "Jacobian of the centroidal momentum");
+      .add_property("dhd_dq", bp::make_getter(&CostDataCentroidalMomentum::dhd_dq, bp::return_internal_reference<>()),
+                    "Jacobian of the centroidal momentum")
+      .add_property("dhd_dv", bp::make_getter(&CostDataCentroidalMomentum::dhd_dv, bp::return_internal_reference<>()),
+                    "Jacobian of the centroidal momentum");
 }
 
 }  // namespace python

--- a/bindings/python/crocoddyl/multibody/costs/com-position.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/com-position.cpp
@@ -68,8 +68,7 @@ void exposeCostCoMPosition() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
-      .add_property("cref",
-                    bp::make_function(&CostModelCoMPosition::get_cref, bp::return_internal_reference<>()),
+      .add_property("cref", bp::make_function(&CostModelCoMPosition::get_cref, bp::return_internal_reference<>()),
                     &CostModelCoMPosition::set_cref, "reference CoM position");
 }
 

--- a/bindings/python/crocoddyl/multibody/costs/com-position.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/com-position.cpp
@@ -69,7 +69,7 @@ void exposeCostCoMPosition() {
            ":param data: shared data\n"
            ":return cost data.")
       .add_property("cref",
-                    bp::make_function(&CostModelCoMPosition::get_cref, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_function(&CostModelCoMPosition::get_cref, bp::return_internal_reference<>()),
                     &CostModelCoMPosition::set_cref, "reference CoM position");
 }
 

--- a/bindings/python/crocoddyl/multibody/costs/contact-force.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/contact-force.cpp
@@ -79,8 +79,7 @@ void exposeCostContactForce() {
           "Create contact force cost data.\n\n"
           ":param model: contact force cost model\n"
           ":param data: shared data")[bp::with_custodian_and_ward<1, 2, bp::with_custodian_and_ward<1, 3> >()])
-      .add_property("Arr_Ru",
-                    bp::make_getter(&CostDataContactForce::Arr_Ru, bp::return_internal_reference<>()),
+      .add_property("Arr_Ru", bp::make_getter(&CostDataContactForce::Arr_Ru, bp::return_internal_reference<>()),
                     "Intermediate product of Arr (2nd deriv of Activation) with Ru (deriv of residue)")
       .add_property("contact",
                     bp::make_getter(&CostDataContactForce::contact, bp::return_value_policy<bp::return_by_value>()),

--- a/bindings/python/crocoddyl/multibody/costs/contact-force.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/contact-force.cpp
@@ -80,7 +80,7 @@ void exposeCostContactForce() {
           ":param model: contact force cost model\n"
           ":param data: shared data")[bp::with_custodian_and_ward<1, 2, bp::with_custodian_and_ward<1, 3> >()])
       .add_property("Arr_Ru",
-                    bp::make_getter(&CostDataContactForce::Arr_Ru, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&CostDataContactForce::Arr_Ru, bp::return_internal_reference<>()),
                     "Intermediate product of Arr (2nd deriv of Activation) with Ru (deriv of residue)")
       .add_property("contact",
                     bp::make_getter(&CostDataContactForce::contact, bp::return_value_policy<bp::return_by_value>()),

--- a/bindings/python/crocoddyl/multibody/costs/contact-friction-cone.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/contact-friction-cone.cpp
@@ -91,7 +91,7 @@ void exposeCostContactFrictionCone() {
           ":param data: shared data")[bp::with_custodian_and_ward<1, 2, bp::with_custodian_and_ward<1, 3> >()])
       .add_property(
           "Arr_Ru",
-          bp::make_getter(&CostDataContactFrictionCone::Arr_Ru, bp::return_value_policy<bp::return_by_value>()),
+          bp::make_getter(&CostDataContactFrictionCone::Arr_Ru, bp::return_internal_reference<>()),
           "Intermediate product of Arr (2nd deriv of Activation) with Ru (deriv of residue)")
       .add_property(
           "contact",

--- a/bindings/python/crocoddyl/multibody/costs/contact-friction-cone.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/contact-friction-cone.cpp
@@ -89,10 +89,8 @@ void exposeCostContactFrictionCone() {
           "Create contact force cost data.\n\n"
           ":param model: contact force cost model\n"
           ":param data: shared data")[bp::with_custodian_and_ward<1, 2, bp::with_custodian_and_ward<1, 3> >()])
-      .add_property(
-          "Arr_Ru",
-          bp::make_getter(&CostDataContactFrictionCone::Arr_Ru, bp::return_internal_reference<>()),
-          "Intermediate product of Arr (2nd deriv of Activation) with Ru (deriv of residue)")
+      .add_property("Arr_Ru", bp::make_getter(&CostDataContactFrictionCone::Arr_Ru, bp::return_internal_reference<>()),
+                    "Intermediate product of Arr (2nd deriv of Activation) with Ru (deriv of residue)")
       .add_property(
           "contact",
           bp::make_getter(&CostDataContactFrictionCone::contact, bp::return_value_policy<bp::return_by_value>()),

--- a/bindings/python/crocoddyl/multibody/costs/control.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/control.cpp
@@ -71,7 +71,7 @@ void exposeCostControl() {
       .def<void (CostModelControl::*)(const boost::shared_ptr<CostDataAbstract>&, const Eigen::VectorXd&)>(
           "calcDiff", &CostModelControl::calcDiff_wrap, bp::args("self", "data", "x"))
       .add_property("uref",
-                    bp::make_function(&CostModelControl::get_uref, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_function(&CostModelControl::get_uref, bp::return_internal_reference<>()),
                     &CostModelControl::set_uref, "reference control");
 }
 

--- a/bindings/python/crocoddyl/multibody/costs/control.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/control.cpp
@@ -70,8 +70,7 @@ void exposeCostControl() {
 
       .def<void (CostModelControl::*)(const boost::shared_ptr<CostDataAbstract>&, const Eigen::VectorXd&)>(
           "calcDiff", &CostModelControl::calcDiff_wrap, bp::args("self", "data", "x"))
-      .add_property("uref",
-                    bp::make_function(&CostModelControl::get_uref, bp::return_internal_reference<>()),
+      .add_property("uref", bp::make_function(&CostModelControl::get_uref, bp::return_internal_reference<>()),
                     &CostModelControl::set_uref, "reference control");
 }
 

--- a/bindings/python/crocoddyl/multibody/costs/frame-placement.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-placement.cpp
@@ -87,11 +87,9 @@ void exposeCostFramePlacement() {
                     "error frame placement of the frame")
       .add_property("J", bp::make_getter(&CostDataFramePlacement::J, bp::return_internal_reference<>()),
                     "Jacobian at the error point")
-      .add_property("rJf",
-                    bp::make_getter(&CostDataFramePlacement::rJf, bp::return_internal_reference<>()),
+      .add_property("rJf", bp::make_getter(&CostDataFramePlacement::rJf, bp::return_internal_reference<>()),
                     "error Jacobian of the frame")
-      .add_property("fJf",
-                    bp::make_getter(&CostDataFramePlacement::fJf, bp::return_internal_reference<>()),
+      .add_property("fJf", bp::make_getter(&CostDataFramePlacement::fJf, bp::return_internal_reference<>()),
                     "local Jacobian of the frame");
 }
 

--- a/bindings/python/crocoddyl/multibody/costs/frame-placement.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-placement.cpp
@@ -80,18 +80,18 @@ void exposeCostFramePlacement() {
           "Create frame placement cost data.\n\n"
           ":param model: frame placement cost model\n"
           ":param data: shared data")[bp::with_custodian_and_ward<1, 2, bp::with_custodian_and_ward<1, 3> >()])
-      .add_property("r", bp::make_getter(&CostDataFramePlacement::r, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("r", bp::make_getter(&CostDataFramePlacement::r, bp::return_internal_reference<>()),
                     "cost residual")
       .add_property("rMf",
                     bp::make_getter(&CostDataFramePlacement::rMf, bp::return_value_policy<bp::return_by_value>()),
                     "error frame placement of the frame")
-      .add_property("J", bp::make_getter(&CostDataFramePlacement::J, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("J", bp::make_getter(&CostDataFramePlacement::J, bp::return_internal_reference<>()),
                     "Jacobian at the error point")
       .add_property("rJf",
-                    bp::make_getter(&CostDataFramePlacement::rJf, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&CostDataFramePlacement::rJf, bp::return_internal_reference<>()),
                     "error Jacobian of the frame")
       .add_property("fJf",
-                    bp::make_getter(&CostDataFramePlacement::fJf, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&CostDataFramePlacement::fJf, bp::return_internal_reference<>()),
                     "local Jacobian of the frame");
 }
 

--- a/bindings/python/crocoddyl/multibody/costs/frame-rotation.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-rotation.cpp
@@ -81,16 +81,13 @@ void exposeCostFrameRotation() {
           ":param data: shared data")[bp::with_custodian_and_ward<1, 2, bp::with_custodian_and_ward<1, 3> >()])
       .add_property("r", bp::make_getter(&CostDataFrameRotation::r, bp::return_internal_reference<>()),
                     "cost residual")
-      .add_property("rRf",
-                    bp::make_getter(&CostDataFrameRotation::rRf, bp::return_internal_reference<>()),
+      .add_property("rRf", bp::make_getter(&CostDataFrameRotation::rRf, bp::return_internal_reference<>()),
                     "rotation error of the frame")
       .add_property("J", bp::make_getter(&CostDataFrameRotation::J, bp::return_internal_reference<>()),
                     "Jacobian at the error point")
-      .add_property("rJf",
-                    bp::make_getter(&CostDataFrameRotation::rJf, bp::return_internal_reference<>()),
+      .add_property("rJf", bp::make_getter(&CostDataFrameRotation::rJf, bp::return_internal_reference<>()),
                     "error Jacobian of the frame")
-      .add_property("fJf",
-                    bp::make_getter(&CostDataFrameRotation::fJf, bp::return_internal_reference<>()),
+      .add_property("fJf", bp::make_getter(&CostDataFrameRotation::fJf, bp::return_internal_reference<>()),
                     "local Jacobian of the frame");
 }
 

--- a/bindings/python/crocoddyl/multibody/costs/frame-rotation.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-rotation.cpp
@@ -79,18 +79,18 @@ void exposeCostFrameRotation() {
           "Create frame rotation cost data.\n\n"
           ":param model: frame rotation cost model\n"
           ":param data: shared data")[bp::with_custodian_and_ward<1, 2, bp::with_custodian_and_ward<1, 3> >()])
-      .add_property("r", bp::make_getter(&CostDataFrameRotation::r, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("r", bp::make_getter(&CostDataFrameRotation::r, bp::return_internal_reference<>()),
                     "cost residual")
       .add_property("rRf",
-                    bp::make_getter(&CostDataFrameRotation::rRf, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&CostDataFrameRotation::rRf, bp::return_internal_reference<>()),
                     "rotation error of the frame")
-      .add_property("J", bp::make_getter(&CostDataFrameRotation::J, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("J", bp::make_getter(&CostDataFrameRotation::J, bp::return_internal_reference<>()),
                     "Jacobian at the error point")
       .add_property("rJf",
-                    bp::make_getter(&CostDataFrameRotation::rJf, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&CostDataFrameRotation::rJf, bp::return_internal_reference<>()),
                     "error Jacobian of the frame")
       .add_property("fJf",
-                    bp::make_getter(&CostDataFrameRotation::fJf, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&CostDataFrameRotation::fJf, bp::return_internal_reference<>()),
                     "local Jacobian of the frame");
 }
 

--- a/bindings/python/crocoddyl/multibody/costs/frame-translation.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-translation.cpp
@@ -81,8 +81,7 @@ void exposeCostFrameTranslation() {
           ":param data: shared data")[bp::with_custodian_and_ward<1, 2, bp::with_custodian_and_ward<1, 3> >()])
       .add_property("J", bp::make_getter(&CostDataFrameTranslation::J, bp::return_internal_reference<>()),
                     "Jacobian at the error point")
-      .add_property("fJf",
-                    bp::make_getter(&CostDataFrameTranslation::fJf, bp::return_internal_reference<>()),
+      .add_property("fJf", bp::make_getter(&CostDataFrameTranslation::fJf, bp::return_internal_reference<>()),
                     "local Jacobian of the frame");
 }
 

--- a/bindings/python/crocoddyl/multibody/costs/frame-translation.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-translation.cpp
@@ -79,10 +79,10 @@ void exposeCostFrameTranslation() {
           "Create frame translation cost data.\n\n"
           ":param model: frame translation cost model\n"
           ":param data: shared data")[bp::with_custodian_and_ward<1, 2, bp::with_custodian_and_ward<1, 3> >()])
-      .add_property("J", bp::make_getter(&CostDataFrameTranslation::J, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("J", bp::make_getter(&CostDataFrameTranslation::J, bp::return_internal_reference<>()),
                     "Jacobian at the error point")
       .add_property("fJf",
-                    bp::make_getter(&CostDataFrameTranslation::fJf, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&CostDataFrameTranslation::fJf, bp::return_internal_reference<>()),
                     "local Jacobian of the frame");
 }
 

--- a/bindings/python/crocoddyl/multibody/costs/frame-velocity.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-velocity.cpp
@@ -85,11 +85,9 @@ void exposeCostFrameVelocity() {
       .add_property("fXj",
                     bp::make_getter(&CostDataFrameVelocity::fXj, bp::return_value_policy<bp::return_by_value>()),
                     "action matrix from contact to local frames")
-      .add_property("dv_dq",
-                    bp::make_getter(&CostDataFrameVelocity::dv_dq, bp::return_internal_reference<>()),
+      .add_property("dv_dq", bp::make_getter(&CostDataFrameVelocity::dv_dq, bp::return_internal_reference<>()),
                     "Jacobian of the spatial body velocity")
-      .add_property("dv_dv",
-                    bp::make_getter(&CostDataFrameVelocity::dv_dv, bp::return_internal_reference<>()),
+      .add_property("dv_dv", bp::make_getter(&CostDataFrameVelocity::dv_dv, bp::return_internal_reference<>()),
                     "Jacobian of the spatial body velocity");
 }
 

--- a/bindings/python/crocoddyl/multibody/costs/frame-velocity.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-velocity.cpp
@@ -86,10 +86,10 @@ void exposeCostFrameVelocity() {
                     bp::make_getter(&CostDataFrameVelocity::fXj, bp::return_value_policy<bp::return_by_value>()),
                     "action matrix from contact to local frames")
       .add_property("dv_dq",
-                    bp::make_getter(&CostDataFrameVelocity::dv_dq, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&CostDataFrameVelocity::dv_dq, bp::return_internal_reference<>()),
                     "Jacobian of the spatial body velocity")
       .add_property("dv_dv",
-                    bp::make_getter(&CostDataFrameVelocity::dv_dv, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&CostDataFrameVelocity::dv_dv, bp::return_internal_reference<>()),
                     "Jacobian of the spatial body velocity");
 }
 

--- a/bindings/python/crocoddyl/multibody/costs/impulse-com.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/impulse-com.cpp
@@ -59,14 +59,11 @@ void exposeCostImpulseCoM() {
       .add_property("impulses",
                     bp::make_getter(&CostDataImpulseCoM::impulses, bp::return_value_policy<bp::return_by_value>()),
                     bp::make_setter(&CostDataImpulseCoM::impulses), "impulses data associated with the current cost")
-      .add_property("Arr_Rx",
-                    bp::make_getter(&CostDataImpulseCoM::Arr_Rx, bp::return_internal_reference<>()),
+      .add_property("Arr_Rx", bp::make_getter(&CostDataImpulseCoM::Arr_Rx, bp::return_internal_reference<>()),
                     "Intermediate product of Arr (2nd deriv of Activation) with Rx (deriv of residue)")
-      .add_property("dvc_dq",
-                    bp::make_getter(&CostDataImpulseCoM::dvc_dq, bp::return_internal_reference<>()),
+      .add_property("dvc_dq", bp::make_getter(&CostDataImpulseCoM::dvc_dq, bp::return_internal_reference<>()),
                     "Jacobian of the CoM velocity")
-      .add_property("ddv_dv",
-                    bp::make_getter(&CostDataImpulseCoM::ddv_dv, bp::return_internal_reference<>()),
+      .add_property("ddv_dv", bp::make_getter(&CostDataImpulseCoM::ddv_dv, bp::return_internal_reference<>()),
                     "Jacobian of the impulse velocity")
       .add_property("pinocchio_internal",
                     bp::make_getter(&CostDataImpulseCoM::pinocchio_internal, bp::return_internal_reference<>()),

--- a/bindings/python/crocoddyl/multibody/costs/impulse-com.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/impulse-com.cpp
@@ -60,13 +60,13 @@ void exposeCostImpulseCoM() {
                     bp::make_getter(&CostDataImpulseCoM::impulses, bp::return_value_policy<bp::return_by_value>()),
                     bp::make_setter(&CostDataImpulseCoM::impulses), "impulses data associated with the current cost")
       .add_property("Arr_Rx",
-                    bp::make_getter(&CostDataImpulseCoM::Arr_Rx, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&CostDataImpulseCoM::Arr_Rx, bp::return_internal_reference<>()),
                     "Intermediate product of Arr (2nd deriv of Activation) with Rx (deriv of residue)")
       .add_property("dvc_dq",
-                    bp::make_getter(&CostDataImpulseCoM::dvc_dq, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&CostDataImpulseCoM::dvc_dq, bp::return_internal_reference<>()),
                     "Jacobian of the CoM velocity")
       .add_property("ddv_dv",
-                    bp::make_getter(&CostDataImpulseCoM::ddv_dv, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&CostDataImpulseCoM::ddv_dv, bp::return_internal_reference<>()),
                     "Jacobian of the impulse velocity")
       .add_property("pinocchio_internal",
                     bp::make_getter(&CostDataImpulseCoM::pinocchio_internal, bp::return_internal_reference<>()),

--- a/bindings/python/crocoddyl/multibody/costs/state.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/state.cpp
@@ -85,8 +85,7 @@ void exposeCostState() {
                                                              ":param u: time-discrete control input\n")
       .def<void (CostModelState::*)(const boost::shared_ptr<CostDataAbstract>&, const Eigen::VectorXd&)>(
           "calcDiff", &CostModelState::calcDiff_wrap, bp::args("self", "data", "x"))
-      .add_property("xref",
-                    bp::make_function(&CostModelState::get_xref, bp::return_internal_reference<>()),
+      .add_property("xref", bp::make_function(&CostModelState::get_xref, bp::return_internal_reference<>()),
                     "reference state")
       .def("createData", &CostModelState::createData, bp::with_custodian_and_ward_postcall<0, 2>(),
            bp::args("self", "data"),

--- a/bindings/python/crocoddyl/multibody/costs/state.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/state.cpp
@@ -86,7 +86,7 @@ void exposeCostState() {
       .def<void (CostModelState::*)(const boost::shared_ptr<CostDataAbstract>&, const Eigen::VectorXd&)>(
           "calcDiff", &CostModelState::calcDiff_wrap, bp::args("self", "data", "x"))
       .add_property("xref",
-                    bp::make_function(&CostModelState::get_xref, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_function(&CostModelState::get_xref, bp::return_internal_reference<>()),
                     "reference state")
       .def("createData", &CostModelState::createData, bp::with_custodian_and_ward_postcall<0, 2>(),
            bp::args("self", "data"),

--- a/bindings/python/crocoddyl/multibody/frames.cpp
+++ b/bindings/python/crocoddyl/multibody/frames.cpp
@@ -23,7 +23,7 @@ void exposeFrames() {
                                             ":param frame: frame ID\n"
                                             ":param oxf: Frame translation w.r.t. the origin"))
       .def_readwrite("frame", &FrameTranslation::frame, "frame ID")
-      .add_property("oxf", bp::make_getter(&FrameTranslation::oxf, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("oxf", bp::make_getter(&FrameTranslation::oxf, bp::return_internal_reference<>()),
                     bp::make_setter(&FrameTranslation::oxf), "frame translation")
       .def(PrintableVisitor<FrameTranslation>());
 
@@ -36,7 +36,7 @@ void exposeFrames() {
                                             ":param frame: frame ID\n"
                                             ":param oRf: Frame rotation w.r.t. the origin"))
       .def_readwrite("frame", &FrameRotation::frame, "frame ID")
-      .add_property("oRf", bp::make_getter(&FrameRotation::oRf, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("oRf", bp::make_getter(&FrameRotation::oRf, bp::return_internal_reference<>()),
                     bp::make_setter(&FrameRotation::oRf), "frame rotation")
       .def(PrintableVisitor<FrameRotation>());
 

--- a/bindings/python/crocoddyl/multibody/friction-cone.cpp
+++ b/bindings/python/crocoddyl/multibody/friction-cone.cpp
@@ -37,8 +37,7 @@ void exposeFrictionCone() {
                     "inequality lower bound")
       .add_property("ub", bp::make_function(&FrictionCone::get_ub, bp::return_internal_reference<>()),
                     "inequality upper bound")
-      .add_property("nsurf",
-                    bp::make_function(&FrictionCone::get_nsurf, bp::return_internal_reference<>()),
+      .add_property("nsurf", bp::make_function(&FrictionCone::get_nsurf, bp::return_internal_reference<>()),
                     "normal vector")
       .add_property("mu", bp::make_function(&FrictionCone::get_mu, bp::return_value_policy<bp::return_by_value>()),
                     "friction coefficient")

--- a/bindings/python/crocoddyl/multibody/friction-cone.cpp
+++ b/bindings/python/crocoddyl/multibody/friction-cone.cpp
@@ -31,14 +31,14 @@ void exposeFrictionCone() {
            ":param inner_appr: inner or outer approximation (default True)\n"
            ":param min_nforce: minimum normal force (default 0.)\n"
            ":param max_nforce: maximum normal force (default sys.float_info.max)")
-      .add_property("A", bp::make_function(&FrictionCone::get_A, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("A", bp::make_function(&FrictionCone::get_A, bp::return_internal_reference<>()),
                     "inequality matrix")
-      .add_property("lb", bp::make_function(&FrictionCone::get_lb, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("lb", bp::make_function(&FrictionCone::get_lb, bp::return_internal_reference<>()),
                     "inequality lower bound")
-      .add_property("ub", bp::make_function(&FrictionCone::get_ub, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("ub", bp::make_function(&FrictionCone::get_ub, bp::return_internal_reference<>()),
                     "inequality upper bound")
       .add_property("nsurf",
-                    bp::make_function(&FrictionCone::get_nsurf, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_function(&FrictionCone::get_nsurf, bp::return_internal_reference<>()),
                     "normal vector")
       .add_property("mu", bp::make_function(&FrictionCone::get_mu, bp::return_value_policy<bp::return_by_value>()),
                     "friction coefficient")

--- a/bindings/python/crocoddyl/multibody/impulse-base.cpp
+++ b/bindings/python/crocoddyl/multibody/impulse-base.cpp
@@ -68,10 +68,10 @@ void exposeImpulseAbstract() {
           ":param data: Pinocchio data")[bp::with_custodian_and_ward<1, 3>()])
       .add_property("pinocchio", bp::make_getter(&ImpulseDataAbstract::pinocchio, bp::return_internal_reference<>()),
                     "pinocchio data")
-      .add_property("Jc", bp::make_getter(&ImpulseDataAbstract::Jc, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("Jc", bp::make_getter(&ImpulseDataAbstract::Jc, bp::return_internal_reference<>()),
                     bp::make_setter(&ImpulseDataAbstract::Jc), "impulse Jacobian")
       .add_property("dv0_dq",
-                    bp::make_getter(&ImpulseDataAbstract::dv0_dq, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&ImpulseDataAbstract::dv0_dq, bp::return_internal_reference<>()),
                     bp::make_setter(&ImpulseDataAbstract::dv0_dq), "Jacobian of the previous impulse velocity")
       .def_readwrite("joint", &ImpulseDataAbstract::joint, "joint index of the impulse frame")
       .def_readwrite("frame", &ImpulseDataAbstract::frame, "frame index of the impulse frame")

--- a/bindings/python/crocoddyl/multibody/impulse-base.cpp
+++ b/bindings/python/crocoddyl/multibody/impulse-base.cpp
@@ -70,8 +70,7 @@ void exposeImpulseAbstract() {
                     "pinocchio data")
       .add_property("Jc", bp::make_getter(&ImpulseDataAbstract::Jc, bp::return_internal_reference<>()),
                     bp::make_setter(&ImpulseDataAbstract::Jc), "impulse Jacobian")
-      .add_property("dv0_dq",
-                    bp::make_getter(&ImpulseDataAbstract::dv0_dq, bp::return_internal_reference<>()),
+      .add_property("dv0_dq", bp::make_getter(&ImpulseDataAbstract::dv0_dq, bp::return_internal_reference<>()),
                     bp::make_setter(&ImpulseDataAbstract::dv0_dq), "Jacobian of the previous impulse velocity")
       .def_readwrite("joint", &ImpulseDataAbstract::joint, "joint index of the impulse frame")
       .def_readwrite("frame", &ImpulseDataAbstract::frame, "frame index of the impulse frame")

--- a/bindings/python/crocoddyl/multibody/impulses/impulse-3d.cpp
+++ b/bindings/python/crocoddyl/multibody/impulses/impulse-3d.cpp
@@ -65,11 +65,9 @@ void exposeImpulse3D() {
                     "action matrix from impulse to local frames")
       .add_property("fJf", bp::make_getter(&ImpulseData3D::fJf, bp::return_internal_reference<>()),
                     "local Jacobian of the impulse frame")
-      .add_property("v_partial_dq",
-                    bp::make_getter(&ImpulseData3D::v_partial_dq, bp::return_internal_reference<>()),
+      .add_property("v_partial_dq", bp::make_getter(&ImpulseData3D::v_partial_dq, bp::return_internal_reference<>()),
                     "Jacobian of the spatial body velocity")
-      .add_property("v_partial_dv",
-                    bp::make_getter(&ImpulseData3D::v_partial_dv, bp::return_internal_reference<>()),
+      .add_property("v_partial_dv", bp::make_getter(&ImpulseData3D::v_partial_dv, bp::return_internal_reference<>()),
                     "Jacobian of the spatial body velocity");
 }
 

--- a/bindings/python/crocoddyl/multibody/impulses/impulse-3d.cpp
+++ b/bindings/python/crocoddyl/multibody/impulses/impulse-3d.cpp
@@ -63,13 +63,13 @@ void exposeImpulse3D() {
                     "local frame placement of the impulse frame")
       .add_property("fXj", bp::make_getter(&ImpulseData3D::fXj, bp::return_value_policy<bp::return_by_value>()),
                     "action matrix from impulse to local frames")
-      .add_property("fJf", bp::make_getter(&ImpulseData3D::fJf, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("fJf", bp::make_getter(&ImpulseData3D::fJf, bp::return_internal_reference<>()),
                     "local Jacobian of the impulse frame")
       .add_property("v_partial_dq",
-                    bp::make_getter(&ImpulseData3D::v_partial_dq, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&ImpulseData3D::v_partial_dq, bp::return_internal_reference<>()),
                     "Jacobian of the spatial body velocity")
       .add_property("v_partial_dv",
-                    bp::make_getter(&ImpulseData3D::v_partial_dv, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&ImpulseData3D::v_partial_dv, bp::return_internal_reference<>()),
                     "Jacobian of the spatial body velocity");
 }
 

--- a/bindings/python/crocoddyl/multibody/impulses/impulse-6d.cpp
+++ b/bindings/python/crocoddyl/multibody/impulses/impulse-6d.cpp
@@ -63,13 +63,13 @@ void exposeImpulse6D() {
                     "local frame placement of the impulse frame")
       .add_property("fXj", bp::make_getter(&ImpulseData6D::fXj, bp::return_value_policy<bp::return_by_value>()),
                     "action matrix from impulse to local frames")
-      .add_property("fJf", bp::make_getter(&ImpulseData6D::fJf, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("fJf", bp::make_getter(&ImpulseData6D::fJf, bp::return_internal_reference<>()),
                     "local Jacobian of the impulse frame")
       .add_property("v_partial_dq",
-                    bp::make_getter(&ImpulseData6D::v_partial_dq, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&ImpulseData6D::v_partial_dq, bp::return_internal_reference<>()),
                     "Jacobian of the spatial body velocity")
       .add_property("v_partial_dv",
-                    bp::make_getter(&ImpulseData6D::v_partial_dv, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&ImpulseData6D::v_partial_dv, bp::return_internal_reference<>()),
                     "Jacobian of the spatial body velocity");
 }
 

--- a/bindings/python/crocoddyl/multibody/impulses/impulse-6d.cpp
+++ b/bindings/python/crocoddyl/multibody/impulses/impulse-6d.cpp
@@ -65,11 +65,9 @@ void exposeImpulse6D() {
                     "action matrix from impulse to local frames")
       .add_property("fJf", bp::make_getter(&ImpulseData6D::fJf, bp::return_internal_reference<>()),
                     "local Jacobian of the impulse frame")
-      .add_property("v_partial_dq",
-                    bp::make_getter(&ImpulseData6D::v_partial_dq, bp::return_internal_reference<>()),
+      .add_property("v_partial_dq", bp::make_getter(&ImpulseData6D::v_partial_dq, bp::return_internal_reference<>()),
                     "Jacobian of the spatial body velocity")
-      .add_property("v_partial_dv",
-                    bp::make_getter(&ImpulseData6D::v_partial_dv, bp::return_internal_reference<>()),
+      .add_property("v_partial_dv", bp::make_getter(&ImpulseData6D::v_partial_dv, bp::return_internal_reference<>()),
                     "Jacobian of the spatial body velocity");
 }
 

--- a/bindings/python/crocoddyl/multibody/impulses/multiple-impulses.cpp
+++ b/bindings/python/crocoddyl/multibody/impulses/multiple-impulses.cpp
@@ -107,10 +107,10 @@ void exposeImpulseMultiple() {
           ":param model: multiimpulse model\n"
           ":param data: Pinocchio data")[bp::with_custodian_and_ward<1, 2, bp::with_custodian_and_ward<1, 3> >()])
       .add_property("vnext",
-                    bp::make_getter(&ImpulseDataMultiple::vnext, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&ImpulseDataMultiple::vnext, bp::return_internal_reference<>()),
                     bp::make_setter(&ImpulseDataMultiple::vnext), "impulse velocity")
       .add_property("dvnext_dx",
-                    bp::make_getter(&ImpulseDataMultiple::dvnext_dx, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&ImpulseDataMultiple::dvnext_dx, bp::return_internal_reference<>()),
                     bp::make_setter(&ImpulseDataMultiple::dvnext_dx), "Jacobian of the impulse velocity")
       .add_property("impulses",
                     bp::make_getter(&ImpulseDataMultiple::impulses, bp::return_value_policy<bp::return_by_value>()),

--- a/bindings/python/crocoddyl/multibody/impulses/multiple-impulses.cpp
+++ b/bindings/python/crocoddyl/multibody/impulses/multiple-impulses.cpp
@@ -106,11 +106,9 @@ void exposeImpulseMultiple() {
           "Create multiimpulse data.\n\n"
           ":param model: multiimpulse model\n"
           ":param data: Pinocchio data")[bp::with_custodian_and_ward<1, 2, bp::with_custodian_and_ward<1, 3> >()])
-      .add_property("vnext",
-                    bp::make_getter(&ImpulseDataMultiple::vnext, bp::return_internal_reference<>()),
+      .add_property("vnext", bp::make_getter(&ImpulseDataMultiple::vnext, bp::return_internal_reference<>()),
                     bp::make_setter(&ImpulseDataMultiple::vnext), "impulse velocity")
-      .add_property("dvnext_dx",
-                    bp::make_getter(&ImpulseDataMultiple::dvnext_dx, bp::return_internal_reference<>()),
+      .add_property("dvnext_dx", bp::make_getter(&ImpulseDataMultiple::dvnext_dx, bp::return_internal_reference<>()),
                     bp::make_setter(&ImpulseDataMultiple::dvnext_dx), "Jacobian of the impulse velocity")
       .add_property("impulses",
                     bp::make_getter(&ImpulseDataMultiple::impulses, bp::return_value_policy<bp::return_by_value>()),


### PR DESCRIPTION
This PR tackles the issue #184 which was first solved in https://github.com/stack-of-tasks/eigenpy/pull/160.

Concretely, it allows the Python users to write values in internal segments of NumPy data. For instance, it is possible to do the follows:
```python
class MyDerivatedModel(crocoddyl.ActionModelAbstract):
    def __init__(self):
        nx, nu, nr = 3, 2, 5
        crocoddyl.ActionModelAbstract.__init__(self, crocoddyl.StateVector(nx), nu, nr)
        self.dt = .1
        self.costWeights = [10., 1.]

    def calc(self, data, x, u):
        # it allows to do this for data.r (and all data members of course):
        data.r[:3] = self.costWeights[0] * x 
        data.r[3:] = self.costWeights[1] * u
        # instead of being constraint to do the follows
        # data.r = np.vstack([self.costWeights[0] * x, self.costWeights[1] * u])
```


On the other hand, there are plenty of getter functions that return `const ref`. For those functions, this PR proposes to return the `const ref` for efficiency reason. Nnote that you can't write internally as it is `const ref`.