### PR TITLE
Retrieve models and solvers only through shooting-problem iface

### DIFF
--- a/bindings/python/crocoddyl/__init__.py
+++ b/bindings/python/crocoddyl/__init__.py
@@ -115,7 +115,8 @@ class GepettoDisplay:
         fs = self.getForceTrajectoryFromSolver(solver)
         ps = self.getFrameTrajectoryFromSolver(solver)
 
-        dts = [m.dt if hasattr(m, "differential") else 0. for m in solver.models()]
+        models = solver.problem.runningModels + [solver.problem.terminalModel]
+        dts = [m.dt if hasattr(m, "differential") else 0. for m in models]
         self.display(solver.xs, fs, ps, dts, factor)
 
     def addRobot(self):
@@ -158,8 +159,10 @@ class GepettoDisplay:
 
     def getForceTrajectoryFromSolver(self, solver):
         fs = []
-        for i, data in enumerate(solver.datas()):
-            model = solver.models()[i]
+        models = solver.problem.runningModels + [solver.problem.terminalModel]
+        datas = solver.problem.runningDatas + [solver.problem.terminalData]
+        for i, data in enumerate(datas):
+            model = models[i]
             if hasattr(data, "differential"):
                 if isinstance(data.differential, libcrocoddyl_pywrap.DifferentialActionDataContactFwdDynamics):
                     fc = []
@@ -195,9 +198,10 @@ class GepettoDisplay:
 
     def getFrameTrajectoryFromSolver(self, solver):
         ps = {fr: [] for fr in self.frameTrajNames}
+        datas = solver.problem.runningDatas + [solver.problem.terminalData]
         for key, p in ps.items():
             frameId = int(key)
-            for data in solver.datas():
+            for data in datas:
                 if hasattr(data, "differential"):
                     if hasattr(data.differential, "pinocchio"):
                         pose = data.differential.pinocchio.oMf[frameId]

--- a/bindings/python/crocoddyl/core/solver-base.cpp
+++ b/bindings/python/crocoddyl/core/solver-base.cpp
@@ -100,8 +100,6 @@ void exposeSolverAbstract() {
           "problem",
           bp::make_function(&SolverAbstract_wrap::get_problem, bp::return_value_policy<bp::copy_const_reference>()),
           "shooting problem")
-      .def("models", &SolverAbstract_wrap::get_models, bp::return_value_policy<bp::copy_const_reference>(), "models")
-      .def("datas", &SolverAbstract_wrap::get_datas, bp::return_value_policy<bp::copy_const_reference>(), "datas")
       .add_property(
           "xs", bp::make_function(&SolverAbstract_wrap::get_xs, bp::return_value_policy<bp::copy_const_reference>()),
           bp::make_function(&SolverAbstract_wrap::set_xs), "state trajectory")

--- a/bindings/python/crocoddyl/utils/__init__.py
+++ b/bindings/python/crocoddyl/utils/__init__.py
@@ -779,8 +779,9 @@ class DDPDerived(crocoddyl.SolverAbstract):
         self.u_reg = self.x_reg
 
     def allocateData(self):
-        self.Vxx = [a2m(np.zeros([m.state.ndx, m.state.ndx])) for m in self.models()]
-        self.Vx = [a2m(np.zeros([m.state.ndx])) for m in self.models()]
+        models = self.problem.runningModels + [self.problem.terminalModel]
+        self.Vxx = [a2m(np.zeros([m.state.ndx, m.state.ndx])) for m in models]
+        self.Vx = [a2m(np.zeros([m.state.ndx])) for m in models]
 
         self.Q = [a2m(np.zeros([m.state.ndx + m.nu, m.state.ndx + m.nu])) for m in self.problem.runningModels]
         self.q = [a2m(np.zeros([m.state.ndx + m.nu])) for m in self.problem.runningModels]

--- a/bindings/python/crocoddyl/utils/biped.py
+++ b/bindings/python/crocoddyl/utils/biped.py
@@ -317,21 +317,23 @@ def plotSolution(solver, bounds=True, figIndex=1, figTitle="", show=True):
         us_lb, us_ub = [], []
         xs_lb, xs_ub = [], []
     if isinstance(solver, list):
-        rmodel = solver[0].models()[0].state.pinocchio
+        rmodel = solver[0].problem.runningModels[0].state.pinocchio
         for s in solver:
             xs.extend(s.xs[:-1])
             us.extend(s.us)
             if bounds:
