### PR TITLE
Function to update a model for a given node

### DIFF
--- a/bindings/python/crocoddyl/core/optctrl/shooting.cpp
+++ b/bindings/python/crocoddyl/core/optctrl/shooting.cpp
@@ -59,6 +59,10 @@ void exposeShootingProblem() {
            "Integrate the dynamics given a control sequence.\n\n"
            "Rollout the dynamics give a sequence of control commands\n"
            ":param us: time-discrete control sequence")
+      .def("updateModel", &ShootingProblem::updateModel, bp::args("self", "i", "model"),
+           "Update a model and allocated new data for a specific node.\n\n"
+           ":param i: index of the node (0 <= i <= T + 1)\n"
+           ":param model: new model")
       .add_property("T", bp::make_function(&ShootingProblem::get_T, bp::return_value_policy<bp::return_by_value>()),
                     "number of nodes")
       .add_property("x0", bp::make_function(&ShootingProblem::get_x0, bp::return_value_policy<bp::return_by_value>()),

--- a/include/crocoddyl/core/optctrl/shooting.hpp
+++ b/include/crocoddyl/core/optctrl/shooting.hpp
@@ -38,6 +38,8 @@ class ShootingProblemTpl {
   void rollout(const std::vector<VectorXs>& us, std::vector<VectorXs>& xs);
   std::vector<VectorXs> rollout_us(const std::vector<VectorXs>& us);
 
+  void updateModel(std::size_t i, boost::shared_ptr<ActionModelAbstract> model);
+
   const std::size_t& get_T() const;
   const VectorXs& get_x0() const;
   const std::vector<boost::shared_ptr<ActionModelAbstract> >& get_runningModels() const;

--- a/include/crocoddyl/core/optctrl/shooting.hxx
+++ b/include/crocoddyl/core/optctrl/shooting.hxx
@@ -120,6 +120,20 @@ std::vector<typename MathBaseTpl<Scalar>::VectorXs> ShootingProblemTpl<Scalar>::
 }
 
 template <typename Scalar>
+void ShootingProblemTpl<Scalar>::updateModel(std::size_t i, boost::shared_ptr<ActionModelAbstract> model) {
+  if (i > T_ + 1) {
+    throw_pretty("Invalid argument: "
+                 << "i is bigger than the allocated horizon (it should be lower than " + std::to_string(T_) + ")");
+  }
+  if (i == T_ + 1) {
+    set_terminalModel(model);
+  } else {
+    running_models_[i] = model;
+    running_datas_[i] = model->createData();
+  }
+}
+
+template <typename Scalar>
 const std::size_t& ShootingProblemTpl<Scalar>::get_T() const {
   return T_;
 }


### PR DESCRIPTION
This PR proposes a function that
 - updates the model of a i node, and
 - allocates data for that node.

This additional function is useful for MPC application, when we might want to replace the action model.