### PR TITLE
Included status information of contacts / impulses (active / inactive)

### DIFF
--- a/bindings/python/crocoddyl/multibody/contacts/multiple-contacts.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/multiple-contacts.cpp
@@ -18,6 +18,8 @@
 namespace crocoddyl {
 namespace python {
 
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(ContactModelMultiple_addContact_wrap, ContactModelMultiple::addContact, 2, 3)
+
 void exposeContactMultiple() {
   // Register custom converters between std::map and Python dict
   typedef boost::shared_ptr<ContactItem> ContactItemPtr;
@@ -35,13 +37,16 @@ void exposeContactMultiple() {
 
   bp::class_<ContactItem, boost::noncopyable>(
       "ContactItem", "Describe a contact item.\n\n",
-      bp::init<std::string, boost::shared_ptr<ContactModelAbstract> >(bp::args("self", "name", " contact"),
-                                                                      "Initialize the contact item.\n\n"
-                                                                      ":param name: contact name\n"
-                                                                      ":param contact: contact model"))
+      bp::init<std::string, boost::shared_ptr<ContactModelAbstract>, bp::optional<bool> >(
+          bp::args("self", "name", "contact", "active"),
+          "Initialize the contact item.\n\n"
+          ":param name: contact name\n"
+          ":param contact: contact model\n"
+          ":param active: True if the contact is activated (default true)"))
       .def_readwrite("name", &ContactItem::name, "contact name")
       .add_property("contact", bp::make_getter(&ContactItem::contact, bp::return_value_policy<bp::return_by_value>()),
-                    "contact model");
+                    "contact model")
+      .def_readwrite("active", &ContactItem::active, "contact status");
 
   bp::register_ptr_to_python<boost::shared_ptr<ContactModelMultiple> >();
 
@@ -51,10 +56,12 @@ void exposeContactMultiple() {
                                                                       "Initialize the multiple contact model.\n\n"
                                                                       ":param state: state of the multibody system\n"
                                                                       ":param nu: dimension of control vector"))
-      .def("addContact", &ContactModelMultiple::addContact, bp::args("self", "name", " contact"),
-           "Add a contact item.\n\n"
-           ":param name: contact name\n"
-           ":param contact: contact model")
+      .def("addContact", &ContactModelMultiple::addContact,
+           ContactModelMultiple_addContact_wrap(bp::args("self", "name", "contact", "active"),
+                                                "Add a contact item.\n\n"
+                                                ":param name: contact name\n"
+                                                ":param contact: contact model\n"
+                                                ":param active: True if the contact is activated (default true)"))
       .def("removeContact", &ContactModelMultiple::removeContact, bp::args("self", "name"),
            "Remove a contact item.\n\n"
            ":param name: contact name")

--- a/bindings/python/crocoddyl/multibody/contacts/multiple-contacts.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/multiple-contacts.cpp
@@ -65,6 +65,10 @@ void exposeContactMultiple() {
       .def("removeContact", &ContactModelMultiple::removeContact, bp::args("self", "name"),
            "Remove a contact item.\n\n"
            ":param name: contact name")
+      .def("changeContactStatus", &ContactModelMultiple::changeContactStatus, bp::args("self", "name", "active"),
+           "Change the contact status.\n\n"
+           ":param name: contact name\n"
+           ":param active: contact status (true for active and false for inactive)")
       .def("calc", &ContactModelMultiple::calc_wrap, bp::args("self", "data", "x"),
            "Compute the total contact Jacobian and drift.\n\n"
            "The rigid contact model throught acceleration-base holonomic constraint\n"

--- a/bindings/python/crocoddyl/multibody/impulses/multiple-impulses.cpp
+++ b/bindings/python/crocoddyl/multibody/impulses/multiple-impulses.cpp
@@ -18,6 +18,8 @@
 namespace crocoddyl {
 namespace python {
 
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(ImpulseModelMultiple_addImpulse_wrap, ImpulseModelMultiple::addImpulse, 2, 3)
+
 void exposeImpulseMultiple() {
   // Register custom converters between std::map and Python dict
   typedef boost::shared_ptr<ImpulseItem> ImpulseItemPtr;
@@ -35,13 +37,17 @@ void exposeImpulseMultiple() {
 
   bp::class_<ImpulseItem, boost::noncopyable>(
       "ImpulseItem", "Describe a impulse item.\n\n",
-      bp::init<std::string, boost::shared_ptr<ImpulseModelAbstract> >(bp::args("self", "name", "impulse"),
-                                                                      "Initialize the impulse item.\n\n"
-                                                                      ":param name: impulse name\n"
-                                                                      ":param impulse: impulse model"))
+      bp::init<std::string, boost::shared_ptr<ImpulseModelAbstract>, bp::optional<bool> >(
+          bp::args("self", "name", "impulse", "active"),
+          "Initialize the impulse item.\n\n"
+          ":param name: impulse name\n"
+          ":param impulse: impulse model\n"
+          ":param active: True if the impulse is activated (default true)"))
       .def_readwrite("name", &ImpulseItem::name, "impulse name")
       .add_property("impulse", bp::make_getter(&ImpulseItem::impulse, bp::return_value_policy<bp::return_by_value>()),
-                    "impulse model");
+                    "impulse model")
+      .def_readwrite("active", &ImpulseItem::active, "impulse status");
+  ;
 
   bp::register_ptr_to_python<boost::shared_ptr<ImpulseModelMultiple> >();
 
@@ -50,12 +56,14 @@ void exposeImpulseMultiple() {
       bp::init<boost::shared_ptr<StateMultibody> >(bp::args("self", "state"),
                                                    "Initialize the multiple impulse model.\n\n"
                                                    ":param state: state of the multibody system"))
-      .def("addImpulse", &ImpulseModelMultiple::addImpulse, bp::args("self", "name", "impulse"),
-           "Add a impulse item.\n\n"
-           ":param name: impulse name\n"
-           ":param impulse: impulse model")
+      .def("addImpulse", &ImpulseModelMultiple::addImpulse,
+           ImpulseModelMultiple_addImpulse_wrap(bp::args("self", "name", "impulse", "active"),
+                                                "Add an impulse item.\n\n"
+                                                ":param name: impulse name\n"
+                                                ":param impulse: impulse model\n"
+                                                ":param active: True if the impulse is activated (default true)"))
       .def("removeImpulse", &ImpulseModelMultiple::removeImpulse, bp::args("self", "name"),
-           "Remove a impulse item.\n\n"
+           "Remove an impulse item.\n\n"
            ":param name: impulse name")
       .def("calc", &ImpulseModelMultiple::calc_wrap, bp::args("self", "data", "x"),
            "Compute the total impulse Jacobian and drift.\n\n"

--- a/bindings/python/crocoddyl/multibody/impulses/multiple-impulses.cpp
+++ b/bindings/python/crocoddyl/multibody/impulses/multiple-impulses.cpp
@@ -65,6 +65,10 @@ void exposeImpulseMultiple() {
       .def("removeImpulse", &ImpulseModelMultiple::removeImpulse, bp::args("self", "name"),
            "Remove an impulse item.\n\n"
            ":param name: impulse name")
+      .def("changeImpulseStatus", &ImpulseModelMultiple::changeImpulseStatus, bp::args("self", "name", "active"),
+           "Change the impulse status.\n\n"
+           ":param name: impulse name\n"
+           ":param active: impulse status (true for active and false for inactive)")
       .def("calc", &ImpulseModelMultiple::calc_wrap, bp::args("self", "data", "x"),
            "Compute the total impulse Jacobian and drift.\n\n"
            "The rigid impulse model throught acceleration-base holonomic constraint\n"

--- a/include/crocoddyl/multibody/contacts/multiple-contacts.hpp
+++ b/include/crocoddyl/multibody/contacts/multiple-contacts.hpp
@@ -25,11 +25,13 @@ struct ContactItemTpl {
 
   typedef _Scalar Scalar;
   ContactItemTpl() {}
-  ContactItemTpl(const std::string& name, boost::shared_ptr<ContactModelAbstractTpl<Scalar> > contact)
-      : name(name), contact(contact) {}
+  ContactItemTpl(const std::string& name, boost::shared_ptr<ContactModelAbstractTpl<Scalar> > contact,
+                 bool active = true)
+      : name(name), contact(contact), active(active) {}
 
   std::string name;
   boost::shared_ptr<ContactModelAbstractTpl<Scalar> > contact;
+  bool active;
 };
 
 template <typename _Scalar>
@@ -59,7 +61,7 @@ class ContactModelMultipleTpl {
   ContactModelMultipleTpl(boost::shared_ptr<StateMultibody> state);
   ~ContactModelMultipleTpl();
 
-  void addContact(const std::string& name, boost::shared_ptr<ContactModelAbstract> contact);
+  void addContact(const std::string& name, boost::shared_ptr<ContactModelAbstract> contact, bool active = true);
   void removeContact(const std::string& name);
 
   void calc(const boost::shared_ptr<ContactDataMultiple>& data, const Eigen::Ref<const VectorXs>& x);

--- a/include/crocoddyl/multibody/contacts/multiple-contacts.hpp
+++ b/include/crocoddyl/multibody/contacts/multiple-contacts.hpp
@@ -63,6 +63,7 @@ class ContactModelMultipleTpl {
 
   void addContact(const std::string& name, boost::shared_ptr<ContactModelAbstract> contact, bool active = true);
   void removeContact(const std::string& name);
+  void changeContactStatus(const std::string& name, bool active);
 
   void calc(const boost::shared_ptr<ContactDataMultiple>& data, const Eigen::Ref<const VectorXs>& x);
   void calcDiff(const boost::shared_ptr<ContactDataMultiple>& data, const Eigen::Ref<const VectorXs>& x);

--- a/include/crocoddyl/multibody/contacts/multiple-contacts.hxx
+++ b/include/crocoddyl/multibody/contacts/multiple-contacts.hxx
@@ -48,6 +48,21 @@ void ContactModelMultipleTpl<Scalar>::removeContact(const std::string& name) {
 }
 
 template <typename Scalar>
+void ContactModelMultipleTpl<Scalar>::changeContactStatus(const std::string& name, bool active) {
+  typename ContactModelContainer::iterator it = contacts_.find(name);
+  if (it != contacts_.end()) {
+    if (active && !it->second->active) {
+      nc_ += it->second->contact->get_nc();
+    } else if (!active && it->second->active) {
+      nc_ -= it->second->contact->get_nc();
+    }
+    it->second->active = active;
+  } else {
+    std::cout << "Warning: this contact item doesn't exist, we cannot change its status" << std::endl;
+  }
+}
+
+template <typename Scalar>
 void ContactModelMultipleTpl<Scalar>::calc(const boost::shared_ptr<ContactDataMultiple>& data,
                                            const Eigen::Ref<const VectorXs>& x) {
   if (data->contacts.size() != contacts_.size()) {

--- a/include/crocoddyl/multibody/contacts/multiple-contacts.hxx
+++ b/include/crocoddyl/multibody/contacts/multiple-contacts.hxx
@@ -41,7 +41,7 @@ void ContactModelMultipleTpl<Scalar>::removeContact(const std::string& name) {
   typename ContactModelContainer::iterator it = contacts_.find(name);
   if (it != contacts_.end()) {
     nc_ -= it->second->contact->get_nc();
-    it->second->active = false;
+    contacts_.erase(it);
   } else {
     std::cout << "Warning: this contact item doesn't exist, we cannot remove it" << std::endl;
   }

--- a/include/crocoddyl/multibody/contacts/multiple-contacts.hxx
+++ b/include/crocoddyl/multibody/contacts/multiple-contacts.hxx
@@ -22,16 +22,16 @@ ContactModelMultipleTpl<Scalar>::~ContactModelMultipleTpl() {}
 
 template <typename Scalar>
 void ContactModelMultipleTpl<Scalar>::addContact(const std::string& name,
-                                                 boost::shared_ptr<ContactModelAbstract> contact) {
+                                                 boost::shared_ptr<ContactModelAbstract> contact, bool active) {
   if (contact->get_nu() != nu_) {
     throw_pretty("Invalid argument: "
                  << "contact item doesn't have the same control dimension (" + std::to_string(nu_) + ")");
   }
   std::pair<typename ContactModelContainer::iterator, bool> ret =
-      contacts_.insert(std::make_pair(name, boost::make_shared<ContactItem>(name, contact)));
+      contacts_.insert(std::make_pair(name, boost::make_shared<ContactItem>(name, contact, active)));
   if (ret.second == false) {
     std::cout << "Warning: this contact item already existed, we cannot add it" << std::endl;
-  } else {
+  } else if (active) {
     nc_ += contact->get_nc();
   }
 }
@@ -41,7 +41,7 @@ void ContactModelMultipleTpl<Scalar>::removeContact(const std::string& name) {
   typename ContactModelContainer::iterator it = contacts_.find(name);
   if (it != contacts_.end()) {
     nc_ -= it->second->contact->get_nc();
-    contacts_.erase(it);
+    it->second->active = false;
   } else {
     std::cout << "Warning: this contact item doesn't exist, we cannot remove it" << std::endl;
   }
@@ -62,14 +62,16 @@ void ContactModelMultipleTpl<Scalar>::calc(const boost::shared_ptr<ContactDataMu
   for (it_m = contacts_.begin(), end_m = contacts_.end(), it_d = data->contacts.begin(), end_d = data->contacts.end();
        it_m != end_m || it_d != end_d; ++it_m, ++it_d) {
     const boost::shared_ptr<ContactItem>& m_i = it_m->second;
-    const boost::shared_ptr<ContactDataAbstract>& d_i = it_d->second;
-    assert_pretty(it_m->first == it_d->first, "it doesn't match the contact name between data and model");
+    if (m_i->active) {
+      const boost::shared_ptr<ContactDataAbstract>& d_i = it_d->second;
+      assert_pretty(it_m->first == it_d->first, "it doesn't match the contact name between data and model");
 
-    m_i->contact->calc(d_i, x);
-    const std::size_t& nc_i = m_i->contact->get_nc();
-    data->a0.segment(nc, nc_i) = d_i->a0;
-    data->Jc.block(nc, 0, nc_i, nv) = d_i->Jc;
-    nc += nc_i;
+      m_i->contact->calc(d_i, x);
+      const std::size_t& nc_i = m_i->contact->get_nc();
+      data->a0.segment(nc, nc_i) = d_i->a0;
+      data->Jc.block(nc, 0, nc_i, nv) = d_i->Jc;
+      nc += nc_i;
+    }
   }
 }
 
@@ -88,13 +90,15 @@ void ContactModelMultipleTpl<Scalar>::calcDiff(const boost::shared_ptr<ContactDa
   for (it_m = contacts_.begin(), end_m = contacts_.end(), it_d = data->contacts.begin(), end_d = data->contacts.end();
        it_m != end_m || it_d != end_d; ++it_m, ++it_d) {
     const boost::shared_ptr<ContactItem>& m_i = it_m->second;
-    const boost::shared_ptr<ContactDataAbstract>& d_i = it_d->second;
-    assert_pretty(it_m->first == it_d->first, "it doesn't match the contact name between data and model");
+    if (m_i->active) {
+      const boost::shared_ptr<ContactDataAbstract>& d_i = it_d->second;
+      assert_pretty(it_m->first == it_d->first, "it doesn't match the contact name between data and model");
 
-    m_i->contact->calcDiff(d_i, x);
-    const std::size_t& nc_i = m_i->contact->get_nc();
-    data->da0_dx.block(nc, 0, nc_i, ndx) = d_i->da0_dx;
-    nc += nc_i;
+      m_i->contact->calcDiff(d_i, x);
+      const std::size_t& nc_i = m_i->contact->get_nc();
+      data->da0_dx.block(nc, 0, nc_i, ndx) = d_i->da0_dx;
+      nc += nc_i;
+    }
   }
 }
 
@@ -130,14 +134,16 @@ void ContactModelMultipleTpl<Scalar>::updateForce(const boost::shared_ptr<Contac
   for (it_m = contacts_.begin(), end_m = contacts_.end(), it_d = data->contacts.begin(), end_d = data->contacts.end();
        it_m != end_m || it_d != end_d; ++it_m, ++it_d) {
     const boost::shared_ptr<ContactItem>& m_i = it_m->second;
-    const boost::shared_ptr<ContactDataAbstract>& d_i = it_d->second;
-    assert_pretty(it_m->first == it_d->first, "it doesn't match the contact name between data and model");
+    if (m_i->active) {
+      const boost::shared_ptr<ContactDataAbstract>& d_i = it_d->second;
+      assert_pretty(it_m->first == it_d->first, "it doesn't match the contact name between data and model");
 
-    const std::size_t& nc_i = m_i->contact->get_nc();
-    const Eigen::VectorBlock<const VectorXs, Eigen::Dynamic> force_i = force.segment(nc, nc_i);
-    m_i->contact->updateForce(d_i, force_i);
-    data->fext[d_i->joint] = d_i->f;
-    nc += nc_i;
+      const std::size_t& nc_i = m_i->contact->get_nc();
+      const Eigen::VectorBlock<const VectorXs, Eigen::Dynamic> force_i = force.segment(nc, nc_i);
+      m_i->contact->updateForce(d_i, force_i);
+      data->fext[d_i->joint] = d_i->f;
+      nc += nc_i;
+    }
   }
 }
 
@@ -178,14 +184,16 @@ void ContactModelMultipleTpl<Scalar>::updateForceDiff(const boost::shared_ptr<Co
   for (it_m = contacts_.begin(), end_m = contacts_.end(), it_d = data->contacts.begin(), end_d = data->contacts.end();
        it_m != end_m || it_d != end_d; ++it_m, ++it_d) {
     const boost::shared_ptr<ContactItem>& m_i = it_m->second;
-    const boost::shared_ptr<ContactDataAbstract>& d_i = it_d->second;
-    assert_pretty(it_m->first == it_d->first, "it doesn't match the contact name between data and model");
+    if (m_i->active) {
+      const boost::shared_ptr<ContactDataAbstract>& d_i = it_d->second;
+      assert_pretty(it_m->first == it_d->first, "it doesn't match the contact name between data and model");
 
-    std::size_t const& nc_i = m_i->contact->get_nc();
-    const Eigen::Block<const MatrixXs> df_dx_i = df_dx.block(nc, 0, nc_i, ndx);
-    const Eigen::Block<const MatrixXs> df_du_i = df_du.block(nc, 0, nc_i, nu_);
-    m_i->contact->updateForceDiff(d_i, df_dx_i, df_du_i);
-    nc += nc_i;
+      std::size_t const& nc_i = m_i->contact->get_nc();
+      const Eigen::Block<const MatrixXs> df_dx_i = df_dx.block(nc, 0, nc_i, ndx);
+      const Eigen::Block<const MatrixXs> df_du_i = df_du.block(nc, 0, nc_i, nu_);
+      m_i->contact->updateForceDiff(d_i, df_dx_i, df_du_i);
+      nc += nc_i;
+    }
   }
 }
 

--- a/include/crocoddyl/multibody/impulses/multiple-impulses.hpp
+++ b/include/crocoddyl/multibody/impulses/multiple-impulses.hpp
@@ -62,6 +62,7 @@ class ImpulseModelMultipleTpl {
 
   void addImpulse(const std::string& name, boost::shared_ptr<ImpulseModelAbstract> impulse, bool active = true);
   void removeImpulse(const std::string& name);
+  void changeImpulseStatus(const std::string& name, bool active);
 
   void calc(const boost::shared_ptr<ImpulseDataMultiple>& data, const Eigen::Ref<const VectorXs>& x);
   void calcDiff(const boost::shared_ptr<ImpulseDataMultiple>& data, const Eigen::Ref<const VectorXs>& x);

--- a/include/crocoddyl/multibody/impulses/multiple-impulses.hpp
+++ b/include/crocoddyl/multibody/impulses/multiple-impulses.hpp
@@ -25,11 +25,13 @@ struct ImpulseItemTpl {
   typedef _Scalar Scalar;
 
   ImpulseItemTpl() {}
-  ImpulseItemTpl(const std::string& name, boost::shared_ptr<ImpulseModelAbstractTpl<Scalar> > impulse)
-      : name(name), impulse(impulse) {}
+  ImpulseItemTpl(const std::string& name, boost::shared_ptr<ImpulseModelAbstractTpl<Scalar> > impulse,
+                 bool active = true)
+      : name(name), impulse(impulse), active(active) {}
 
   std::string name;
   boost::shared_ptr<ImpulseModelAbstractTpl<Scalar> > impulse;
+  bool active;
 };
 
 template <typename _Scalar>
@@ -58,7 +60,7 @@ class ImpulseModelMultipleTpl {
   explicit ImpulseModelMultipleTpl(boost::shared_ptr<StateMultibody> state);
   ~ImpulseModelMultipleTpl();
 
-  void addImpulse(const std::string& name, boost::shared_ptr<ImpulseModelAbstract> impulse);
+  void addImpulse(const std::string& name, boost::shared_ptr<ImpulseModelAbstract> impulse, bool active = true);
   void removeImpulse(const std::string& name);
 
   void calc(const boost::shared_ptr<ImpulseDataMultiple>& data, const Eigen::Ref<const VectorXs>& x);

--- a/include/crocoddyl/multibody/impulses/multiple-impulses.hxx
+++ b/include/crocoddyl/multibody/impulses/multiple-impulses.hxx
@@ -35,7 +35,7 @@ void ImpulseModelMultipleTpl<Scalar>::removeImpulse(const std::string& name) {
   typename ImpulseModelContainer::iterator it = impulses_.find(name);
   if (it != impulses_.end()) {
     ni_ -= it->second->impulse->get_ni();
-    it->second->active = false;
+    impulses_.erase(it);
   } else {
     std::cout << "Warning: this impulse item doesn't exist, we cannot remove it" << std::endl;
   }

--- a/include/crocoddyl/multibody/impulses/multiple-impulses.hxx
+++ b/include/crocoddyl/multibody/impulses/multiple-impulses.hxx
@@ -22,7 +22,7 @@ template <typename Scalar>
 void ImpulseModelMultipleTpl<Scalar>::addImpulse(const std::string& name,
                                                  boost::shared_ptr<ImpulseModelAbstract> impulse, bool active) {
   std::pair<typename ImpulseModelContainer::iterator, bool> ret =
-      impulses_.insert(std::make_pair(name, boost::make_shared<ImpulseItem>(name, impulse)));
+      impulses_.insert(std::make_pair(name, boost::make_shared<ImpulseItem>(name, impulse, active)));
   if (ret.second == false) {
     std::cout << "Warning: this impulse item already existed, we cannot add it" << std::endl;
   } else if (active) {
@@ -38,6 +38,21 @@ void ImpulseModelMultipleTpl<Scalar>::removeImpulse(const std::string& name) {
     impulses_.erase(it);
   } else {
     std::cout << "Warning: this impulse item doesn't exist, we cannot remove it" << std::endl;
+  }
+}
+
+template <typename Scalar>
+void ImpulseModelMultipleTpl<Scalar>::changeImpulseStatus(const std::string& name, bool active) {
+  typename ImpulseModelContainer::iterator it = impulses_.find(name);
+  if (it != impulses_.end()) {
+    if (active && !it->second->active) {
+      ni_ += it->second->impulse->get_ni();
+    } else if (!active && it->second->active) {
+      ni_ -= it->second->impulse->get_ni();
+    }
+    it->second->active = active;
+  } else {
+    std::cout << "Warning: this impulse item doesn't exist, we cannot change its status" << std::endl;
   }
 }
 

--- a/include/crocoddyl/multibody/impulses/multiple-impulses.hxx
+++ b/include/crocoddyl/multibody/impulses/multiple-impulses.hxx
@@ -20,12 +20,12 @@ ImpulseModelMultipleTpl<Scalar>::~ImpulseModelMultipleTpl() {}
 
 template <typename Scalar>
 void ImpulseModelMultipleTpl<Scalar>::addImpulse(const std::string& name,
-                                                 boost::shared_ptr<ImpulseModelAbstract> impulse) {
+                                                 boost::shared_ptr<ImpulseModelAbstract> impulse, bool active) {
   std::pair<typename ImpulseModelContainer::iterator, bool> ret =
       impulses_.insert(std::make_pair(name, boost::make_shared<ImpulseItem>(name, impulse)));
   if (ret.second == false) {
     std::cout << "Warning: this impulse item already existed, we cannot add it" << std::endl;
-  } else {
+  } else if (active) {
     ni_ += impulse->get_ni();
   }
 }
@@ -35,7 +35,7 @@ void ImpulseModelMultipleTpl<Scalar>::removeImpulse(const std::string& name) {
   typename ImpulseModelContainer::iterator it = impulses_.find(name);
   if (it != impulses_.end()) {
     ni_ -= it->second->impulse->get_ni();
-    impulses_.erase(it);
+    it->second->active = false;
   } else {
     std::cout << "Warning: this impulse item doesn't exist, we cannot remove it" << std::endl;
   }
@@ -56,13 +56,15 @@ void ImpulseModelMultipleTpl<Scalar>::calc(const boost::shared_ptr<ImpulseDataMu
   for (it_m = impulses_.begin(), end_m = impulses_.end(), it_d = data->impulses.begin(), end_d = data->impulses.end();
        it_m != end_m || it_d != end_d; ++it_m, ++it_d) {
     const boost::shared_ptr<ImpulseItem>& m_i = it_m->second;
-    const boost::shared_ptr<ImpulseDataAbstract>& d_i = it_d->second;
-    assert_pretty(it_m->first == it_d->first, "it doesn't match the impulse name between data and model");
+    if (m_i->active) {
+      const boost::shared_ptr<ImpulseDataAbstract>& d_i = it_d->second;
+      assert_pretty(it_m->first == it_d->first, "it doesn't match the impulse name between data and model");
 
-    m_i->impulse->calc(d_i, x);
-    const std::size_t& ni_i = m_i->impulse->get_ni();
-    data->Jc.block(ni, 0, ni_i, nv) = d_i->Jc;
-    ni += ni_i;
+      m_i->impulse->calc(d_i, x);
+      const std::size_t& ni_i = m_i->impulse->get_ni();
+      data->Jc.block(ni, 0, ni_i, nv) = d_i->Jc;
+      ni += ni_i;
+    }
   }
 }
 
@@ -81,13 +83,15 @@ void ImpulseModelMultipleTpl<Scalar>::calcDiff(const boost::shared_ptr<ImpulseDa
   for (it_m = impulses_.begin(), end_m = impulses_.end(), it_d = data->impulses.begin(), end_d = data->impulses.end();
        it_m != end_m || it_d != end_d; ++it_m, ++it_d) {
     const boost::shared_ptr<ImpulseItem>& m_i = it_m->second;
-    const boost::shared_ptr<ImpulseDataAbstract>& d_i = it_d->second;
-    assert_pretty(it_m->first == it_d->first, "it doesn't match the impulse name between data and model");
+    if (m_i->active) {
+      const boost::shared_ptr<ImpulseDataAbstract>& d_i = it_d->second;
+      assert_pretty(it_m->first == it_d->first, "it doesn't match the impulse name between data and model");
 
-    m_i->impulse->calcDiff(d_i, x);
-    const std::size_t& ni_i = m_i->impulse->get_ni();
-    data->dv0_dq.block(ni, 0, ni_i, nv) = d_i->dv0_dq;
-    ni += ni_i;
+      m_i->impulse->calcDiff(d_i, x);
+      const std::size_t& ni_i = m_i->impulse->get_ni();
+      data->dv0_dq.block(ni, 0, ni_i, nv) = d_i->dv0_dq;
+      ni += ni_i;
+    }
   }
 }
 
@@ -123,14 +127,16 @@ void ImpulseModelMultipleTpl<Scalar>::updateForce(const boost::shared_ptr<Impuls
   for (it_m = impulses_.begin(), end_m = impulses_.end(), it_d = data->impulses.begin(), end_d = data->impulses.end();
        it_m != end_m || it_d != end_d; ++it_m, ++it_d) {
     const boost::shared_ptr<ImpulseItem>& m_i = it_m->second;
-    const boost::shared_ptr<ImpulseDataAbstract>& d_i = it_d->second;
-    assert_pretty(it_m->first == it_d->first, "it doesn't match the impulse name between data and model");
+    if (m_i->active) {
+      const boost::shared_ptr<ImpulseDataAbstract>& d_i = it_d->second;
+      assert_pretty(it_m->first == it_d->first, "it doesn't match the impulse name between data and model");
 
-    const std::size_t& ni_i = m_i->impulse->get_ni();
-    const Eigen::VectorBlock<const VectorXs, Eigen::Dynamic> force_i = force.segment(ni, ni_i);
-    m_i->impulse->updateForce(d_i, force_i);
-    data->fext[d_i->joint] = d_i->f;
-    ni += ni_i;
+      const std::size_t& ni_i = m_i->impulse->get_ni();
+      const Eigen::VectorBlock<const VectorXs, Eigen::Dynamic> force_i = force.segment(ni, ni_i);
+      m_i->impulse->updateForce(d_i, force_i);
+      data->fext[d_i->joint] = d_i->f;
+      ni += ni_i;
+    }
   }
 }
 
@@ -165,13 +171,15 @@ void ImpulseModelMultipleTpl<Scalar>::updateForceDiff(const boost::shared_ptr<Im
   for (it_m = impulses_.begin(), end_m = impulses_.end(), it_d = data->impulses.begin(), end_d = data->impulses.end();
        it_m != end_m || it_d != end_d; ++it_m, ++it_d) {
     const boost::shared_ptr<ImpulseItem>& m_i = it_m->second;
-    const boost::shared_ptr<ImpulseDataAbstract>& d_i = it_d->second;
-    assert_pretty(it_m->first == it_d->first, "it doesn't match the impulse name between data and model");
+    if (m_i->active) {
+      const boost::shared_ptr<ImpulseDataAbstract>& d_i = it_d->second;
+      assert_pretty(it_m->first == it_d->first, "it doesn't match the impulse name between data and model");
 
-    const std::size_t& ni_i = m_i->impulse->get_ni();
-    const Eigen::Block<const MatrixXs> df_dq_i = df_dq.block(ni, 0, ni_i, nv);
-    m_i->impulse->updateForceDiff(d_i, df_dq_i);
-    ni += ni_i;
+      const std::size_t& ni_i = m_i->impulse->get_ni();
+      const Eigen::Block<const MatrixXs> df_dq_i = df_dq.block(ni, 0, ni_i, nv);
+      m_i->impulse->updateForceDiff(d_i, df_dq_i);
+      ni += ni_i;
+    }
   }
 }
 

--- a/unittest/test_multiple_contacts.cpp
+++ b/unittest/test_multiple_contacts.cpp
@@ -70,11 +70,15 @@ void test_addContact() {
   crocoddyl::ContactModelMultiple model(boost::static_pointer_cast<crocoddyl::StateMultibody>(
       state_factory.create(StateModelTypes::StateMultibody_RandomHumanoid)));
 
-  // add an contact object to the container
-  model.addContact("random_contact", create_random_contact());
+  // add an active contact
+  boost::shared_ptr<crocoddyl::ContactModelAbstract> rand_contact_1 = create_random_contact();
+  model.addContact("random_contact_1", rand_contact_1);
+  BOOST_CHECK(model.get_nc() == rand_contact_1->get_nc());
 
-  // Test the final size of the map
-  BOOST_CHECK(model.get_contacts().size() == 1);
+  // add an inactive contact
+  boost::shared_ptr<crocoddyl::ContactModelAbstract> rand_contact_2 = create_random_contact();
+  model.addContact("random_contact_2", rand_contact_2, false);
+  BOOST_CHECK(model.get_nc() == rand_contact_1->get_nc());
 }
 
 void test_addContact_error_message() {
@@ -107,14 +111,14 @@ void test_removeContact() {
   crocoddyl::ContactModelMultiple model(boost::static_pointer_cast<crocoddyl::StateMultibody>(
       state_factory.create(StateModelTypes::StateMultibody_RandomHumanoid)));
 
-  // add an contact object to the container
-  model.addContact("random_contact", create_random_contact());
+  // add an active contact
+  boost::shared_ptr<crocoddyl::ContactModelAbstract> rand_contact = create_random_contact();
+  model.addContact("random_contact", rand_contact);
+  BOOST_CHECK(model.get_nc() == rand_contact->get_nc());
 
-  // add an contact object to the container
+  // remove the contact
   model.removeContact("random_contact");
-
-  // Test the final size of the map
-  BOOST_CHECK(model.get_contacts().size() == 0);
+  BOOST_CHECK(model.get_nc() == 0);
 }
 
 void test_removeContact_error_message() {

--- a/unittest/test_multiple_contacts.cpp
+++ b/unittest/test_multiple_contacts.cpp
@@ -79,6 +79,14 @@ void test_addContact() {
   boost::shared_ptr<crocoddyl::ContactModelAbstract> rand_contact_2 = create_random_contact();
   model.addContact("random_contact_2", rand_contact_2, false);
   BOOST_CHECK(model.get_nc() == rand_contact_1->get_nc());
+
+  // change the random contact 2 status
+  model.changeContactStatus("random_contact_2", true);
+  BOOST_CHECK(model.get_nc() == rand_contact_1->get_nc() + rand_contact_2->get_nc());
+
+  // change the random contact 1 status
+  model.changeContactStatus("random_contact_1", false);
+  BOOST_CHECK(model.get_nc() == rand_contact_2->get_nc());
 }
 
 void test_addContact_error_message() {
@@ -93,15 +101,21 @@ void test_addContact_error_message() {
   // add twice the same contact object to the container
   model.addContact("random_contact", rand_contact);
 
-  // Expect a cout message here
+  // test error message when we add a duplicate contact
   CaptureIOStream capture_ios;
   capture_ios.beginCapture();
   model.addContact("random_contact", rand_contact);
   capture_ios.endCapture();
-
-  // Test that the error message is sent.
   std::stringstream expected_buffer;
   expected_buffer << "Warning: this contact item already existed, we cannot add it" << std::endl;
+  BOOST_CHECK(capture_ios.str() == expected_buffer.str());
+
+  // test error message when we change the contact status of an inexistent contact
+  capture_ios.beginCapture();
+  model.changeContactStatus("no_exist_contact", true);
+  capture_ios.endCapture();
+  expected_buffer.clear();
+  expected_buffer << "Warning: this contact item doesn't exist, we cannot change its status" << std::endl;
   BOOST_CHECK(capture_ios.str() == expected_buffer.str());
 }
 

--- a/unittest/test_multiple_impulses.cpp
+++ b/unittest/test_multiple_impulses.cpp
@@ -71,11 +71,15 @@ void test_addImpulse() {
   crocoddyl::ImpulseModelMultiple model(boost::static_pointer_cast<crocoddyl::StateMultibody>(
       state_factory.create(StateModelTypes::StateMultibody_RandomHumanoid)));
 
-  // add an impulse object to the container
-  model.addImpulse("random_impulse", create_random_impulse());
+  // add an active impulse
+  boost::shared_ptr<crocoddyl::ImpulseModelAbstract> rand_impulse_1 = create_random_impulse();
+  model.addImpulse("random_impulse_1", rand_impulse_1);
+  BOOST_CHECK(model.get_ni() == rand_impulse_1->get_ni());
 
-  // Test the final size of the map
-  BOOST_CHECK(model.get_impulses().size() == 1);
+  // add an inactive impulse
+  boost::shared_ptr<crocoddyl::ImpulseModelAbstract> rand_impulse_2 = create_random_impulse();
+  model.addImpulse("random_impulse_2", rand_impulse_2, false);
+  BOOST_CHECK(model.get_ni() == rand_impulse_1->get_ni());
 }
 
 void test_addImpulse_error_message() {
@@ -108,14 +112,14 @@ void test_removeImpulse() {
   crocoddyl::ImpulseModelMultiple model(boost::static_pointer_cast<crocoddyl::StateMultibody>(
       state_factory.create(StateModelTypes::StateMultibody_RandomHumanoid)));
 
-  // add an impulse object to the container
-  model.addImpulse("random_impulse", create_random_impulse());
+  // add an active impulse
+  boost::shared_ptr<crocoddyl::ImpulseModelAbstract> rand_impulse = create_random_impulse();
+  model.addImpulse("random_impulse", rand_impulse);
+  BOOST_CHECK(model.get_ni() == rand_impulse->get_ni());
 
-  // add an impulse object to the container
+  // remove the impulse
   model.removeImpulse("random_impulse");
-
-  // Test the final size of the map
-  BOOST_CHECK(model.get_impulses().size() == 0);
+  BOOST_CHECK(model.get_ni() == 0);
 }
 
 void test_removeImpulse_error_message() {

--- a/unittest/test_multiple_impulses.cpp
+++ b/unittest/test_multiple_impulses.cpp
@@ -80,6 +80,14 @@ void test_addImpulse() {
   boost::shared_ptr<crocoddyl::ImpulseModelAbstract> rand_impulse_2 = create_random_impulse();
   model.addImpulse("random_impulse_2", rand_impulse_2, false);
   BOOST_CHECK(model.get_ni() == rand_impulse_1->get_ni());
+
+  // change the random impulse 2 status
+  model.changeImpulseStatus("random_impulse_2", true);
+  BOOST_CHECK(model.get_ni() == rand_impulse_1->get_ni() + rand_impulse_2->get_ni());
+
+  // change the random impulse 1 status
+  model.changeImpulseStatus("random_impulse_1", false);
+  BOOST_CHECK(model.get_ni() == rand_impulse_2->get_ni());
 }
 
 void test_addImpulse_error_message() {
@@ -94,15 +102,21 @@ void test_addImpulse_error_message() {
   // add twice the same impulse object to the container
   model.addImpulse("random_impulse", rand_impulse);
 
-  // Expect a cout message here
+  // test error message when we add a duplicate impulse
   CaptureIOStream capture_ios;
   capture_ios.beginCapture();
   model.addImpulse("random_impulse", rand_impulse);
   capture_ios.endCapture();
-
-  // Test that the error message is sent.
   std::stringstream expected_buffer;
   expected_buffer << "Warning: this impulse item already existed, we cannot add it" << std::endl;
+  BOOST_CHECK(capture_ios.str() == expected_buffer.str());
+
+  // test error message when we change the impulse status of an inexistent impulse
+  capture_ios.beginCapture();
+  model.changeImpulseStatus("no_exist_impulse", true);
+  capture_ios.endCapture();
+  expected_buffer.clear();
+  expected_buffer << "Warning: this impulse item doesn't exist, we cannot change its status" << std::endl;
   BOOST_CHECK(capture_ios.str() == expected_buffer.str());
 }
 


### PR DESCRIPTION
This PR extends the API to handle the contact / impulse status, however, **it is still back compatible with previous code**. The rationality behind this modification is as follows

 "_If we need to re-assign new set of contacts (or impulses), then we need to create the multi-contact(-impulse) data again and this is not convenient for MPC applications_"

To avoid this, we need to allocate the contact (or impulse) data for all possible contacts (or impulses) as global mechanism allocation. Then, we process the corresponding contacts (or impulses) giving its status (active or inactive).

Finally, the PR includes extra unittest regarding this modification. 