-                for m in s.models():
+                models = s.problem.runningModels + [s.problem.terminalModel]
+                for m in models:
                     us_lb += [m.u_lb]
                     us_ub += [m.u_ub]
                     xs_lb += [m.state.lb]
                     xs_ub += [m.state.ub]
     else:
-        rmodel = solver.models()[0].state.pinocchio
+        rmodel = solver.problem.runningModels[0].state.pinocchio
         xs, us = solver.xs, solver.us
         if bounds:
-            for m in solver.models():
+            models = s.problem.runningModels + [s.problem.terminalModel]
+            for m in models:
                 us_lb += [m.u_lb]
                 us_ub += [m.u_ub]
                 xs_lb += [m.state.lb]

--- a/bindings/python/crocoddyl/utils/quadruped.py
+++ b/bindings/python/crocoddyl/utils/quadruped.py
@@ -563,21 +563,23 @@ def plotSolution(solver, bounds=True, figIndex=1, figTitle="", show=True):
         us_lb, us_ub = [], []
         xs_lb, xs_ub = [], []
     if isinstance(solver, list):
-        rmodel = solver[0].models()[0].state.pinocchio
+        rmodel = solver[0].problem.runningModels[0].state.pinocchio
         for s in solver:
             xs.extend(s.xs[:-1])
             us.extend(s.us)
             if bounds:
-                for m in s.models():
+                models = s.problem.runningModels + [s.problem.terminalModel]
+                for m in models:
                     us_lb += [m.u_lb]
                     us_ub += [m.u_ub]
                     xs_lb += [m.state.lb]
                     xs_ub += [m.state.ub]
     else:
-        rmodel = solver.models()[0].state.pinocchio
+        rmodel = solver.problem.runningModels[0].state.pinocchio
         xs, us = solver.xs, solver.us
         if bounds:
-            for m in solver.models():
+            models = solver.problem.runningModels + [solver.problem.terminalModel]
+            for m in models:
                 us_lb += [m.u_lb]
                 us_ub += [m.u_ub]
                 xs_lb += [m.state.lb]

--- a/examples/bipedal_walk.py
+++ b/examples/bipedal_walk.py
@@ -67,8 +67,11 @@ for i, phase in enumerate(GAITPHASES):
         ddp[i].setCallbacks([crocoddyl.CallbackVerbose()])
 
     # Solving the problem with the DDP solver
-    xs = [talos_legs.model.defaultState] * len(ddp[i].models())
-    us = [m.quasiStatic(d, talos_legs.model.defaultState) for m, d in list(zip(ddp[i].models(), ddp[i].datas()))[:-1]]
+    xs = [talos_legs.model.defaultState] * (ddp[i].problem.T + 1)
+    us = [
+        m.quasiStatic(d, talos_legs.model.defaultState)
+        for m, d in list(zip(ddp[i].problem.runningModels, ddp[i].problem.runningDatas))
+    ]
     ddp[i].solve(xs, us, 100, False, 0.1)
 
     # Defining the final state as initial one for the next phase

--- a/examples/bipedal_walk_ubound.py
+++ b/examples/bipedal_walk_ubound.py
@@ -70,8 +70,11 @@ for i, phase in enumerate(GAITPHASES):
         ddp[i].setCallbacks([crocoddyl.CallbackVerbose()])
 
     # Solving the problem with the DDP solver
-    xs = [talos_legs.model.defaultState] * len(ddp[i].models())
-    us = [m.quasiStatic(d, talos_legs.model.defaultState) for m, d in list(zip(ddp[i].models(), ddp[i].datas()))[:-1]]
+    xs = [talos_legs.model.defaultState] * (ddp[i].problem.T + 1)
+    us = [
+        m.quasiStatic(d, talos_legs.model.defaultState)
+        for m, d in list(zip(ddp[i].problem.runningModels, ddp[i].problem.runningDatas))
+    ]
     ddp[i].solve(xs, us, 100, False, 0.1)
 
     # Defining the final state as initial one for the next phase

--- a/examples/boxfddp_vs_boxddp.py
+++ b/examples/boxfddp_vs_boxddp.py
@@ -73,8 +73,11 @@ else:
     boxddp.setCallbacks([crocoddyl.CallbackVerbose()])
 
 # Solving the problem with the both solvers
-xs = [anymal.model.defaultState] * len(boxfddp.models())
-us = [m.quasiStatic(d, anymal.model.defaultState) for m, d in list(zip(boxfddp.models(), boxfddp.datas()))[:-1]]
+xs = [anymal.model.defaultState] * (boxfddp.problem.T + 1)
+us = [
+    m.quasiStatic(d, anymal.model.defaultState)
+    for m, d in list(zip(boxfddp.problem.runningModels, boxfddp.problem.runningDatas))
+]
 
 print('*** SOLVE with Box-FDDP ***')
 boxfddp.th_stop = 1e-7

--- a/examples/humanoid_manipulation.py
+++ b/examples/humanoid_manipulation.py
@@ -138,8 +138,8 @@ else:
     ddp.setCallbacks([crocoddyl.CallbackVerbose()])
 
 # Solving it with the DDP algorithm
-xs = [rmodel.defaultState] * len(ddp.models())
-us = [m.quasiStatic(d, rmodel.defaultState) for m, d in list(zip(ddp.models(), ddp.datas()))[:-1]]
+xs = [rmodel.defaultState] * (ddp.problem.T + 1)
+us = [m.quasiStatic(d, rmodel.defaultState) for m, d in list(zip(ddp.problem.runningModels, ddp.problem.runningDatas))]
 ddp.solve(xs, us, 500, False, 0.1)
 
 # Visualizing the solution in gepetto-viewer

--- a/examples/humanoid_manipulation_ubound.py
+++ b/examples/humanoid_manipulation_ubound.py
@@ -141,8 +141,8 @@ else:
     ddp.setCallbacks([crocoddyl.CallbackVerbose()])
 
 # Solving it with the DDP algorithm
-xs = [rmodel.defaultState] * len(ddp.models())
-us = [m.quasiStatic(d, rmodel.defaultState) for m, d in list(zip(ddp.models(), ddp.datas()))[:-1]]
+xs = [rmodel.defaultState] * (ddp.problem.T + 1)
+us = [m.quasiStatic(d, rmodel.defaultState) for m, d in list(zip(ddp.problem.runningModels, ddp.problem.runningDatas))]
 ddp.solve(xs, us, 500, False, 1e-9)
 
 # Visualizing the solution in gepetto-viewer

--- a/examples/humanoid_taichi.py
+++ b/examples/humanoid_taichi.py
@@ -171,8 +171,8 @@ else:
     ddp.setCallbacks([crocoddyl.CallbackVerbose()])
 
 # Solving it with the DDP algorithm
-xs = [rmodel.defaultState] * len(ddp.models())
-us = [m.quasiStatic(d, rmodel.defaultState) for m, d in list(zip(ddp.models(), ddp.datas()))[:-1]]
+xs = [rmodel.defaultState] * (ddp.problem.T + 1)
+us = [m.quasiStatic(d, rmodel.defaultState) for m, d in list(zip(ddp.problem.runningModels, ddp.problem.runningDatas))]
 ddp.th_stop = 1e-7
 ddp.solve(xs, us, 500, False, 1e-9)
 

--- a/examples/quadrupedal_gaits.py
+++ b/examples/quadrupedal_gaits.py
@@ -118,8 +118,11 @@ for i, phase in enumerate(GAITPHASES):
         ddp[i].setCallbacks([crocoddyl.CallbackVerbose()])
 
     # Solving the problem with the DDP solver
-    xs = [anymal.model.defaultState] * len(ddp[i].models())
-    us = [m.quasiStatic(d, anymal.model.defaultState) for m, d in list(zip(ddp[i].models(), ddp[i].datas()))[:-1]]
+    xs = [anymal.model.defaultState] * (ddp[i].problem.T + 1)
+    us = [
+        m.quasiStatic(d, anymal.model.defaultState)
+        for m, d in list(zip(ddp[i].problem.runningModels, ddp[i].problem.runningDatas))
+    ]
     ddp[i].solve(xs, us, 100, False, 0.1)
 
     # Defining the final state as initial one for the next phase

--- a/examples/quadrupedal_walk_ubound.py
+++ b/examples/quadrupedal_walk_ubound.py
@@ -57,8 +57,8 @@ elif WITHPLOT:
 else:
     boxddp.setCallbacks([crocoddyl.CallbackVerbose()])
 
-xs = [robot_model.defaultState] * len(boxddp.models())
-us = [m.quasiStatic(d, robot_model.defaultState) for m, d in list(zip(boxddp.models(), boxddp.datas()))[:-1]]
+xs = [robot_model.defaultState] * (boxddp.problem.T + 1)
+us = [m.quasiStatic(d, robot_model.defaultState) for m, d in list(zip(boxddp.problem.runningModels, boxddp.problem.runningDatas))]
 
 # Solve the DDP problem
 boxddp.solve(xs, us, 100, False, 0.1)

--- a/examples/quadrupedal_walk_ubound.py
+++ b/examples/quadrupedal_walk_ubound.py
@@ -58,7 +58,10 @@ else:
     boxddp.setCallbacks([crocoddyl.CallbackVerbose()])
 
 xs = [robot_model.defaultState] * (boxddp.problem.T + 1)
-us = [m.quasiStatic(d, robot_model.defaultState) for m, d in list(zip(boxddp.problem.runningModels, boxddp.problem.runningDatas))]
+us = [
+    m.quasiStatic(d, robot_model.defaultState)
+    for m, d in list(zip(boxddp.problem.runningModels, boxddp.problem.runningDatas))
+]
 
 # Solve the DDP problem
 boxddp.solve(xs, us, 100, False, 0.1)

--- a/include/crocoddyl/core/solver-base.hpp
+++ b/include/crocoddyl/core/solver-base.hpp
@@ -40,8 +40,6 @@ class SolverAbstract {
   const std::vector<boost::shared_ptr<CallbackAbstract> >& getCallbacks() const;
 
   const boost::shared_ptr<ShootingProblem>& get_problem() const;
-  const std::vector<boost::shared_ptr<ActionModelAbstract> >& get_models() const;
-  const std::vector<boost::shared_ptr<ActionDataAbstract> >& get_datas() const;
   const std::vector<Eigen::VectorXd>& get_xs() const;
   const std::vector<Eigen::VectorXd>& get_us() const;
   const bool& get_is_feasible() const;
@@ -66,8 +64,6 @@ class SolverAbstract {
 
  protected:
   boost::shared_ptr<ShootingProblem> problem_;                   //!< optimal control problem
-  std::vector<boost::shared_ptr<ActionModelAbstract> > models_;  //!< Models defined in the problem
-  std::vector<boost::shared_ptr<ActionDataAbstract> > datas_;    //!< Data for all action models along the problem
   std::vector<Eigen::VectorXd> xs_;                              //!< State trajectory
   std::vector<Eigen::VectorXd> us_;                              //!< Control trajectory
   std::vector<boost::shared_ptr<CallbackAbstract> > callbacks_;  //!< Callback functions

--- a/src/core/solver-base.cpp
+++ b/src/core/solver-base.cpp
@@ -28,8 +28,6 @@ SolverAbstract::SolverAbstract(boost::shared_ptr<ShootingProblem> problem)
   const std::size_t& T = problem_->get_T();
   xs_.resize(T + 1);
   us_.resize(T);
-  models_.resize(T + 1);
-  datas_.resize(T + 1);
   for (std::size_t t = 0; t < T; ++t) {
     const boost::shared_ptr<ActionModelAbstract>& model = problem_->get_runningModels()[t];
     const boost::shared_ptr<ActionDataAbstract>& data = problem_->get_runningDatas()[t];
@@ -37,12 +35,8 @@ SolverAbstract::SolverAbstract(boost::shared_ptr<ShootingProblem> problem)
 
     xs_[t] = model->get_state()->zero();
     us_[t] = Eigen::VectorXd::Zero(nu);
-    models_[t] = model;
-    datas_[t] = data;
   }
   xs_.back() = problem_->get_terminalModel()->get_state()->zero();
-  models_.back() = problem_->get_terminalModel();
-  datas_.back() = problem_->get_terminalData();
 }
 
 SolverAbstract::~SolverAbstract() {}
@@ -82,10 +76,6 @@ void SolverAbstract::setCallbacks(const std::vector<boost::shared_ptr<CallbackAb
 const std::vector<boost::shared_ptr<CallbackAbstract> >& SolverAbstract::getCallbacks() const { return callbacks_; }
 
 const boost::shared_ptr<ShootingProblem>& SolverAbstract::get_problem() const { return problem_; }
-
-const std::vector<boost::shared_ptr<ActionModelAbstract> >& SolverAbstract::get_models() const { return models_; }
-
-const std::vector<boost::shared_ptr<ActionDataAbstract> >& SolverAbstract::get_datas() const { return datas_; }
 
 const std::vector<Eigen::VectorXd>& SolverAbstract::get_xs() const { return xs_; }
 


### PR DESCRIPTION
In Crocoddyl, there is a clear division between problem and solvers and the following functions (inside the solver abstraction) do not respect it:
 - `solver.get_models()`,
 - `solver.get_datas()`,

furthermore, they are also unnecessary (and make confusion) because both models and datas can be retrieved through shooting problem, e.g.
```cpp
solver.get_problem()->get_runningDatas();
```
or (in Python)
```python
solver.problem.runningDatas
```

To make the library consistent, the PR cleans the examples and unittest code. Additionally, it removes the duplicated functions in the solver abstraction.