### PR TITLE
Created abstract function for setting and getting cost references

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ APPLY_DEFAULT_APPLE_CONFIGURATION()
 
 # Add the different required and optional dependencies
 ADD_REQUIRED_DEPENDENCY("eigen3 >= 3.0.5")
-ADD_REQUIRED_DEPENDENCY("eigenpy")
+ADD_REQUIRED_DEPENDENCY("eigenpy >= 2.2.0")
 ADD_REQUIRED_DEPENDENCY("pinocchio >= 2.2.1")
 ADD_REQUIRED_DEPENDENCY("example-robot-data >= 3.1.2")
 ADD_OPTIONAL_DEPENDENCY("quadprog")

--- a/bindings/python/crocoddyl/multibody/costs/centroidal-momentum.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/centroidal-momentum.cpp
@@ -70,6 +70,11 @@ void exposeCostCentroidalMomentum() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
+      .add_property("reference",
+                    bp::make_function(&CostModelCentroidalMomentum::get_reference<MathBaseTpl<double>::Vector6s>,
+                                      bp::return_value_policy<bp::return_by_value>()),
+                    &CostModelCentroidalMomentum::set_reference<MathBaseTpl<double>::Vector6s>,
+                    "reference centroidal momentum")
       .add_property(
           "href",
           bp::make_function(&CostModelCentroidalMomentum::get_href, bp::return_value_policy<bp::return_by_value>()),

--- a/bindings/python/crocoddyl/multibody/costs/centroidal-momentum.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/centroidal-momentum.cpp
@@ -70,11 +70,10 @@ void exposeCostCentroidalMomentum() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
-      .add_property("reference",
-                    bp::make_function(&CostModelCentroidalMomentum::get_reference<MathBaseTpl<double>::Vector6s>,
-                                      bp::return_value_policy<bp::return_by_value>()),
-                    &CostModelCentroidalMomentum::set_reference<MathBaseTpl<double>::Vector6s>,
-                    "reference centroidal momentum")
+      .add_property(
+          "reference",
+          bp::make_function(&CostModelCentroidalMomentum::get_href, bp::return_value_policy<bp::return_by_value>()),
+          &CostModelCentroidalMomentum::set_reference<MathBaseTpl<double>::Vector6s>, "reference centroidal momentum")
       .add_property(
           "href",
           bp::make_function(&CostModelCentroidalMomentum::get_href, bp::return_value_policy<bp::return_by_value>()),

--- a/bindings/python/crocoddyl/multibody/costs/com-position.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/com-position.cpp
@@ -68,8 +68,7 @@ void exposeCostCoMPosition() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
-      .add_property("reference",
-                    bp::make_function(&CostModelCoMPosition::get_cref, bp::return_internal_reference<>()),
+      .add_property("reference", bp::make_function(&CostModelCoMPosition::get_cref, bp::return_internal_reference<>()),
                     &CostModelCoMPosition::set_reference<Eigen::Vector3d>, "reference CoM position")
       .add_property("cref", bp::make_function(&CostModelCoMPosition::get_cref, bp::return_internal_reference<>()),
                     &CostModelCoMPosition::set_cref, "reference CoM position");

--- a/bindings/python/crocoddyl/multibody/costs/com-position.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/com-position.cpp
@@ -69,8 +69,7 @@ void exposeCostCoMPosition() {
            ":param data: shared data\n"
            ":return cost data.")
       .add_property("reference",
-                    bp::make_function(&CostModelCoMPosition::get_reference<Eigen::Vector3d>,
-                                      bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_function(&CostModelCoMPosition::get_cref, bp::return_value_policy<bp::return_by_value>()),
                     &CostModelCoMPosition::set_reference<Eigen::Vector3d>, "reference CoM position")
       .add_property("cref",
                     bp::make_function(&CostModelCoMPosition::get_cref, bp::return_value_policy<bp::return_by_value>()),

--- a/bindings/python/crocoddyl/multibody/costs/com-position.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/com-position.cpp
@@ -68,6 +68,10 @@ void exposeCostCoMPosition() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
+      .add_property("reference",
+                    bp::make_function(&CostModelCoMPosition::get_reference<Eigen::Vector3d>,
+                                      bp::return_value_policy<bp::return_by_value>()),
+                    &CostModelCoMPosition::set_reference<Eigen::Vector3d>, "reference CoM position")
       .add_property("cref",
                     bp::make_function(&CostModelCoMPosition::get_cref, bp::return_value_policy<bp::return_by_value>()),
                     &CostModelCoMPosition::set_cref, "reference CoM position");

--- a/bindings/python/crocoddyl/multibody/costs/contact-force.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/contact-force.cpp
@@ -67,6 +67,10 @@ void exposeCostContactForce() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
+      .add_property("reference",
+                    bp::make_function(&CostModelContactForce::get_reference<FrameForce>,
+                                      bp::return_value_policy<bp::return_by_value>()),
+                    &CostModelContactForce::set_reference<FrameForce>, "reference frame force")
       .add_property("fref", bp::make_function(&CostModelContactForce::get_fref, bp::return_internal_reference<>()),
                     &CostModelContactForce::set_fref, "reference contact force");
 

--- a/bindings/python/crocoddyl/multibody/costs/contact-force.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/contact-force.cpp
@@ -68,8 +68,7 @@ void exposeCostContactForce() {
            ":param data: shared data\n"
            ":return cost data.")
       .add_property("reference",
-                    bp::make_function(&CostModelContactForce::get_reference<FrameForce>,
-                                      bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_function(&CostModelContactForce::get_fref, bp::return_internal_reference<>()),
                     &CostModelContactForce::set_reference<FrameForce>, "reference frame force")
       .add_property("fref", bp::make_function(&CostModelContactForce::get_fref, bp::return_internal_reference<>()),
                     &CostModelContactForce::set_fref, "reference contact force");

--- a/bindings/python/crocoddyl/multibody/costs/contact-friction-cone.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/contact-friction-cone.cpp
@@ -67,6 +67,10 @@ void exposeCostContactFrictionCone() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
+      .add_property("reference",
+                    bp::make_function(&CostModelContactFrictionCone::get_reference<FrameFrictionCone>,
+                                      bp::return_value_policy<bp::return_by_value>()),
+                    &CostModelContactFrictionCone::set_reference<FrameFrictionCone>, "reference frame friction cone")
       .add_property(
           "friction_cone",
           bp::make_function(&CostModelContactFrictionCone::get_friction_cone, bp::return_internal_reference<>()),

--- a/bindings/python/crocoddyl/multibody/costs/contact-friction-cone.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/contact-friction-cone.cpp
@@ -68,17 +68,8 @@ void exposeCostContactFrictionCone() {
            ":param data: shared data\n"
            ":return cost data.")
       .add_property("reference",
-                    bp::make_function(&CostModelContactFrictionCone::get_reference<FrameFrictionCone>,
-                                      bp::return_value_policy<bp::return_by_value>()),
-                    &CostModelContactFrictionCone::set_reference<FrameFrictionCone>, "reference frame friction cone")
-      .add_property(
-          "friction_cone",
-          bp::make_function(&CostModelContactFrictionCone::get_friction_cone, bp::return_internal_reference<>()),
-          &CostModelContactFrictionCone::set_friction_cone, "friction cone")
-      .add_property(
-          "frame",
-          bp::make_function(&CostModelContactFrictionCone::get_frame, bp::return_value_policy<bp::return_by_value>()),
-          &CostModelContactFrictionCone::set_frame, "frame index");
+                    bp::make_function(&CostModelContactFrictionCone::get_fref, bp::return_internal_reference<>()),
+                    &CostModelContactFrictionCone::set_reference<FrameFrictionCone>, "reference frame friction cone");
 
   bp::register_ptr_to_python<boost::shared_ptr<CostDataContactFrictionCone> >();
 

--- a/bindings/python/crocoddyl/multibody/costs/contact-friction-cone.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/contact-friction-cone.cpp
@@ -16,39 +16,35 @@ namespace python {
 void exposeCostContactFrictionCone() {
   bp::class_<CostModelContactFrictionCone, bp::bases<CostModelAbstract> >(
       "CostModelContactFrictionCone",
-      bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActivationModelAbstract>, FrictionCone, FrameIndex,
-               int>(bp::args("self", "state", "activation", "cone", "frame", "nu"),
-                    "Initialize the contact friction cone cost model.\n\n"
-                    ":param state: state of the multibody system\n"
-                    ":param activation: activation model\n"
-                    ":param cone: friction cone\n"
-                    ":param frame: frame index\n"
-                    ":param nu: dimension of control vector"))
-      .def(bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActivationModelAbstract>, FrictionCone,
-                    FrameIndex>(bp::args("self", "state", "activation", "cone", "frame"),
-                                "Initialize the contact force cost model.\n\n"
-                                "For this case the default nu is equals to model.nv.\n"
-                                ":param state: state of the multibody system\n"
-                                ":param activation: activation model\n"
-                                ":param cone: friction cone\n"
-                                ":param frame: frame index"))
-      .def(bp::init<boost::shared_ptr<StateMultibody>, FrictionCone, FrameIndex, int>(
-          bp::args("self", "state", "cone", "frame", "nu"),
+      bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActivationModelAbstract>, FrameFrictionCone, int>(
+          bp::args("self", "state", "activation", "fref", "nu"),
+          "Initialize the contact friction cone cost model.\n\n"
+          ":param state: state of the multibody system\n"
+          ":param activation: activation model\n"
+          ":param fref: frame friction cone\n"
+          ":param nu: dimension of control vector"))
+      .def(bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActivationModelAbstract>, FrameFrictionCone>(
+          bp::args("self", "state", "activation", "fref"),
+          "Initialize the contact force cost model.\n\n"
+          "For this case the default nu is equals to model.nv.\n"
+          ":param state: state of the multibody system\n"
+          ":param activation: activation model\n"
+          ":param fref: frame friction cone"))
+      .def(bp::init<boost::shared_ptr<StateMultibody>, FrameFrictionCone, int>(
+          bp::args("self", "state", "fref", "nu"),
           "Initialize the contact force cost model.\n\n"
           "For this case the default activation model is quadratic, i.e.\n"
           "crocoddyl.ActivationModelQuad(6).\n"
           ":param state: state of the multibody system\n"
-          ":param cone: friction cone\n"
-          ":param frame: frame index\n"
+          ":param fref: frame friction cone\n"
           ":param nu: dimension of control vector"))
-      .def(bp::init<boost::shared_ptr<StateMultibody>, FrictionCone, FrameIndex>(
-          bp::args("self", "state", "cone", "frame"),
+      .def(bp::init<boost::shared_ptr<StateMultibody>, FrameFrictionCone>(
+          bp::args("self", "state", "fref"),
           "Initialize the contact force cost model.\n\n"
           "For this case the default activation model is quadratic, i.e.\n"
           "crocoddyl.ActivationModelQuad(6), and nu is equals to model.nv.\n"
           ":param state: state of the multibody system\n"
-          ":param cone: friction cone\n"
-          ":param frame: frame index"))
+          ":param fref: frame friction cone"))
       .def("calc", &CostModelContactFrictionCone::calc_wrap,
            CostModel_calc_wraps(bp::args("self", "data", "x", "u"),
                                 "Compute the contact force cost.\n\n"

--- a/bindings/python/crocoddyl/multibody/costs/control.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/control.cpp
@@ -70,8 +70,7 @@ void exposeCostControl() {
 
       .def<void (CostModelControl::*)(const boost::shared_ptr<CostDataAbstract>&, const Eigen::VectorXd&)>(
           "calcDiff", &CostModelControl::calcDiff_wrap, bp::args("self", "data", "x"))
-      .add_property("reference",
-                    bp::make_function(&CostModelControl::get_uref, bp::return_internal_reference<>()),
+      .add_property("reference", bp::make_function(&CostModelControl::get_uref, bp::return_internal_reference<>()),
                     &CostModelControl::set_reference<Eigen::VectorXd>, "reference control vector")
       .add_property("uref", bp::make_function(&CostModelControl::get_uref, bp::return_internal_reference<>()),
                     &CostModelControl::set_uref, "reference control");

--- a/bindings/python/crocoddyl/multibody/costs/control.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/control.cpp
@@ -71,8 +71,7 @@ void exposeCostControl() {
       .def<void (CostModelControl::*)(const boost::shared_ptr<CostDataAbstract>&, const Eigen::VectorXd&)>(
           "calcDiff", &CostModelControl::calcDiff_wrap, bp::args("self", "data", "x"))
       .add_property("reference",
-                    bp::make_function(&CostModelControl::get_reference<Eigen::VectorXd>,
-                                      bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_function(&CostModelControl::get_uref, bp::return_value_policy<bp::return_by_value>()),
                     &CostModelControl::set_reference<Eigen::VectorXd>, "reference control vector")
       .add_property("uref",
                     bp::make_function(&CostModelControl::get_uref, bp::return_value_policy<bp::return_by_value>()),

--- a/bindings/python/crocoddyl/multibody/costs/control.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/control.cpp
@@ -70,6 +70,10 @@ void exposeCostControl() {
 
       .def<void (CostModelControl::*)(const boost::shared_ptr<CostDataAbstract>&, const Eigen::VectorXd&)>(
           "calcDiff", &CostModelControl::calcDiff_wrap, bp::args("self", "data", "x"))
+      .add_property("reference",
+                    bp::make_function(&CostModelControl::get_reference<Eigen::VectorXd>,
+                                      bp::return_value_policy<bp::return_by_value>()),
+                    &CostModelControl::set_reference<Eigen::VectorXd>, "reference control vector")
       .add_property("uref",
                     bp::make_function(&CostModelControl::get_uref, bp::return_value_policy<bp::return_by_value>()),
                     &CostModelControl::set_uref, "reference control");

--- a/bindings/python/crocoddyl/multibody/costs/frame-placement.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-placement.cpp
@@ -69,8 +69,7 @@ void exposeCostFramePlacement() {
            ":param data: shared data\n"
            ":return cost data.")
       .add_property("reference",
-                    bp::make_function(&CostModelFramePlacement::get_reference<FramePlacement>,
-                                      bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_function(&CostModelFramePlacement::get_Mref, bp::return_internal_reference<>()),
                     &CostModelFramePlacement::set_reference<FramePlacement>, "reference frame placement")
       .add_property("Mref", bp::make_function(&CostModelFramePlacement::get_Mref, bp::return_internal_reference<>()),
                     &CostModelFramePlacement::set_Mref, "reference frame placement");

--- a/bindings/python/crocoddyl/multibody/costs/frame-placement.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-placement.cpp
@@ -68,6 +68,10 @@ void exposeCostFramePlacement() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
+      .add_property("reference",
+                    bp::make_function(&CostModelFramePlacement::get_reference<FramePlacement>,
+                                      bp::return_value_policy<bp::return_by_value>()),
+                    &CostModelFramePlacement::set_reference<FramePlacement>, "reference frame placement")
       .add_property("Mref", bp::make_function(&CostModelFramePlacement::get_Mref, bp::return_internal_reference<>()),
                     &CostModelFramePlacement::set_Mref, "reference frame placement");
 

--- a/bindings/python/crocoddyl/multibody/costs/frame-rotation.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-rotation.cpp
@@ -67,6 +67,10 @@ void exposeCostFrameRotation() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
+      .add_property("reference",
+                    bp::make_function(&CostModelFrameRotation::get_reference<FrameRotation>,
+                                      bp::return_value_policy<bp::return_by_value>()),
+                    &CostModelFrameRotation::set_reference<FrameRotation>, "reference frame rotation")
       .add_property("Rref", bp::make_function(&CostModelFrameRotation::get_Rref, bp::return_internal_reference<>()),
                     &CostModelFrameRotation::set_Rref, "reference frame rotation");
 

--- a/bindings/python/crocoddyl/multibody/costs/frame-rotation.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-rotation.cpp
@@ -68,8 +68,7 @@ void exposeCostFrameRotation() {
            ":param data: shared data\n"
            ":return cost data.")
       .add_property("reference",
-                    bp::make_function(&CostModelFrameRotation::get_reference<FrameRotation>,
-                                      bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_function(&CostModelFrameRotation::get_Rref, bp::return_internal_reference<>()),
                     &CostModelFrameRotation::set_reference<FrameRotation>, "reference frame rotation")
       .add_property("Rref", bp::make_function(&CostModelFrameRotation::get_Rref, bp::return_internal_reference<>()),
                     &CostModelFrameRotation::set_Rref, "reference frame rotation");

--- a/bindings/python/crocoddyl/multibody/costs/frame-translation.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-translation.cpp
@@ -68,8 +68,7 @@ void exposeCostFrameTranslation() {
            ":param data: shared data\n"
            ":return cost data.")
       .add_property("reference",
-                    bp::make_function(&CostModelFrameTranslation::get_reference<FrameTranslation>,
-                                      bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_function(&CostModelFrameTranslation::get_xref, bp::return_internal_reference<>()),
                     &CostModelFrameTranslation::set_reference<FrameTranslation>, "reference frame translation")
       .add_property("xref", bp::make_function(&CostModelFrameTranslation::get_xref, bp::return_internal_reference<>()),
                     &CostModelFrameTranslation::set_xref, "reference frame translation");

--- a/bindings/python/crocoddyl/multibody/costs/frame-translation.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-translation.cpp
@@ -67,6 +67,10 @@ void exposeCostFrameTranslation() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
+      .add_property("reference",
+                    bp::make_function(&CostModelFrameTranslation::get_reference<FrameTranslation>,
+                                      bp::return_value_policy<bp::return_by_value>()),
+                    &CostModelFrameTranslation::set_reference<FrameTranslation>, "reference frame translation")
       .add_property("xref", bp::make_function(&CostModelFrameTranslation::get_xref, bp::return_internal_reference<>()),
                     &CostModelFrameTranslation::set_xref, "reference frame translation");
 

--- a/bindings/python/crocoddyl/multibody/costs/frame-velocity.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-velocity.cpp
@@ -68,8 +68,7 @@ void exposeCostFrameVelocity() {
            ":param data: shared data\n"
            ":return cost data.")
       .add_property("reference",
-                    bp::make_function(&CostModelFrameVelocity::get_reference<FrameMotion>,
-                                      bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_function(&CostModelFrameVelocity::get_vref, bp::return_internal_reference<>()),
                     &CostModelFrameVelocity::set_reference<FrameMotion>, "reference frame velocity")
       .add_property("vref", bp::make_function(&CostModelFrameVelocity::get_vref, bp::return_internal_reference<>()),
                     &CostModelFrameVelocity::set_vref, "reference frame velocity");

--- a/bindings/python/crocoddyl/multibody/costs/frame-velocity.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-velocity.cpp
@@ -67,6 +67,10 @@ void exposeCostFrameVelocity() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
+      .add_property("reference",
+                    bp::make_function(&CostModelFrameVelocity::get_reference<FrameMotion>,
+                                      bp::return_value_policy<bp::return_by_value>()),
+                    &CostModelFrameVelocity::set_reference<FrameMotion>, "reference frame velocity")
       .add_property("vref", bp::make_function(&CostModelFrameVelocity::get_vref, bp::return_internal_reference<>()),
                     &CostModelFrameVelocity::set_vref, "reference frame velocity");
 

--- a/bindings/python/crocoddyl/multibody/costs/state.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/state.cpp
@@ -85,16 +85,20 @@ void exposeCostState() {
                                                              ":param u: time-discrete control input\n")
       .def<void (CostModelState::*)(const boost::shared_ptr<CostDataAbstract>&, const Eigen::VectorXd&)>(
           "calcDiff", &CostModelState::calcDiff_wrap, bp::args("self", "data", "x"))
-      .add_property("xref",
-                    bp::make_function(&CostModelState::get_xref, bp::return_value_policy<bp::return_by_value>()),
-                    "reference state")
       .def("createData", &CostModelState::createData, bp::with_custodian_and_ward_postcall<0, 2>(),
            bp::args("self", "data"),
            "Create the state cost data.\n\n"
            "Each cost model has its own data that needs to be allocated. This function\n"
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
-           ":return cost data.");
+           ":return cost data.")
+      .add_property("reference",
+                    bp::make_function(&CostModelState::get_reference<Eigen::VectorXd>,
+                                      bp::return_value_policy<bp::return_by_value>()),
+                    &CostModelState::set_reference<Eigen::VectorXd>, "reference state")
+      .add_property("xref",
+                    bp::make_function(&CostModelState::get_xref, bp::return_value_policy<bp::return_by_value>()),
+                    "reference state");
 }
 
 }  // namespace python

--- a/bindings/python/crocoddyl/multibody/costs/state.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/state.cpp
@@ -92,11 +92,9 @@ void exposeCostState() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
-      .add_property("reference",
-                    bp::make_function(&CostModelState::get_xref, bp::return_internal_reference<>()),
+      .add_property("reference", bp::make_function(&CostModelState::get_xref, bp::return_internal_reference<>()),
                     &CostModelState::set_reference<Eigen::VectorXd>, "reference state")
-      .add_property("xref",
-                    bp::make_function(&CostModelState::get_xref, bp::return_internal_reference<>()),
+      .add_property("xref", bp::make_function(&CostModelState::get_xref, bp::return_internal_reference<>()),
                     "reference state");
 }
 

--- a/bindings/python/crocoddyl/multibody/costs/state.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/state.cpp
@@ -93,8 +93,7 @@ void exposeCostState() {
            ":param data: shared data\n"
            ":return cost data.")
       .add_property("reference",
-                    bp::make_function(&CostModelState::get_reference<Eigen::VectorXd>,
-                                      bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_function(&CostModelState::get_xref, bp::return_value_policy<bp::return_by_value>()),
                     &CostModelState::set_reference<Eigen::VectorXd>, "reference state")
       .add_property("xref",
                     bp::make_function(&CostModelState::get_xref, bp::return_value_policy<bp::return_by_value>()),

--- a/bindings/python/crocoddyl/multibody/frames.cpp
+++ b/bindings/python/crocoddyl/multibody/frames.cpp
@@ -32,7 +32,7 @@ void exposeFrames() {
       "Frame rotation describe using Pinocchio.\n\n"
       "It defines a frame rotation (rotation matrix) for a given frame ID",
       bp::init<FrameIndex, Eigen::Matrix3d>(bp::args("self", "frame", "oRf"),
-                                            "Initialize the frame translation.\n\n"
+                                            "Initialize the frame rotation.\n\n"
                                             ":param frame: frame ID\n"
                                             ":param oRf: Frame rotation w.r.t. the origin"))
       .def_readwrite("frame", &FrameRotation::frame, "frame ID")
@@ -69,7 +69,7 @@ void exposeFrames() {
       "Frame force describe using Pinocchio.\n\n"
       "It defines a frame motion (tangent of SE(3) point) for a given frame ID",
       bp::init<FrameIndex, pinocchio::Force>(bp::args("self", "frame", "oFf"),
-                                             "Initialize the frame motion.\n\n"
+                                             "Initialize the frame force.\n\n"
                                              ":param frame: frame ID\n"
                                              ":param oFf: Frame force w.r.t. the origin"))
       .def_readwrite("frame", &FrameForce::frame, "frame ID")

--- a/bindings/python/crocoddyl/multibody/frames.cpp
+++ b/bindings/python/crocoddyl/multibody/frames.cpp
@@ -22,6 +22,7 @@ void exposeFrames() {
                                             "Initialize the frame translation.\n\n"
                                             ":param frame: frame ID\n"
                                             ":param oxf: Frame translation w.r.t. the origin"))
+      .def(bp::init<>(bp::args("self"), "Default initialization of the frame translation."))
       .def_readwrite("frame", &FrameTranslation::frame, "frame ID")
       .add_property("oxf", bp::make_getter(&FrameTranslation::oxf, bp::return_value_policy<bp::return_by_value>()),
                     bp::make_setter(&FrameTranslation::oxf), "frame translation")
@@ -35,6 +36,7 @@ void exposeFrames() {
                                             "Initialize the frame rotation.\n\n"
                                             ":param frame: frame ID\n"
                                             ":param oRf: Frame rotation w.r.t. the origin"))
+      .def(bp::init<>(bp::args("self"), "Default initialization of the frame rotation."))
       .def_readwrite("frame", &FrameRotation::frame, "frame ID")
       .add_property("oRf", bp::make_getter(&FrameRotation::oRf, bp::return_value_policy<bp::return_by_value>()),
                     bp::make_setter(&FrameRotation::oRf), "frame rotation")
@@ -48,6 +50,7 @@ void exposeFrames() {
                                            "Initialize the frame placement.\n\n"
                                            ":param frame: frame ID\n"
                                            ":param oMf: Frame placement w.r.t. the origin"))
+      .def(bp::init<>(bp::args("self"), "Default initialization of the frame placement."))
       .def_readwrite("frame", &FramePlacement::frame, "frame ID")
       .add_property("oMf", bp::make_getter(&FramePlacement::oMf, bp::return_internal_reference<>()), "frame placement")
       .def(PrintableVisitor<FramePlacement>());
@@ -60,6 +63,7 @@ void exposeFrames() {
                                               "Initialize the frame motion.\n\n"
                                               ":param frame: frame ID\n"
                                               ":param oMf: Frame motion w.r.t. the origin"))
+      .def(bp::init<>(bp::args("self"), "Default initialization of the frame motion."))
       .def_readwrite("frame", &FrameMotion::frame, "frame ID")
       .add_property("oMf", bp::make_getter(&FrameMotion::oMf, bp::return_internal_reference<>()), "frame motion")
       .def(PrintableVisitor<FrameMotion>());
@@ -72,6 +76,7 @@ void exposeFrames() {
                                              "Initialize the frame force.\n\n"
                                              ":param frame: frame ID\n"
                                              ":param oFf: Frame force w.r.t. the origin"))
+      .def(bp::init<>(bp::args("self"), "Default initialization of the frame force."))
       .def_readwrite("frame", &FrameForce::frame, "frame ID")
       .add_property("oFf", bp::make_getter(&FrameForce::oFf, bp::return_internal_reference<>()), "frame force")
       .def(PrintableVisitor<FrameForce>());

--- a/bindings/python/crocoddyl/multibody/frames.cpp
+++ b/bindings/python/crocoddyl/multibody/frames.cpp
@@ -28,54 +28,50 @@ void exposeFrames() {
                     bp::make_setter(&FrameTranslation::oxf), "frame translation")
       .def(PrintableVisitor<FrameTranslation>());
 
-  bp::class_<FrameRotation>(
-      "FrameRotation",
-      "Frame rotation describe using Pinocchio.\n\n"
-      "It defines a frame rotation (rotation matrix) for a given frame ID",
-      bp::init<FrameIndex, Eigen::Matrix3d>(bp::args("self", "frame", "oRf"),
-                                            "Initialize the frame rotation.\n\n"
-                                            ":param frame: frame ID\n"
-                                            ":param oRf: Frame rotation w.r.t. the origin"))
+  bp::class_<FrameRotation>("FrameRotation",
+                            "Frame rotation describe using Pinocchio.\n\n"
+                            "It defines a frame rotation (rotation matrix) for a given frame ID",
+                            bp::init<FrameIndex, Eigen::Matrix3d>(bp::args("self", "frame", "oRf"),
+                                                                  "Initialize the frame rotation.\n\n"
+                                                                  ":param frame: frame ID\n"
+                                                                  ":param oRf: Frame rotation w.r.t. the origin"))
       .def(bp::init<>(bp::args("self"), "Default initialization of the frame rotation."))
       .def_readwrite("frame", &FrameRotation::frame, "frame ID")
       .add_property("oRf", bp::make_getter(&FrameRotation::oRf, bp::return_value_policy<bp::return_by_value>()),
                     bp::make_setter(&FrameRotation::oRf), "frame rotation")
       .def(PrintableVisitor<FrameRotation>());
 
-  bp::class_<FramePlacement>(
-      "FramePlacement",
-      "Frame placement describe using Pinocchio.\n\n"
-      "It defines a frame placement (SE(3) point) for a given frame ID",
-      bp::init<FrameIndex, pinocchio::SE3>(bp::args("self", "frame", "oMf"),
-                                           "Initialize the frame placement.\n\n"
-                                           ":param frame: frame ID\n"
-                                           ":param oMf: Frame placement w.r.t. the origin"))
+  bp::class_<FramePlacement>("FramePlacement",
+                             "Frame placement describe using Pinocchio.\n\n"
+                             "It defines a frame placement (SE(3) point) for a given frame ID",
+                             bp::init<FrameIndex, pinocchio::SE3>(bp::args("self", "frame", "oMf"),
+                                                                  "Initialize the frame placement.\n\n"
+                                                                  ":param frame: frame ID\n"
+                                                                  ":param oMf: Frame placement w.r.t. the origin"))
       .def(bp::init<>(bp::args("self"), "Default initialization of the frame placement."))
       .def_readwrite("frame", &FramePlacement::frame, "frame ID")
       .add_property("oMf", bp::make_getter(&FramePlacement::oMf, bp::return_internal_reference<>()), "frame placement")
       .def(PrintableVisitor<FramePlacement>());
 
-  bp::class_<FrameMotion>(
-      "FrameMotion",
-      "Frame motion describe using Pinocchio.\n\n"
-      "It defines a frame motion (tangent of SE(3) point) for a given frame ID",
-      bp::init<FrameIndex, pinocchio::Motion>(bp::args("self", "frame", "oMf"),
-                                              "Initialize the frame motion.\n\n"
-                                              ":param frame: frame ID\n"
-                                              ":param oMf: Frame motion w.r.t. the origin"))
+  bp::class_<FrameMotion>("FrameMotion",
+                          "Frame motion describe using Pinocchio.\n\n"
+                          "It defines a frame motion (tangent of SE(3) point) for a given frame ID",
+                          bp::init<FrameIndex, pinocchio::Motion>(bp::args("self", "frame", "oMf"),
+                                                                  "Initialize the frame motion.\n\n"
+                                                                  ":param frame: frame ID\n"
+                                                                  ":param oMf: Frame motion w.r.t. the origin"))
       .def(bp::init<>(bp::args("self"), "Default initialization of the frame motion."))
       .def_readwrite("frame", &FrameMotion::frame, "frame ID")
       .add_property("oMf", bp::make_getter(&FrameMotion::oMf, bp::return_internal_reference<>()), "frame motion")
       .def(PrintableVisitor<FrameMotion>());
 
-  bp::class_<FrameForce>(
-      "FrameForce",
-      "Frame force describe using Pinocchio.\n\n"
-      "It defines a frame motion (tangent of SE(3) point) for a given frame ID",
-      bp::init<FrameIndex, pinocchio::Force>(bp::args("self", "frame", "oFf"),
-                                             "Initialize the frame force.\n\n"
-                                             ":param frame: frame ID\n"
-                                             ":param oFf: Frame force w.r.t. the origin"))
+  bp::class_<FrameForce>("FrameForce",
+                         "Frame force describe using Pinocchio.\n\n"
+                         "It defines a frame force for a given frame ID",
+                         bp::init<FrameIndex, pinocchio::Force>(bp::args("self", "frame", "oFf"),
+                                                                "Initialize the frame force.\n\n"
+                                                                ":param frame: frame ID\n"
+                                                                ":param oFf: Frame force w.r.t. the origin"))
       .def(bp::init<>(bp::args("self"), "Default initialization of the frame force."))
       .def_readwrite("frame", &FrameForce::frame, "frame ID")
       .add_property("oFf", bp::make_getter(&FrameForce::oFf, bp::return_internal_reference<>()), "frame force")

--- a/bindings/python/crocoddyl/multibody/frames.cpp
+++ b/bindings/python/crocoddyl/multibody/frames.cpp
@@ -80,6 +80,20 @@ void exposeFrames() {
       .def_readwrite("frame", &FrameForce::frame, "frame ID")
       .add_property("oFf", bp::make_getter(&FrameForce::oFf, bp::return_internal_reference<>()), "frame force")
       .def(PrintableVisitor<FrameForce>());
+
+  bp::class_<FrameFrictionCone>(
+      "FrameFrictionCone",
+      "Frame friction cone.\n\n"
+      "It defines a friction cone for a given frame ID",
+      bp::init<FrameIndex, FrictionCone>(bp::args("self", "frame", "oRf"),
+                                         "Initialize the frame friction cone.\n\n"
+                                         ":param frame: frame ID\n"
+                                         ":param oRf: Frame friction cone w.r.t. the origin"))
+      .def(bp::init<>(bp::args("self"), "Default initialization of the frame friction cone."))
+      .def_readwrite("frame", &FrameFrictionCone::frame, "frame ID")
+      .add_property("oRf", bp::make_getter(&FrameFrictionCone::oRf, bp::return_internal_reference<>()),
+                    "frame friction cone")
+      .def(PrintableVisitor<FrameFrictionCone>());
 }
 
 }  // namespace python

--- a/bindings/python/crocoddyl/multibody/frames.cpp
+++ b/bindings/python/crocoddyl/multibody/frames.cpp
@@ -14,7 +14,7 @@ namespace crocoddyl {
 namespace python {
 
 void exposeFrames() {
-  bp::class_<FrameTranslation, boost::noncopyable>(
+  bp::class_<FrameTranslation>(
       "FrameTranslation",
       "Frame translation describe using Pinocchio.\n\n"
       "It defines a frame translation (3D vector) for a given frame ID",
@@ -27,7 +27,7 @@ void exposeFrames() {
                     bp::make_setter(&FrameTranslation::oxf), "frame translation")
       .def(PrintableVisitor<FrameTranslation>());
 
-  bp::class_<FrameRotation, boost::noncopyable>(
+  bp::class_<FrameRotation>(
       "FrameRotation",
       "Frame rotation describe using Pinocchio.\n\n"
       "It defines a frame rotation (rotation matrix) for a given frame ID",
@@ -40,7 +40,7 @@ void exposeFrames() {
                     bp::make_setter(&FrameRotation::oRf), "frame rotation")
       .def(PrintableVisitor<FrameRotation>());
 
-  bp::class_<FramePlacement, boost::noncopyable>(
+  bp::class_<FramePlacement>(
       "FramePlacement",
       "Frame placement describe using Pinocchio.\n\n"
       "It defines a frame placement (SE(3) point) for a given frame ID",
@@ -52,7 +52,7 @@ void exposeFrames() {
       .add_property("oMf", bp::make_getter(&FramePlacement::oMf, bp::return_internal_reference<>()), "frame placement")
       .def(PrintableVisitor<FramePlacement>());
 
-  bp::class_<FrameMotion, boost::noncopyable>(
+  bp::class_<FrameMotion>(
       "FrameMotion",
       "Frame motion describe using Pinocchio.\n\n"
       "It defines a frame motion (tangent of SE(3) point) for a given frame ID",
@@ -64,7 +64,7 @@ void exposeFrames() {
       .add_property("oMf", bp::make_getter(&FrameMotion::oMf, bp::return_internal_reference<>()), "frame motion")
       .def(PrintableVisitor<FrameMotion>());
 
-  bp::class_<FrameForce, boost::noncopyable>(
+  bp::class_<FrameForce>(
       "FrameForce",
       "Frame force describe using Pinocchio.\n\n"
       "It defines a frame motion (tangent of SE(3) point) for a given frame ID",

--- a/bindings/python/crocoddyl/multibody/friction-cone.cpp
+++ b/bindings/python/crocoddyl/multibody/friction-cone.cpp
@@ -13,7 +13,7 @@ namespace crocoddyl {
 namespace python {
 
 void exposeFrictionCone() {
-  bp::class_<FrictionCone, boost::noncopyable>(
+  bp::class_<FrictionCone>(
       "FrictionCone", "Model of the friction cone as lb <= Af <= ub",
       bp::init<Eigen::Vector3d, double, bp::optional<std::size_t, bool, double, double> >(
           bp::args("self", "normal", "mu", "nf", "inner_appr", "min_nforce", "max_nforce"),

--- a/bindings/python/crocoddyl/multibody/friction-cone.cpp
+++ b/bindings/python/crocoddyl/multibody/friction-cone.cpp
@@ -13,17 +13,17 @@ namespace crocoddyl {
 namespace python {
 
 void exposeFrictionCone() {
-  bp::class_<FrictionCone>(
-      "FrictionCone", "Model of the friction cone as lb <= Af <= ub",
-      bp::init<Eigen::Vector3d, double, bp::optional<std::size_t, bool, double, double> >(
-          bp::args("self", "normal", "mu", "nf", "inner_appr", "min_nforce", "max_nforce"),
-          "Initialize the linearize friction cone.\n\n"
-          ":param normal: normal vector that defines the cone orientation\n"
-          ":param mu: friction coefficient\n"
-          ":param nf: number of facets\n"
-          ":param inner_appr: inner or outer approximation (default True)\n"
-          ":param min_nforce: minimum normal force (default 0.)\n"
-          ":param max_nforce: maximum normal force (default sys.float_info.max)\n"))
+  bp::class_<FrictionCone>("FrictionCone", "Model of the friction cone as lb <= Af <= ub",
+                           bp::init<Eigen::Vector3d, double, bp::optional<std::size_t, bool, double, double> >(
+                               bp::args("self", "normal", "mu", "nf", "inner_appr", "min_nforce", "max_nforce"),
+                               "Initialize the linearize friction cone.\n\n"
+                               ":param normal: normal vector that defines the cone orientation\n"
+                               ":param mu: friction coefficient\n"
+                               ":param nf: number of facets\n"
+                               ":param inner_appr: inner or outer approximation (default True)\n"
+                               ":param min_nforce: minimum normal force (default 0.)\n"
+                               ":param max_nforce: maximum normal force (default sys.float_info.max)\n"))
+      .def(bp::init<>(bp::args("self"), "Default initialization of the friction cone."))
       .def("update", &FrictionCone::update, bp::args("self", "normal", "mu", "inner_appr", "min_nforce", "max_nforce"),
            "Update the linear inequality (matrix and bounds).\n\n"
            ":param normal: normal vector that defines the cone orientation\n"

--- a/bindings/python/crocoddyl/utils/biped.py
+++ b/bindings/python/crocoddyl/utils/biped.py
@@ -194,7 +194,7 @@ class SimpleBipedGaitProblem:
             cone = crocoddyl.FrictionCone(self.nsurf, self.mu, 4, False)
             frictionCone = crocoddyl.CostModelContactFrictionCone(
                 self.state, crocoddyl.ActivationModelQuadraticBarrier(crocoddyl.ActivationBounds(cone.lb, cone.ub)),
-                cone, i, self.actuation.nu)
+                crocoddyl.FrameFrictionCone(i, cone), self.actuation.nu)
             costModel.addCost(self.rmodel.frames[i].name + "_frictionCone", frictionCone, 1e1)
         if swingFootTask is not None:
             for i in swingFootTask:
@@ -252,7 +252,7 @@ class SimpleBipedGaitProblem:
             cone = crocoddyl.FrictionCone(self.nsurf, self.mu, 4, False)
             frictionCone = crocoddyl.CostModelContactFrictionCone(
                 self.state, crocoddyl.ActivationModelQuadraticBarrier(crocoddyl.ActivationBounds(cone.lb, cone.ub)),
-                cone, i, self.actuation.nu)
+                crocoddyl.FrameFrictionCone(i, cone), self.actuation.nu)
             costModel.addCost(self.rmodel.frames[i].name + "_frictionCone", frictionCone, 1e1)
         if swingFootTask is not None:
             for i in swingFootTask:

--- a/bindings/python/crocoddyl/utils/quadruped.py
+++ b/bindings/python/crocoddyl/utils/quadruped.py
@@ -430,7 +430,7 @@ class SimpleQuadrupedalGaitProblem:
             cone = crocoddyl.FrictionCone(self.nsurf, self.mu, 4, False)
             frictionCone = crocoddyl.CostModelContactFrictionCone(
                 self.state, crocoddyl.ActivationModelQuadraticBarrier(crocoddyl.ActivationBounds(cone.lb, cone.ub)),
-                cone, i, self.actuation.nu)
+                crocoddyl.FrameFrictionCone(i, cone), self.actuation.nu)
             costModel.addCost(self.rmodel.frames[i].name + "_frictionCone", frictionCone, 1e1)
         if swingFootTask is not None:
             for i in swingFootTask:
@@ -496,7 +496,7 @@ class SimpleQuadrupedalGaitProblem:
             cone = crocoddyl.FrictionCone(self.nsurf, self.mu, 4, False)
             frictionCone = crocoddyl.CostModelContactFrictionCone(
                 self.state, crocoddyl.ActivationModelQuadraticBarrier(crocoddyl.ActivationBounds(cone.lb, cone.ub)),
-                cone, i, self.actuation.nu)
+                crocoddyl.FrameFrictionCone(i, cone), self.actuation.nu)
             costModel.addCost(self.rmodel.frames[i].name + "_frictionCone", frictionCone, 1e1)
         if swingFootTask is not None:
             for i in swingFootTask:

--- a/include/crocoddyl/multibody/cost-base.hpp
+++ b/include/crocoddyl/multibody/cost-base.hpp
@@ -58,13 +58,14 @@ class CostModelAbstractTpl {
 
   template <class T>
   void set_reference(T ref);
-  virtual void set_referenceImpl(const std::type_info&, const void*);
 
   template <class T>
   T get_reference();
-  virtual void get_referenceImpl(const std::type_info&, void*);
 
  protected:
+  virtual void set_referenceImpl(const std::type_info&, const void*);
+  virtual void get_referenceImpl(const std::type_info&, void*);
+
   boost::shared_ptr<StateMultibody> state_;
   boost::shared_ptr<ActivationModelAbstract> activation_;
   std::size_t nu_;

--- a/include/crocoddyl/multibody/cost-base.hpp
+++ b/include/crocoddyl/multibody/cost-base.hpp
@@ -60,7 +60,7 @@ class CostModelAbstractTpl {
   void set_reference(T ref);
 
   template <class T>
-  T get_reference();
+  void get_reference(T& ref);
 
  protected:
   virtual void set_referenceImpl(const std::type_info&, const void*);

--- a/include/crocoddyl/multibody/cost-base.hpp
+++ b/include/crocoddyl/multibody/cost-base.hpp
@@ -56,6 +56,14 @@ class CostModelAbstractTpl {
   const boost::shared_ptr<ActivationModelAbstract>& get_activation() const;
   const std::size_t& get_nu() const;
 
+  template <class T>
+  void set_reference(T ref);
+  virtual void set_referenceImpl(const std::type_info&, const void*);
+
+  template <class T>
+  T get_reference();
+  virtual void get_referenceImpl(const std::type_info&, void*);
+
  protected:
   boost::shared_ptr<StateMultibody> state_;
   boost::shared_ptr<ActivationModelAbstract> activation_;

--- a/include/crocoddyl/multibody/cost-base.hxx
+++ b/include/crocoddyl/multibody/cost-base.hxx
@@ -67,4 +67,28 @@ const std::size_t& CostModelAbstractTpl<Scalar>::get_nu() const {
   return nu_;
 }
 
+template <typename Scalar>
+template <class T>
+void CostModelAbstractTpl<Scalar>::set_reference(T ref) {
+  set_referenceImpl(typeid(ref), &ref);
+}
+
+template <typename Scalar>
+void CostModelAbstractTpl<Scalar>::set_referenceImpl(const std::type_info&, const void*) {
+  throw_pretty("It has not been implemented the set_referenceImpl() function");
+}
+
+template <typename Scalar>
+template <class T>
+T CostModelAbstractTpl<Scalar>::get_reference() {
+  T ref;
+  get_referenceImpl(typeid(ref), &ref);
+  return ref;
+}
+
+template <typename Scalar>
+void CostModelAbstractTpl<Scalar>::get_referenceImpl(const std::type_info&, void*) {
+  throw_pretty("It has not been implemented the set_referenceImpl() function");
+}
+
 }  // namespace crocoddyl

--- a/include/crocoddyl/multibody/cost-base.hxx
+++ b/include/crocoddyl/multibody/cost-base.hxx
@@ -80,10 +80,8 @@ void CostModelAbstractTpl<Scalar>::set_referenceImpl(const std::type_info&, cons
 
 template <typename Scalar>
 template <class T>
-T CostModelAbstractTpl<Scalar>::get_reference() {
-  T ref;
+void CostModelAbstractTpl<Scalar>::get_reference(T& ref) {
   get_referenceImpl(typeid(ref), &ref);
-  return ref;
 }
 
 template <typename Scalar>

--- a/include/crocoddyl/multibody/costs/centroidal-momentum.hpp
+++ b/include/crocoddyl/multibody/costs/centroidal-momentum.hpp
@@ -49,6 +49,9 @@ class CostModelCentroidalMomentumTpl : public CostModelAbstractTpl<_Scalar> {
                         const Eigen::Ref<const VectorXs>& u);
   virtual boost::shared_ptr<CostDataAbstract> createData(DataCollectorAbstract* const data);
 
+  virtual void set_referenceImpl(const std::type_info& ti, const void* pv);
+  virtual void get_referenceImpl(const std::type_info& ti, void* pv);
+
   const Vector6s& get_href() const;
   void set_href(const Vector6s& mref_in);
 

--- a/include/crocoddyl/multibody/costs/centroidal-momentum.hxx
+++ b/include/crocoddyl/multibody/costs/centroidal-momentum.hxx
@@ -95,8 +95,7 @@ void CostModelCentroidalMomentumTpl<Scalar>::set_referenceImpl(const std::type_i
   if (ti == typeid(Vector6s)) {
     href_ = *static_cast<const Vector6s*>(pv);
   } else {
-    throw_pretty("Invalid argument: "
-                 << "incorrect type (it should be Vector6s)");
+    throw_pretty("Invalid argument: incorrect type (it should be Vector6s)");
   }
 }
 
@@ -111,8 +110,7 @@ void CostModelCentroidalMomentumTpl<Scalar>::get_referenceImpl(const std::type_i
     ref_map[4] = href_[4];
     ref_map[5] = href_[5];
   } else {
-    throw_pretty("Invalid argument: "
-                 << "incorrect type (it should be Vector6s)");
+    throw_pretty("Invalid argument: incorrect type (it should be Vector6s)");
   }
 }
 

--- a/include/crocoddyl/multibody/costs/centroidal-momentum.hxx
+++ b/include/crocoddyl/multibody/costs/centroidal-momentum.hxx
@@ -89,6 +89,33 @@ boost::shared_ptr<CostDataAbstractTpl<Scalar> > CostModelCentroidalMomentumTpl<S
     DataCollectorAbstract* const data) {
   return boost::make_shared<CostDataCentroidalMomentumTpl<Scalar> >(this, data);
 }
+
+template <typename Scalar>
+void CostModelCentroidalMomentumTpl<Scalar>::set_referenceImpl(const std::type_info& ti, const void* pv) {
+  if (ti == typeid(Vector6s)) {
+    href_ = *static_cast<const Vector6s*>(pv);
+  } else {
+    throw_pretty("Invalid argument: "
+                 << "incorrect type (it should be Vector6s)");
+  }
+}
+
+template <typename Scalar>
+void CostModelCentroidalMomentumTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) {
+  if (ti == typeid(Vector6s)) {
+    Eigen::Map<Vector6s> ref_map(static_cast<Vector6s*>(pv)->data());
+    ref_map[0] = href_[0];
+    ref_map[1] = href_[1];
+    ref_map[2] = href_[2];
+    ref_map[3] = href_[3];
+    ref_map[4] = href_[4];
+    ref_map[5] = href_[5];
+  } else {
+    throw_pretty("Invalid argument: "
+                 << "incorrect type (it should be Vector6s)");
+  }
+}
+
 template <typename Scalar>
 const typename MathBaseTpl<Scalar>::Vector6s& CostModelCentroidalMomentumTpl<Scalar>::get_href() const {
   return href_;

--- a/include/crocoddyl/multibody/costs/com-position.hpp
+++ b/include/crocoddyl/multibody/costs/com-position.hpp
@@ -52,6 +52,9 @@ class CostModelCoMPositionTpl : public CostModelAbstractTpl<_Scalar> {
   void set_cref(const Vector3s& cref_in);
 
  protected:
+  virtual void set_referenceImpl(const std::type_info& ti, const void* pv);
+  virtual void get_referenceImpl(const std::type_info& ti, void* pv);
+
   using Base::activation_;
   using Base::nu_;
   using Base::state_;

--- a/include/crocoddyl/multibody/costs/com-position.hxx
+++ b/include/crocoddyl/multibody/costs/com-position.hxx
@@ -82,8 +82,7 @@ void CostModelCoMPositionTpl<Scalar>::set_referenceImpl(const std::type_info& ti
   if (ti == typeid(Vector3s)) {
     cref_ = *static_cast<const Vector3s*>(pv);
   } else {
-    throw_pretty("Invalid argument: "
-                 << "incorrect type (it should be Vector3s)");
+    throw_pretty("Invalid argument: incorrect type (it should be Vector3s)");
   }
 }
 
@@ -95,8 +94,7 @@ void CostModelCoMPositionTpl<Scalar>::get_referenceImpl(const std::type_info& ti
     ref_map[1] = cref_[1];
     ref_map[2] = cref_[2];
   } else {
-    throw_pretty("Invalid argument: "
-                 << "incorrect type (it should be Vector3s)");
+    throw_pretty("Invalid argument: incorrect type (it should be Vector3s)");
   }
 }
 

--- a/include/crocoddyl/multibody/costs/com-position.hxx
+++ b/include/crocoddyl/multibody/costs/com-position.hxx
@@ -78,6 +78,29 @@ boost::shared_ptr<CostDataAbstractTpl<Scalar> > CostModelCoMPositionTpl<Scalar>:
 }
 
 template <typename Scalar>
+void CostModelCoMPositionTpl<Scalar>::set_referenceImpl(const std::type_info& ti, const void* pv) {
+  if (ti == typeid(Vector3s)) {
+    cref_ = *static_cast<const Vector3s*>(pv);
+  } else {
+    throw_pretty("Invalid argument: "
+                 << "incorrect type (it should be Vector3s)");
+  }
+}
+
+template <typename Scalar>
+void CostModelCoMPositionTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) {
+  if (ti == typeid(Vector3s)) {
+    Eigen::Map<Vector3s> ref_map(static_cast<Vector3s*>(pv)->data());
+    ref_map[0] = cref_[0];
+    ref_map[1] = cref_[1];
+    ref_map[2] = cref_[2];
+  } else {
+    throw_pretty("Invalid argument: "
+                 << "incorrect type (it should be Vector3s)");
+  }
+}
+
+template <typename Scalar>
 const typename MathBaseTpl<Scalar>::Vector3s& CostModelCoMPositionTpl<Scalar>::get_cref() const {
   return cref_;
 }

--- a/include/crocoddyl/multibody/costs/contact-force.hpp
+++ b/include/crocoddyl/multibody/costs/contact-force.hpp
@@ -55,6 +55,9 @@ class CostModelContactForceTpl : public CostModelAbstractTpl<_Scalar> {
   void set_fref(const FrameForce& fref);
 
  protected:
+  virtual void set_referenceImpl(const std::type_info& ti, const void* pv);
+  virtual void get_referenceImpl(const std::type_info& ti, void* pv);
+
   using Base::activation_;
   using Base::nu_;
   using Base::state_;

--- a/include/crocoddyl/multibody/costs/contact-force.hxx
+++ b/include/crocoddyl/multibody/costs/contact-force.hxx
@@ -88,6 +88,27 @@ boost::shared_ptr<CostDataAbstractTpl<Scalar> > CostModelContactForceTpl<Scalar>
 }
 
 template <typename Scalar>
+void CostModelContactForceTpl<Scalar>::set_referenceImpl(const std::type_info& ti, const void* pv) {
+  if (ti == typeid(FrameForce)) {
+    fref_ = *static_cast<const FrameForce*>(pv);
+  } else {
+    throw_pretty("Invalid argument: "
+                 << "incorrect type (it should be FrameForce)");
+  }
+}
+
+template <typename Scalar>
+void CostModelContactForceTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) {
+  if (ti == typeid(FrameForce)) {
+    FrameForce& ref_map = *static_cast<FrameForce*>(pv);
+    ref_map = fref_;
+  } else {
+    throw_pretty("Invalid argument: "
+                 << "incorrect type (it should be FrameForce)");
+  }
+}
+
+template <typename Scalar>
 const FrameForceTpl<Scalar>& CostModelContactForceTpl<Scalar>::get_fref() const {
   return fref_;
 }

--- a/include/crocoddyl/multibody/costs/contact-force.hxx
+++ b/include/crocoddyl/multibody/costs/contact-force.hxx
@@ -92,8 +92,7 @@ void CostModelContactForceTpl<Scalar>::set_referenceImpl(const std::type_info& t
   if (ti == typeid(FrameForce)) {
     fref_ = *static_cast<const FrameForce*>(pv);
   } else {
-    throw_pretty("Invalid argument: "
-                 << "incorrect type (it should be FrameForce)");
+    throw_pretty("Invalid argument: incorrect type (it should be FrameForce)");
   }
 }
 
@@ -103,8 +102,7 @@ void CostModelContactForceTpl<Scalar>::get_referenceImpl(const std::type_info& t
     FrameForce& ref_map = *static_cast<FrameForce*>(pv);
     ref_map = fref_;
   } else {
-    throw_pretty("Invalid argument: "
-                 << "incorrect type (it should be FrameForce)");
+    throw_pretty("Invalid argument: incorrect type (it should be FrameForce)");
   }
 }
 

--- a/include/crocoddyl/multibody/costs/contact-friction-cone.hpp
+++ b/include/crocoddyl/multibody/costs/contact-friction-cone.hpp
@@ -36,21 +36,21 @@ class CostModelContactFrictionConeTpl : public CostModelAbstractTpl<_Scalar> {
   typedef DataCollectorAbstractTpl<Scalar> DataCollectorAbstract;
   typedef FrameForceTpl<Scalar> FrameForce;
   typedef FrictionConeTpl<Scalar> FrictionCone;
+  typedef FrameFrictionConeTpl<Scalar> FrameFrictionCone;
   typedef typename MathBase::Vector6s Vector6s;
   typedef typename MathBase::VectorXs VectorXs;
   typedef typename MathBase::MatrixXs MatrixXs;
   typedef typename MathBase::MatrixX3s MatrixX3s;
 
   CostModelContactFrictionConeTpl(boost::shared_ptr<StateMultibody> state,
-                                  boost::shared_ptr<ActivationModelAbstract> activation, const FrictionCone& cone,
-                                  const FrameIndex& frame, const std::size_t& nu);
+                                  boost::shared_ptr<ActivationModelAbstract> activation, const FrameFrictionCone& fref,
+                                  const std::size_t& nu);
   CostModelContactFrictionConeTpl(boost::shared_ptr<StateMultibody> state,
-                                  boost::shared_ptr<ActivationModelAbstract> activation, const FrictionCone& cone,
-                                  const FrameIndex& frame);
-  CostModelContactFrictionConeTpl(boost::shared_ptr<StateMultibody> state, const FrictionCone& cone,
-                                  const FrameIndex& frame, const std::size_t& nu);
-  CostModelContactFrictionConeTpl(boost::shared_ptr<StateMultibody> state, const FrictionCone& cone,
-                                  const FrameIndex& frame);
+                                  boost::shared_ptr<ActivationModelAbstract> activation,
+                                  const FrameFrictionCone& fref);
+  CostModelContactFrictionConeTpl(boost::shared_ptr<StateMultibody> state, const FrameFrictionCone& fref,
+                                  const std::size_t& nu);
+  CostModelContactFrictionConeTpl(boost::shared_ptr<StateMultibody> state, const FrameFrictionCone& fref);
   ~CostModelContactFrictionConeTpl();
 
   virtual void calc(const boost::shared_ptr<CostDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,
@@ -70,9 +70,8 @@ class CostModelContactFrictionConeTpl : public CostModelAbstractTpl<_Scalar> {
   using Base::state_;
   using Base::unone_;
 
- protected:
-  FrictionCone friction_cone_;
-  FrameIndex frame_;
+ private:
+  FrameFrictionCone fref_;
 };
 
 template <typename _Scalar>

--- a/include/crocoddyl/multibody/costs/contact-friction-cone.hpp
+++ b/include/crocoddyl/multibody/costs/contact-friction-cone.hpp
@@ -59,10 +59,8 @@ class CostModelContactFrictionConeTpl : public CostModelAbstractTpl<_Scalar> {
                         const Eigen::Ref<const VectorXs>& u);
   virtual boost::shared_ptr<CostDataAbstract> createData(DataCollectorAbstract* const data);
 
-  const FrictionCone& get_friction_cone() const;
-  const FrameIndex& get_frame() const;
-  void set_friction_cone(const FrictionCone& cone);
-  void set_frame(const FrameIndex& frame);
+  const FrameFrictionCone& get_fref() const;
+  void set_fref(const FrameFrictionCone& fref);
 
  protected:
   virtual void set_referenceImpl(const std::type_info& ti, const void* pv);
@@ -86,6 +84,7 @@ struct CostDataContactFrictionConeTpl : public CostDataAbstractTpl<_Scalar> {
   typedef CostDataAbstractTpl<Scalar> Base;
   typedef DataCollectorAbstractTpl<Scalar> DataCollectorAbstract;
   typedef ContactModelMultipleTpl<Scalar> ContactModelMultiple;
+  typedef FrameFrictionConeTpl<Scalar> FrameFrictionCone;
   typedef typename MathBase::VectorXs VectorXs;
   typedef typename MathBase::MatrixXs MatrixXs;
   typedef typename MathBase::Matrix6xs Matrix6xs;
@@ -104,11 +103,12 @@ struct CostDataContactFrictionConeTpl : public CostDataAbstractTpl<_Scalar> {
     }
 
     // Avoids data casting at runtime
-    std::string frame_name = model->get_state()->get_pinocchio()->frames[model->get_frame()].name;
+    const FrameFrictionCone& fref = model->get_fref();
+    std::string frame_name = model->get_state()->get_pinocchio()->frames[fref.frame].name;
     bool found_contact = false;
     for (typename ContactModelMultiple::ContactDataContainer::iterator it = d->contacts->contacts.begin();
          it != d->contacts->contacts.end(); ++it) {
-      if (it->second->frame == model->get_frame()) {
+      if (it->second->frame == fref.frame) {
         ContactData3DTpl<Scalar>* d3d = dynamic_cast<ContactData3DTpl<Scalar>*>(it->second.get());
         if (d3d != NULL) {
           found_contact = true;

--- a/include/crocoddyl/multibody/costs/contact-friction-cone.hpp
+++ b/include/crocoddyl/multibody/costs/contact-friction-cone.hpp
@@ -65,6 +65,9 @@ class CostModelContactFrictionConeTpl : public CostModelAbstractTpl<_Scalar> {
   void set_frame(const FrameIndex& frame);
 
  protected:
+  virtual void set_referenceImpl(const std::type_info& ti, const void* pv);
+  virtual void get_referenceImpl(const std::type_info& ti, void* pv);
+
   using Base::activation_;
   using Base::nu_;
   using Base::state_;

--- a/include/crocoddyl/multibody/costs/contact-friction-cone.hxx
+++ b/include/crocoddyl/multibody/costs/contact-friction-cone.hxx
@@ -95,8 +95,7 @@ void CostModelContactFrictionConeTpl<Scalar>::set_referenceImpl(const std::type_
   if (ti == typeid(FrameFrictionCone)) {
     fref_ = *static_cast<const FrameFrictionCone*>(pv);
   } else {
-    throw_pretty("Invalid argument: "
-                 << "incorrect type (it should be FrameFrictionCone)");
+    throw_pretty("Invalid argument: incorrect type (it should be FrameFrictionCone)");
   }
 }
 
@@ -106,8 +105,7 @@ void CostModelContactFrictionConeTpl<Scalar>::get_referenceImpl(const std::type_
     FrameFrictionCone& ref_map = *static_cast<FrameFrictionCone*>(pv);
     ref_map = fref_;
   } else {
-    throw_pretty("Invalid argument: "
-                 << "incorrect type (it should be FrameFrictionCone)");
+    throw_pretty("Invalid argument: incorrect type (it should be FrameFrictionCone)");
   }
 }
 

--- a/include/crocoddyl/multibody/costs/contact-friction-cone.hxx
+++ b/include/crocoddyl/multibody/costs/contact-friction-cone.hxx
@@ -14,37 +14,35 @@ namespace crocoddyl {
 template <typename Scalar>
 CostModelContactFrictionConeTpl<Scalar>::CostModelContactFrictionConeTpl(
     boost::shared_ptr<StateMultibody> state, boost::shared_ptr<ActivationModelAbstract> activation,
-    const FrictionCone& cone, const FrameIndex& frame, const std::size_t& nu)
-    : Base(state, activation, nu), friction_cone_(cone), frame_(frame) {
-  if (activation_->get_nr() != friction_cone_.get_nf() + 1) {
+    const FrameFrictionCone& fref, const std::size_t& nu)
+    : Base(state, activation, nu), fref_(fref) {
+  if (activation_->get_nr() != fref_.oRf.get_nf() + 1) {
     throw_pretty("Invalid argument: "
-                 << "nr is equals to " << friction_cone_.get_nf() + 1);
+                 << "nr is equals to " << fref_.oRf.get_nf() + 1);
   }
 }
 
 template <typename Scalar>
 CostModelContactFrictionConeTpl<Scalar>::CostModelContactFrictionConeTpl(
     boost::shared_ptr<StateMultibody> state, boost::shared_ptr<ActivationModelAbstract> activation,
-    const FrictionCone& cone, const FrameIndex& frame)
-    : Base(state, activation), friction_cone_(cone), frame_(frame) {
-  if (activation_->get_nr() != friction_cone_.get_nf() + 1) {
+    const FrameFrictionCone& fref)
+    : Base(state, activation), fref_(fref) {
+  if (activation_->get_nr() != fref_.oRf.get_nf() + 1) {
     throw_pretty("Invalid argument: "
-                 << "nr is equals to " << friction_cone_.get_nf() + 1);
+                 << "nr is equals to " << fref_.oRf.get_nf() + 1);
   }
 }
 
 template <typename Scalar>
 CostModelContactFrictionConeTpl<Scalar>::CostModelContactFrictionConeTpl(boost::shared_ptr<StateMultibody> state,
-                                                                         const FrictionCone& cone,
-                                                                         const FrameIndex& frame,
+                                                                         const FrameFrictionCone& fref,
                                                                          const std::size_t& nu)
-    : Base(state, cone.get_nf() + 1, nu), friction_cone_(cone), frame_(frame) {}
+    : Base(state, fref.oRf.get_nf() + 1, nu), fref_(fref) {}
 
 template <typename Scalar>
 CostModelContactFrictionConeTpl<Scalar>::CostModelContactFrictionConeTpl(boost::shared_ptr<StateMultibody> state,
-                                                                         const FrictionCone& cone,
-                                                                         const FrameIndex& frame)
-    : Base(state, cone.get_nf() + 1), friction_cone_(cone), frame_(frame) {}
+                                                                         const FrameFrictionCone& fref)
+    : Base(state, fref.oRf.get_nf() + 1), fref_(fref) {}
 
 template <typename Scalar>
 CostModelContactFrictionConeTpl<Scalar>::~CostModelContactFrictionConeTpl() {}
@@ -57,7 +55,7 @@ void CostModelContactFrictionConeTpl<Scalar>::calc(const boost::shared_ptr<CostD
 
   // Compute the residual of the friction cone. Note that we need to transform the force
   // to the contact frame
-  data->r.noalias() = friction_cone_.get_A() * d->contact->jMf.actInv(d->contact->f).linear();
+  data->r.noalias() = fref_.oRf.get_A() * d->contact->jMf.actInv(d->contact->f).linear();
 
   // Compute the cost
   activation_->calc(data->activation, data->r);
@@ -72,7 +70,7 @@ void CostModelContactFrictionConeTpl<Scalar>::calcDiff(const boost::shared_ptr<C
 
   const MatrixXs& df_dx = d->contact->df_dx;
   const MatrixXs& df_du = d->contact->df_du;
-  const MatrixX3s& A = friction_cone_.get_A();
+  const MatrixX3s& A = fref_.oRf.get_A();
 
   activation_->calcDiff(data->activation, data->r);
   if (d->more_than_3_constraints) {
@@ -100,22 +98,22 @@ boost::shared_ptr<CostDataAbstractTpl<Scalar> > CostModelContactFrictionConeTpl<
 
 template <typename Scalar>
 const FrictionConeTpl<Scalar>& CostModelContactFrictionConeTpl<Scalar>::get_friction_cone() const {
-  return friction_cone_;
+  return fref_.oRf;
 }
 
 template <typename Scalar>
 const pinocchio::FrameIndex& CostModelContactFrictionConeTpl<Scalar>::get_frame() const {
-  return frame_;
+  return fref_.frame;
 }
 
 template <typename Scalar>
 void CostModelContactFrictionConeTpl<Scalar>::set_friction_cone(const FrictionCone& cone) {
-  friction_cone_ = cone;
+  fref_.oRf = cone;
 }
 
 template <typename Scalar>
 void CostModelContactFrictionConeTpl<Scalar>::set_frame(const FrameIndex& frame) {
-  frame_ = frame;
+  fref_.frame = frame;
 }
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/multibody/costs/contact-friction-cone.hxx
+++ b/include/crocoddyl/multibody/costs/contact-friction-cone.hxx
@@ -91,6 +91,12 @@ void CostModelContactFrictionConeTpl<Scalar>::calcDiff(const boost::shared_ptr<C
 }
 
 template <typename Scalar>
+boost::shared_ptr<CostDataAbstractTpl<Scalar> > CostModelContactFrictionConeTpl<Scalar>::createData(
+    DataCollectorAbstract* const data) {
+  return boost::make_shared<CostDataContactFrictionConeTpl<Scalar> >(this, data);
+}
+
+template <typename Scalar>
 void CostModelContactFrictionConeTpl<Scalar>::set_referenceImpl(const std::type_info& ti, const void* pv) {
   if (ti == typeid(FrameFrictionCone)) {
     fref_ = *static_cast<const FrameFrictionCone*>(pv);
@@ -110,29 +116,13 @@ void CostModelContactFrictionConeTpl<Scalar>::get_referenceImpl(const std::type_
 }
 
 template <typename Scalar>
-boost::shared_ptr<CostDataAbstractTpl<Scalar> > CostModelContactFrictionConeTpl<Scalar>::createData(
-    DataCollectorAbstract* const data) {
-  return boost::make_shared<CostDataContactFrictionConeTpl<Scalar> >(this, data);
+const FrameFrictionConeTpl<Scalar>& CostModelContactFrictionConeTpl<Scalar>::get_fref() const {
+  return fref_;
 }
 
 template <typename Scalar>
-const FrictionConeTpl<Scalar>& CostModelContactFrictionConeTpl<Scalar>::get_friction_cone() const {
-  return fref_.oRf;
-}
-
-template <typename Scalar>
-const pinocchio::FrameIndex& CostModelContactFrictionConeTpl<Scalar>::get_frame() const {
-  return fref_.frame;
-}
-
-template <typename Scalar>
-void CostModelContactFrictionConeTpl<Scalar>::set_friction_cone(const FrictionCone& cone) {
-  fref_.oRf = cone;
-}
-
-template <typename Scalar>
-void CostModelContactFrictionConeTpl<Scalar>::set_frame(const FrameIndex& frame) {
-  fref_.frame = frame;
+void CostModelContactFrictionConeTpl<Scalar>::set_fref(const FrameFrictionCone& fref_in) {
+  fref_ = fref_in;
 }
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/multibody/costs/contact-friction-cone.hxx
+++ b/include/crocoddyl/multibody/costs/contact-friction-cone.hxx
@@ -91,6 +91,27 @@ void CostModelContactFrictionConeTpl<Scalar>::calcDiff(const boost::shared_ptr<C
 }
 
 template <typename Scalar>
+void CostModelContactFrictionConeTpl<Scalar>::set_referenceImpl(const std::type_info& ti, const void* pv) {
+  if (ti == typeid(FrameFrictionCone)) {
+    fref_ = *static_cast<const FrameFrictionCone*>(pv);
+  } else {
+    throw_pretty("Invalid argument: "
+                 << "incorrect type (it should be FrameFrictionCone)");
+  }
+}
+
+template <typename Scalar>
+void CostModelContactFrictionConeTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) {
+  if (ti == typeid(FrameFrictionCone)) {
+    FrameFrictionCone& ref_map = *static_cast<FrameFrictionCone*>(pv);
+    ref_map = fref_;
+  } else {
+    throw_pretty("Invalid argument: "
+                 << "incorrect type (it should be FrameFrictionCone)");
+  }
+}
+
+template <typename Scalar>
 boost::shared_ptr<CostDataAbstractTpl<Scalar> > CostModelContactFrictionConeTpl<Scalar>::createData(
     DataCollectorAbstract* const data) {
   return boost::make_shared<CostDataContactFrictionConeTpl<Scalar> >(this, data);

--- a/include/crocoddyl/multibody/costs/control.hpp
+++ b/include/crocoddyl/multibody/costs/control.hpp
@@ -49,6 +49,9 @@ class CostModelControlTpl : public CostModelAbstractTpl<_Scalar> {
   void set_uref(const VectorXs& uref_in);
 
  protected:
+  virtual void set_referenceImpl(const std::type_info& ti, const void* pv);
+  virtual void get_referenceImpl(const std::type_info& ti, void* pv);
+
   using Base::activation_;
   using Base::nu_;
   using Base::state_;

--- a/include/crocoddyl/multibody/costs/control.hxx
+++ b/include/crocoddyl/multibody/costs/control.hxx
@@ -87,6 +87,29 @@ void CostModelControlTpl<Scalar>::calcDiff(const boost::shared_ptr<CostDataAbstr
 }
 
 template <typename Scalar>
+void CostModelControlTpl<Scalar>::set_referenceImpl(const std::type_info& ti, const void* pv) {
+  if (ti == typeid(VectorXs)) {
+    uref_ = *static_cast<const VectorXs*>(pv);
+  } else {
+    throw_pretty("Invalid argument: "
+                 << "incorrect type (it should be VectorXs)");
+  }
+}
+
+template <typename Scalar>
+void CostModelControlTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) {
+  if (ti == typeid(VectorXs)) {
+    Eigen::Map<VectorXs> ref_map(static_cast<VectorXs*>(pv)->data(), nu_);
+    for (std::size_t i = 0; i < nu_; ++i) {
+      ref_map[i] = uref_[i];
+    }
+  } else {
+    throw_pretty("Invalid argument: "
+                 << "incorrect type (it should be VectorXs)");
+  }
+}
+
+template <typename Scalar>
 const typename MathBaseTpl<Scalar>::VectorXs& CostModelControlTpl<Scalar>::get_uref() const {
   return uref_;
 }

--- a/include/crocoddyl/multibody/costs/control.hxx
+++ b/include/crocoddyl/multibody/costs/control.hxx
@@ -95,8 +95,7 @@ void CostModelControlTpl<Scalar>::set_referenceImpl(const std::type_info& ti, co
     }
     uref_ = *static_cast<const VectorXs*>(pv);
   } else {
-    throw_pretty("Invalid argument: "
-                 << "incorrect type (it should be VectorXs)");
+    throw_pretty("Invalid argument: incorrect type (it should be VectorXs)");
   }
 }
 
@@ -110,8 +109,7 @@ void CostModelControlTpl<Scalar>::get_referenceImpl(const std::type_info& ti, vo
       ref_map[i] = uref_[i];
     }
   } else {
-    throw_pretty("Invalid argument: "
-                 << "incorrect type (it should be VectorXs)");
+    throw_pretty("Invalid argument: incorrect type (it should be VectorXs)");
   }
 }
 

--- a/include/crocoddyl/multibody/costs/control.hxx
+++ b/include/crocoddyl/multibody/costs/control.hxx
@@ -89,6 +89,10 @@ void CostModelControlTpl<Scalar>::calcDiff(const boost::shared_ptr<CostDataAbstr
 template <typename Scalar>
 void CostModelControlTpl<Scalar>::set_referenceImpl(const std::type_info& ti, const void* pv) {
   if (ti == typeid(VectorXs)) {
+    if (static_cast<std::size_t>(static_cast<const VectorXs*>(pv)->size()) != nu_) {
+      throw_pretty("Invalid argument: "
+                   << "reference has wrong dimension (it should be " + std::to_string(nu_) + ")");
+    }
     uref_ = *static_cast<const VectorXs*>(pv);
   } else {
     throw_pretty("Invalid argument: "
@@ -99,6 +103,8 @@ void CostModelControlTpl<Scalar>::set_referenceImpl(const std::type_info& ti, co
 template <typename Scalar>
 void CostModelControlTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) {
   if (ti == typeid(VectorXs)) {
+    Eigen::VectorXd& tmp = *static_cast<VectorXs*>(pv);
+    tmp.resize(nu_);
     Eigen::Map<VectorXs> ref_map(static_cast<VectorXs*>(pv)->data(), nu_);
     for (std::size_t i = 0; i < nu_; ++i) {
       ref_map[i] = uref_[i];

--- a/include/crocoddyl/multibody/costs/frame-placement.hpp
+++ b/include/crocoddyl/multibody/costs/frame-placement.hpp
@@ -54,6 +54,9 @@ class CostModelFramePlacementTpl : public CostModelAbstractTpl<_Scalar> {
   void set_Mref(const FramePlacement& Mref_in);
 
  protected:
+  virtual void set_referenceImpl(const std::type_info& ti, const void* pv);
+  virtual void get_referenceImpl(const std::type_info& ti, void* pv);
+
   using Base::activation_;
   using Base::nu_;
   using Base::state_;

--- a/include/crocoddyl/multibody/costs/frame-placement.hxx
+++ b/include/crocoddyl/multibody/costs/frame-placement.hxx
@@ -92,6 +92,27 @@ boost::shared_ptr<CostDataAbstractTpl<Scalar> > CostModelFramePlacementTpl<Scala
 }
 
 template <typename Scalar>
+void CostModelFramePlacementTpl<Scalar>::set_referenceImpl(const std::type_info& ti, const void* pv) {
+  if (ti == typeid(FramePlacement)) {
+    Mref_ = *static_cast<const FramePlacement*>(pv);
+  } else {
+    throw_pretty("Invalid argument: "
+                 << "incorrect type (it should be FramePlacement)");
+  }
+}
+
+template <typename Scalar>
+void CostModelFramePlacementTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) {
+  if (ti == typeid(FramePlacement)) {
+    FramePlacement& ref_map = *static_cast<FramePlacement*>(pv);
+    ref_map = Mref_;
+  } else {
+    throw_pretty("Invalid argument: "
+                 << "incorrect type (it should be FramePlacement)");
+  }
+}
+
+template <typename Scalar>
 const FramePlacementTpl<Scalar>& CostModelFramePlacementTpl<Scalar>::get_Mref() const {
   return Mref_;
 }

--- a/include/crocoddyl/multibody/costs/frame-placement.hxx
+++ b/include/crocoddyl/multibody/costs/frame-placement.hxx
@@ -96,8 +96,7 @@ void CostModelFramePlacementTpl<Scalar>::set_referenceImpl(const std::type_info&
   if (ti == typeid(FramePlacement)) {
     Mref_ = *static_cast<const FramePlacement*>(pv);
   } else {
-    throw_pretty("Invalid argument: "
-                 << "incorrect type (it should be FramePlacement)");
+    throw_pretty("Invalid argument: incorrect type (it should be FramePlacement)");
   }
 }
 
@@ -107,8 +106,7 @@ void CostModelFramePlacementTpl<Scalar>::get_referenceImpl(const std::type_info&
     FramePlacement& ref_map = *static_cast<FramePlacement*>(pv);
     ref_map = Mref_;
   } else {
-    throw_pretty("Invalid argument: "
-                 << "incorrect type (it should be FramePlacement)");
+    throw_pretty("Invalid argument: incorrect type (it should be FramePlacement)");
   }
 }
 

--- a/include/crocoddyl/multibody/costs/frame-rotation.hpp
+++ b/include/crocoddyl/multibody/costs/frame-rotation.hpp
@@ -53,6 +53,9 @@ class CostModelFrameRotationTpl : public CostModelAbstractTpl<_Scalar> {
   void set_Rref(const FrameRotation& Rref_in);
 
  protected:
+  virtual void set_referenceImpl(const std::type_info& ti, const void* pv);
+  virtual void get_referenceImpl(const std::type_info& ti, void* pv);
+
   using Base::activation_;
   using Base::nu_;
   using Base::state_;

--- a/include/crocoddyl/multibody/costs/frame-rotation.hxx
+++ b/include/crocoddyl/multibody/costs/frame-rotation.hxx
@@ -92,6 +92,27 @@ boost::shared_ptr<CostDataAbstractTpl<Scalar> > CostModelFrameRotationTpl<Scalar
 }
 
 template <typename Scalar>
+void CostModelFrameRotationTpl<Scalar>::set_referenceImpl(const std::type_info& ti, const void* pv) {
+  if (ti == typeid(FrameRotation)) {
+    Rref_ = *static_cast<const FrameRotation*>(pv);
+  } else {
+    throw_pretty("Invalid argument: "
+                 << "incorrect type (it should be FrameRotation)");
+  }
+}
+
+template <typename Scalar>
+void CostModelFrameRotationTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) {
+  if (ti == typeid(FrameRotation)) {
+    FrameRotation& ref_map = *static_cast<FrameRotation*>(pv);
+    ref_map = Rref_;
+  } else {
+    throw_pretty("Invalid argument: "
+                 << "incorrect type (it should be FrameRotation)");
+  }
+}
+
+template <typename Scalar>
 const FrameRotationTpl<Scalar>& CostModelFrameRotationTpl<Scalar>::get_Rref() const {
   return Rref_;
 }

--- a/include/crocoddyl/multibody/costs/frame-rotation.hxx
+++ b/include/crocoddyl/multibody/costs/frame-rotation.hxx
@@ -96,8 +96,7 @@ void CostModelFrameRotationTpl<Scalar>::set_referenceImpl(const std::type_info& 
   if (ti == typeid(FrameRotation)) {
     Rref_ = *static_cast<const FrameRotation*>(pv);
   } else {
-    throw_pretty("Invalid argument: "
-                 << "incorrect type (it should be FrameRotation)");
+    throw_pretty("Invalid argument: incorrect type (it should be FrameRotation)");
   }
 }
 
@@ -107,8 +106,7 @@ void CostModelFrameRotationTpl<Scalar>::get_referenceImpl(const std::type_info& 
     FrameRotation& ref_map = *static_cast<FrameRotation*>(pv);
     ref_map = Rref_;
   } else {
-    throw_pretty("Invalid argument: "
-                 << "incorrect type (it should be FrameRotation)");
+    throw_pretty("Invalid argument: incorrect type (it should be FrameRotation)");
   }
 }
 

--- a/include/crocoddyl/multibody/costs/frame-translation.hpp
+++ b/include/crocoddyl/multibody/costs/frame-translation.hpp
@@ -55,6 +55,9 @@ class CostModelFrameTranslationTpl : public CostModelAbstractTpl<_Scalar> {
   void set_xref(const FrameTranslation& xref_in);
 
  protected:
+  virtual void set_referenceImpl(const std::type_info& ti, const void* pv);
+  virtual void get_referenceImpl(const std::type_info& ti, void* pv);
+
   using Base::activation_;
   using Base::nu_;
   using Base::state_;

--- a/include/crocoddyl/multibody/costs/frame-translation.hxx
+++ b/include/crocoddyl/multibody/costs/frame-translation.hxx
@@ -91,8 +91,7 @@ void CostModelFrameTranslationTpl<Scalar>::set_referenceImpl(const std::type_inf
   if (ti == typeid(FrameTranslation)) {
     xref_ = *static_cast<const FrameTranslation*>(pv);
   } else {
-    throw_pretty("Invalid argument: "
-                 << "incorrect type (it should be FrameTranslation)");
+    throw_pretty("Invalid argument: incorrect type (it should be FrameTranslation)");
   }
 }
 
@@ -102,8 +101,7 @@ void CostModelFrameTranslationTpl<Scalar>::get_referenceImpl(const std::type_inf
     FrameTranslation& ref_map = *static_cast<FrameTranslation*>(pv);
     ref_map = xref_;
   } else {
-    throw_pretty("Invalid argument: "
-                 << "incorrect type (it should be FrameTranslation)");
+    throw_pretty("Invalid argument: incorrect type (it should be FrameTranslation)");
   }
 }
 

--- a/include/crocoddyl/multibody/costs/frame-translation.hxx
+++ b/include/crocoddyl/multibody/costs/frame-translation.hxx
@@ -87,6 +87,27 @@ boost::shared_ptr<CostDataAbstractTpl<Scalar> > CostModelFrameTranslationTpl<Sca
 }
 
 template <typename Scalar>
+void CostModelFrameTranslationTpl<Scalar>::set_referenceImpl(const std::type_info& ti, const void* pv) {
+  if (ti == typeid(FrameTranslation)) {
+    xref_ = *static_cast<const FrameTranslation*>(pv);
+  } else {
+    throw_pretty("Invalid argument: "
+                 << "incorrect type (it should be FrameTranslation)");
+  }
+}
+
+template <typename Scalar>
+void CostModelFrameTranslationTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) {
+  if (ti == typeid(FrameTranslation)) {
+    FrameTranslation& ref_map = *static_cast<FrameTranslation*>(pv);
+    ref_map = xref_;
+  } else {
+    throw_pretty("Invalid argument: "
+                 << "incorrect type (it should be FrameTranslation)");
+  }
+}
+
+template <typename Scalar>
 const FrameTranslationTpl<Scalar>& CostModelFrameTranslationTpl<Scalar>::get_xref() const {
   return xref_;
 }

--- a/include/crocoddyl/multibody/costs/frame-velocity.hpp
+++ b/include/crocoddyl/multibody/costs/frame-velocity.hpp
@@ -53,6 +53,9 @@ class CostModelFrameVelocityTpl : public CostModelAbstractTpl<_Scalar> {
   void set_vref(const FrameMotion& vref_in);
 
  protected:
+  virtual void set_referenceImpl(const std::type_info& ti, const void* pv);
+  virtual void get_referenceImpl(const std::type_info& ti, void* pv);
+
   using Base::activation_;
   using Base::nu_;
   using Base::state_;

--- a/include/crocoddyl/multibody/costs/frame-velocity.hxx
+++ b/include/crocoddyl/multibody/costs/frame-velocity.hxx
@@ -89,6 +89,27 @@ boost::shared_ptr<CostDataAbstractTpl<Scalar> > CostModelFrameVelocityTpl<Scalar
 }
 
 template <typename Scalar>
+void CostModelFrameVelocityTpl<Scalar>::set_referenceImpl(const std::type_info& ti, const void* pv) {
+  if (ti == typeid(FrameTranslation)) {
+    vref_ = *static_cast<const FrameMotion*>(pv);
+  } else {
+    throw_pretty("Invalid argument: "
+                 << "incorrect type (it should be FrameMotion)");
+  }
+}
+
+template <typename Scalar>
+void CostModelFrameVelocityTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) {
+  if (ti == typeid(FrameMotion)) {
+    FrameMotion& ref_map = *static_cast<FrameMotion*>(pv);
+    ref_map = vref_;
+  } else {
+    throw_pretty("Invalid argument: "
+                 << "incorrect type (it should be FrameMotion)");
+  }
+}
+
+template <typename Scalar>
 const FrameMotionTpl<Scalar>& CostModelFrameVelocityTpl<Scalar>::get_vref() const {
   return vref_;
 }

--- a/include/crocoddyl/multibody/costs/frame-velocity.hxx
+++ b/include/crocoddyl/multibody/costs/frame-velocity.hxx
@@ -90,7 +90,7 @@ boost::shared_ptr<CostDataAbstractTpl<Scalar> > CostModelFrameVelocityTpl<Scalar
 
 template <typename Scalar>
 void CostModelFrameVelocityTpl<Scalar>::set_referenceImpl(const std::type_info& ti, const void* pv) {
-  if (ti == typeid(FrameTranslation)) {
+  if (ti == typeid(FrameMotion)) {
     vref_ = *static_cast<const FrameMotion*>(pv);
   } else {
     throw_pretty("Invalid argument: "

--- a/include/crocoddyl/multibody/costs/frame-velocity.hxx
+++ b/include/crocoddyl/multibody/costs/frame-velocity.hxx
@@ -93,8 +93,7 @@ void CostModelFrameVelocityTpl<Scalar>::set_referenceImpl(const std::type_info& 
   if (ti == typeid(FrameMotion)) {
     vref_ = *static_cast<const FrameMotion*>(pv);
   } else {
-    throw_pretty("Invalid argument: "
-                 << "incorrect type (it should be FrameMotion)");
+    throw_pretty("Invalid argument: incorrect type (it should be FrameMotion)");
   }
 }
 
@@ -104,8 +103,7 @@ void CostModelFrameVelocityTpl<Scalar>::get_referenceImpl(const std::type_info& 
     FrameMotion& ref_map = *static_cast<FrameMotion*>(pv);
     ref_map = vref_;
   } else {
-    throw_pretty("Invalid argument: "
-                 << "incorrect type (it should be FrameMotion)");
+    throw_pretty("Invalid argument: incorrect type (it should be FrameMotion)");
   }
 }
 

--- a/include/crocoddyl/multibody/costs/state.hpp
+++ b/include/crocoddyl/multibody/costs/state.hpp
@@ -55,6 +55,9 @@ class CostModelStateTpl : public CostModelAbstractTpl<_Scalar> {
   void set_xref(const VectorXs& xref_in);
 
  protected:
+  virtual void set_referenceImpl(const std::type_info& ti, const void* pv);
+  virtual void get_referenceImpl(const std::type_info& ti, void* pv);
+
   using Base::activation_;
   using Base::nu_;
   using Base::state_;

--- a/include/crocoddyl/multibody/costs/state.hxx
+++ b/include/crocoddyl/multibody/costs/state.hxx
@@ -162,6 +162,29 @@ boost::shared_ptr<CostDataAbstractTpl<Scalar> > CostModelStateTpl<Scalar>::creat
 }
 
 template <typename Scalar>
+void CostModelStateTpl<Scalar>::set_referenceImpl(const std::type_info& ti, const void* pv) {
+  if (ti == typeid(VectorXs)) {
+    xref_ = *static_cast<const VectorXs*>(pv);
+  } else {
+    throw_pretty("Invalid argument: "
+                 << "incorrect type (it should be VectorXs)");
+  }
+}
+
+template <typename Scalar>
+void CostModelStateTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) {
+  if (ti == typeid(VectorXs)) {
+    Eigen::Map<VectorXs> ref_map(static_cast<VectorXs*>(pv)->data(), state_->get_nx());
+    for (std::size_t i = 0; i < state_->get_nx(); ++i) {
+      ref_map[i] = xref_[i];
+    }
+  } else {
+    throw_pretty("Invalid argument: "
+                 << "incorrect type (it should be VectorXs)");
+  }
+}
+
+template <typename Scalar>
 const typename MathBaseTpl<Scalar>::VectorXs& CostModelStateTpl<Scalar>::get_xref() const {
   return xref_;
 }

--- a/include/crocoddyl/multibody/costs/state.hxx
+++ b/include/crocoddyl/multibody/costs/state.hxx
@@ -170,8 +170,7 @@ void CostModelStateTpl<Scalar>::set_referenceImpl(const std::type_info& ti, cons
     }
     xref_ = *static_cast<const VectorXs*>(pv);
   } else {
-    throw_pretty("Invalid argument: "
-                 << "incorrect type (it should be VectorXs)");
+    throw_pretty("Invalid argument: incorrect type (it should be VectorXs)");
   }
 }
 
@@ -185,8 +184,7 @@ void CostModelStateTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void
       ref_map[i] = xref_[i];
     }
   } else {
-    throw_pretty("Invalid argument: "
-                 << "incorrect type (it should be VectorXs)");
+    throw_pretty("Invalid argument: incorrect type (it should be VectorXs)");
   }
 }
 

--- a/include/crocoddyl/multibody/costs/state.hxx
+++ b/include/crocoddyl/multibody/costs/state.hxx
@@ -164,6 +164,10 @@ boost::shared_ptr<CostDataAbstractTpl<Scalar> > CostModelStateTpl<Scalar>::creat
 template <typename Scalar>
 void CostModelStateTpl<Scalar>::set_referenceImpl(const std::type_info& ti, const void* pv) {
   if (ti == typeid(VectorXs)) {
+    if (static_cast<std::size_t>(static_cast<const VectorXs*>(pv)->size()) != state_->get_nx()) {
+      throw_pretty("Invalid argument: "
+                   << "reference has wrong dimension (it should be " + std::to_string(state_->get_nx()) + ")");
+    }
     xref_ = *static_cast<const VectorXs*>(pv);
   } else {
     throw_pretty("Invalid argument: "
@@ -174,6 +178,8 @@ void CostModelStateTpl<Scalar>::set_referenceImpl(const std::type_info& ti, cons
 template <typename Scalar>
 void CostModelStateTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) {
   if (ti == typeid(VectorXs)) {
+    Eigen::VectorXd& tmp = *static_cast<VectorXs*>(pv);
+    tmp.resize(state_->get_nx());
     Eigen::Map<VectorXs> ref_map(static_cast<VectorXs*>(pv)->data(), state_->get_nx());
     for (std::size_t i = 0; i < state_->get_nx(); ++i) {
       ref_map[i] = xref_[i];

--- a/include/crocoddyl/multibody/frames.hpp
+++ b/include/crocoddyl/multibody/frames.hpp
@@ -29,6 +29,7 @@ struct FrameTranslationTpl {
   typedef typename MathBaseTpl<Scalar>::Vector3s Vector3s;
 
   explicit FrameTranslationTpl() : frame(0), oxf(Vector3s::Zero()) {}
+  FrameTranslationTpl(const FrameTranslationTpl& value) : frame(value.frame), oxf(value.oxf) {}
   FrameTranslationTpl(const FrameIndex& frame, const Vector3s& oxf) : frame(frame), oxf(oxf) {}
   friend std::ostream& operator<<(std::ostream& os, const FrameTranslationTpl<Scalar>& X) {
     os << "      frame: " << X.frame << std::endl << "translation: " << std::endl << X.oxf.transpose() << std::endl;
@@ -47,6 +48,7 @@ struct FrameRotationTpl {
   typedef typename MathBaseTpl<Scalar>::Matrix3s Matrix3s;
 
   explicit FrameRotationTpl() : frame(0), oRf(Matrix3s::Identity()) {}
+  FrameRotationTpl(const FrameRotationTpl& value) : frame(value.frame), oRf(value.oRf) {}
   FrameRotationTpl(const FrameIndex& frame, const Matrix3s& oRf) : frame(frame), oRf(oRf) {}
   friend std::ostream& operator<<(std::ostream& os, const FrameRotationTpl<Scalar>& X) {
     os << "   frame: " << X.frame << std::endl << "rotation: " << std::endl << X.oRf << std::endl;
@@ -65,6 +67,7 @@ struct FramePlacementTpl {
   typedef pinocchio::SE3Tpl<Scalar> SE3;
 
   explicit FramePlacementTpl() : frame(0), oMf(SE3::Zero()) {}
+  FramePlacementTpl(const FramePlacementTpl& value) : frame(value.frame), oMf(value.oMf) {}
   FramePlacementTpl(const FrameIndex& frame, const SE3& oMf) : frame(frame), oMf(oMf) {}
   friend std::ostream& operator<<(std::ostream& os, const FramePlacementTpl<Scalar>& X) {
     os << "    frame: " << X.frame << std::endl << "placement: " << std::endl << X.oMf << std::endl;
@@ -83,6 +86,7 @@ struct FrameMotionTpl {
   typedef pinocchio::MotionTpl<Scalar> Motion;
 
   explicit FrameMotionTpl() : frame(0), oMf(Motion::Zero()) {}
+  FrameMotionTpl(const FrameMotionTpl& value) : frame(value.frame), oMf(value.oMf) {}
   FrameMotionTpl(const FrameIndex& frame, const Motion& oMf) : frame(frame), oMf(oMf) {}
   friend std::ostream& operator<<(std::ostream& os, const FrameMotionTpl<Scalar>& X) {
     os << " frame: " << X.frame << std::endl << "motion: " << std::endl << X.oMf << std::endl;
@@ -101,6 +105,7 @@ struct FrameForceTpl {
   typedef pinocchio::ForceTpl<Scalar> Force;
 
   explicit FrameForceTpl() : frame(0), oFf(Force::Zero()) {}
+  FrameForceTpl(const FrameForceTpl& value) : frame(value.frame), oFf(value.oFf) {}
   FrameForceTpl(const FrameIndex& frame, const Force& oFf) : frame(frame), oFf(oFf) {}
   friend std::ostream& operator<<(std::ostream& os, const FrameForceTpl<Scalar>& X) {
     os << "frame: " << X.frame << std::endl << "force: " << std::endl << X.oFf << std::endl;

--- a/include/crocoddyl/multibody/frames.hpp
+++ b/include/crocoddyl/multibody/frames.hpp
@@ -11,6 +11,7 @@
 #define CROCODDYL_MULTIBODY_FRAMES_HPP_
 
 #include "crocoddyl/multibody/fwd.hpp"
+#include "crocoddyl/multibody/friction-cone.hpp"
 #include "crocoddyl/core/mathbase.hpp"
 
 #include <pinocchio/spatial/se3.hpp>
@@ -66,7 +67,7 @@ struct FramePlacementTpl {
   typedef _Scalar Scalar;
   typedef pinocchio::SE3Tpl<Scalar> SE3;
 
-  explicit FramePlacementTpl() : frame(0), oMf(SE3::Zero()) {}
+  explicit FramePlacementTpl() : frame(0), oMf(SE3::Identity()) {}
   FramePlacementTpl(const FramePlacementTpl& value) : frame(value.frame), oMf(value.oMf) {}
   FramePlacementTpl(const FrameIndex& frame, const SE3& oMf) : frame(frame), oMf(oMf) {}
   friend std::ostream& operator<<(std::ostream& os, const FramePlacementTpl<Scalar>& X) {
@@ -114,6 +115,25 @@ struct FrameForceTpl {
 
   FrameIndex frame;
   pinocchio::ForceTpl<Scalar> oFf;
+};
+
+template <typename _Scalar>
+struct FrameFrictionConeTpl {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  typedef _Scalar Scalar;
+  typedef FrictionConeTpl<Scalar> FrictionCone;
+
+  explicit FrameFrictionConeTpl() : frame(0), oRf(FrictionCone()) {}
+  FrameFrictionConeTpl(const FrameFrictionConeTpl& value) : frame(value.frame), oRf(value.oRf) {}
+  FrameFrictionConeTpl(const FrameIndex& frame, const FrictionCone& oRf) : frame(frame), oRf(oRf) {}
+  friend std::ostream& operator<<(std::ostream& os, const FrameFrictionConeTpl& X) {
+    os << "frame: " << X.frame << std::endl << "cone: " << std::endl << X.oRf << std::endl;
+    return os;
+  }
+
+  FrameIndex frame;
+  FrictionCone oRf;
 };
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/multibody/frames.hpp
+++ b/include/crocoddyl/multibody/frames.hpp
@@ -28,6 +28,7 @@ struct FrameTranslationTpl {
   typedef _Scalar Scalar;
   typedef typename MathBaseTpl<Scalar>::Vector3s Vector3s;
 
+  explicit FrameTranslationTpl() : frame(0), oxf(Vector3s::Zero()) {}
   FrameTranslationTpl(const FrameIndex& frame, const Vector3s& oxf) : frame(frame), oxf(oxf) {}
   friend std::ostream& operator<<(std::ostream& os, const FrameTranslationTpl<Scalar>& X) {
     os << "      frame: " << X.frame << std::endl << "translation: " << std::endl << X.oxf.transpose() << std::endl;
@@ -45,6 +46,7 @@ struct FrameRotationTpl {
   typedef _Scalar Scalar;
   typedef typename MathBaseTpl<Scalar>::Matrix3s Matrix3s;
 
+  explicit FrameRotationTpl() : frame(0), oRf(Matrix3s::Identity()) {}
   FrameRotationTpl(const FrameIndex& frame, const Matrix3s& oRf) : frame(frame), oRf(oRf) {}
   friend std::ostream& operator<<(std::ostream& os, const FrameRotationTpl<Scalar>& X) {
     os << "   frame: " << X.frame << std::endl << "rotation: " << std::endl << X.oRf << std::endl;
@@ -60,8 +62,10 @@ struct FramePlacementTpl {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   typedef _Scalar Scalar;
+  typedef pinocchio::SE3Tpl<Scalar> SE3;
 
-  FramePlacementTpl(const FrameIndex& frame, const pinocchio::SE3Tpl<Scalar>& oMf) : frame(frame), oMf(oMf) {}
+  explicit FramePlacementTpl() : frame(0), oMf(SE3::Zero()) {}
+  FramePlacementTpl(const FrameIndex& frame, const SE3& oMf) : frame(frame), oMf(oMf) {}
   friend std::ostream& operator<<(std::ostream& os, const FramePlacementTpl<Scalar>& X) {
     os << "    frame: " << X.frame << std::endl << "placement: " << std::endl << X.oMf << std::endl;
     return os;
@@ -76,8 +80,10 @@ struct FrameMotionTpl {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   typedef _Scalar Scalar;
+  typedef pinocchio::MotionTpl<Scalar> Motion;
 
-  FrameMotionTpl(const FrameIndex& frame, const pinocchio::MotionTpl<Scalar>& oMf) : frame(frame), oMf(oMf) {}
+  explicit FrameMotionTpl() : frame(0), oMf(Motion::Zero()) {}
+  FrameMotionTpl(const FrameIndex& frame, const Motion& oMf) : frame(frame), oMf(oMf) {}
   friend std::ostream& operator<<(std::ostream& os, const FrameMotionTpl<Scalar>& X) {
     os << " frame: " << X.frame << std::endl << "motion: " << std::endl << X.oMf << std::endl;
     return os;
@@ -92,8 +98,10 @@ struct FrameForceTpl {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   typedef _Scalar Scalar;
+  typedef pinocchio::ForceTpl<Scalar> Force;
 
-  FrameForceTpl(const FrameIndex& frame, const pinocchio::ForceTpl<Scalar>& oFf) : frame(frame), oFf(oFf) {}
+  explicit FrameForceTpl() : frame(0), oFf(Force::Zero()) {}
+  FrameForceTpl(const FrameIndex& frame, const Force& oFf) : frame(frame), oFf(oFf) {}
   friend std::ostream& operator<<(std::ostream& os, const FrameForceTpl<Scalar>& X) {
     os << "frame: " << X.frame << std::endl << "force: " << std::endl << X.oFf << std::endl;
     return os;

--- a/include/crocoddyl/multibody/frames.hpp
+++ b/include/crocoddyl/multibody/frames.hpp
@@ -128,7 +128,7 @@ struct FrameFrictionConeTpl {
   FrameFrictionConeTpl(const FrameFrictionConeTpl& value) : frame(value.frame), oRf(value.oRf) {}
   FrameFrictionConeTpl(const FrameIndex& frame, const FrictionCone& oRf) : frame(frame), oRf(oRf) {}
   friend std::ostream& operator<<(std::ostream& os, const FrameFrictionConeTpl& X) {
-    os << "frame: " << X.frame << std::endl << "cone: " << std::endl << X.oRf << std::endl;
+    os << "frame: " << X.frame << std::endl << " cone: " << std::endl << X.oRf << std::endl;
     return os;
   }
 

--- a/include/crocoddyl/multibody/friction-cone.hpp
+++ b/include/crocoddyl/multibody/friction-cone.hpp
@@ -28,6 +28,7 @@ class FrictionConeTpl {
   typedef typename MathBase::MatrixX3s MatrixX3s;
   typedef typename MathBase::Quaternions Quaternions;
 
+  explicit FrictionConeTpl();
   FrictionConeTpl(const Vector3s& normal, const Scalar& mu, std::size_t nf = 4, bool inner_appr = true,
                   const Scalar& min_nforce = 0., const Scalar& max_nforce = std::numeric_limits<Scalar>::max());
   FrictionConeTpl(const FrictionConeTpl<Scalar>& cone);
@@ -45,6 +46,9 @@ class FrictionConeTpl {
   const bool& get_inner_appr() const;
   const Scalar& get_min_nforce() const;
   const Scalar& get_max_nforce() const;
+
+  template <class Scalar>
+  friend std::ostream& operator<<(std::ostream& os, const FrictionConeTpl<Scalar>& X);
 
  private:
   MatrixX3s A_;

--- a/include/crocoddyl/multibody/friction-cone.hxx
+++ b/include/crocoddyl/multibody/friction-cone.hxx
@@ -12,6 +12,15 @@
 namespace crocoddyl {
 
 template <typename Scalar>
+FrictionConeTpl<Scalar>::FrictionConeTpl() : nf_(4) {
+  A_.resize(nf_ + 1, 3);
+  lb_.resize(nf_ + 1);
+  ub_.resize(nf_ + 1);
+  // compute the matrix
+  update(Vector3s(0, 0, 1), 0.7, true, 0., std::numeric_limits<Scalar>::max());
+}
+
+template <typename Scalar>
 FrictionConeTpl<Scalar>::FrictionConeTpl(const Vector3s& normal, const Scalar& mu, std::size_t nf, bool inner_appr,
                                          const Scalar& min_nforce, const Scalar& max_nforce)
     : nf_(nf) {
@@ -129,6 +138,17 @@ const Scalar& FrictionConeTpl<Scalar>::get_min_nforce() const {
 template <typename Scalar>
 const Scalar& FrictionConeTpl<Scalar>::get_max_nforce() const {
   return max_nforce_;
+}
+
+template <typename Scalar>
+std::ostream& operator<<(std::ostream& os, const FrictionConeTpl<Scalar>& X) {
+  os << "    normal: " << X.get_nsurf().transpose() << std::endl;
+  os << "        mu: " << X.get_mu() << std::endl;
+  os << "        nf: " << X.get_nf() << std::endl;
+  os << "inner_appr: " << X.get_inner_appr() << std::endl;
+  os << " min_force: " << X.get_min_nforce() << std::endl;
+  os << " max_force: " << X.get_max_nforce() << std::endl;
+  return os;
 }
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/multibody/fwd.hpp
+++ b/include/crocoddyl/multibody/fwd.hpp
@@ -254,6 +254,8 @@ typedef CostDataNumDiffTpl<double> CostDataNumDiff;
 typedef ContactModelNumDiffTpl<double> ContactModelNumDiff;
 typedef ContactDataNumDiffTpl<double> ContactDataNumDiff;
 
+typedef FrictionConeTpl<double> FrictionCone;
+
 typedef FrameTranslationTpl<double> FrameTranslation;
 typedef FrameRotationTpl<double> FrameRotation;
 typedef FramePlacementTpl<double> FramePlacement;
@@ -298,8 +300,6 @@ typedef ContactModel3DTpl<double> ContactModel3D;
 typedef ContactData3DTpl<double> ContactData3D;
 typedef ContactModel6DTpl<double> ContactModel6D;
 typedef ContactData6DTpl<double> ContactData6D;
-
-typedef FrictionConeTpl<double> FrictionCone;
 
 typedef StateMultibodyTpl<double> StateMultibody;
 

--- a/include/crocoddyl/multibody/fwd.hpp
+++ b/include/crocoddyl/multibody/fwd.hpp
@@ -73,6 +73,9 @@ class FrameMotionTpl;
 template <typename Scalar>
 class FrameForceTpl;
 
+template <typename Scalar>
+class FrameFrictionConeTpl;
+
 // Costs
 template <typename Scalar>
 class CostModelAbstractTpl;
@@ -261,6 +264,7 @@ typedef FrameRotationTpl<double> FrameRotation;
 typedef FramePlacementTpl<double> FramePlacement;
 typedef FrameMotionTpl<double> FrameMotion;
 typedef FrameForceTpl<double> FrameForce;
+typedef FrameFrictionConeTpl<double> FrameFrictionCone;
 
 typedef CostModelAbstractTpl<double> CostModelAbstract;
 typedef CostDataAbstractTpl<double> CostDataAbstract;

--- a/src/core/solver-base.cpp
+++ b/src/core/solver-base.cpp
@@ -30,7 +30,6 @@ SolverAbstract::SolverAbstract(boost::shared_ptr<ShootingProblem> problem)
   us_.resize(T);
   for (std::size_t t = 0; t < T; ++t) {
     const boost::shared_ptr<ActionModelAbstract>& model = problem_->get_runningModels()[t];
-    const boost::shared_ptr<ActionDataAbstract>& data = problem_->get_runningDatas()[t];
     const std::size_t& nu = model->get_nu();
 
     xs_[t] = model->get_state()->zero();

--- a/unittest/bindings/test_friction_cone_cost.py
+++ b/unittest/bindings/test_friction_cone_cost.py
@@ -29,11 +29,13 @@ frictionCone = crocoddyl.FrictionCone(np.matrix([0., 0., 1.]).T, 0.7, 4, False)
 activation = crocoddyl.ActivationModelQuadraticBarrier(crocoddyl.ActivationBounds(frictionCone.lb, frictionCone.ub))
 COSTS.addCost(
     "r_sole_friction_cone",
-    crocoddyl.CostModelContactFrictionCone(ROBOT_STATE, activation, frictionCone, ROBOT_MODEL.getFrameId('r_sole'),
+    crocoddyl.CostModelContactFrictionCone(ROBOT_STATE, activation,
+                                           crocoddyl.FrameFrictionCone(ROBOT_MODEL.getFrameId('r_sole'), frictionCone),
                                            ACTUATION.nu), 1.)
 COSTS.addCost(
     "l_sole_friction_cone",
-    crocoddyl.CostModelContactFrictionCone(ROBOT_STATE, activation, frictionCone, ROBOT_MODEL.getFrameId('l_sole'),
+    crocoddyl.CostModelContactFrictionCone(ROBOT_STATE, activation,
+                                           crocoddyl.FrameFrictionCone(ROBOT_MODEL.getFrameId('l_sole'), frictionCone),
                                            ACTUATION.nu), 1.)
 MODEL = crocoddyl.DifferentialActionModelContactFwdDynamics(ROBOT_STATE, ACTUATION, CONTACTS, COSTS, 0., True)
 DATA = MODEL.createData()

--- a/unittest/factory/diff_action.cpp
+++ b/unittest/factory/diff_action.cpp
@@ -161,22 +161,30 @@ DifferentialActionModelFactory::create_contactFwdDynamics(StateModelTypes::Type 
                                                                 Eigen::Vector3d::Zero()),
                                     actuation->get_nu()));
       if (with_friction) {
-        cost->addCost("lf_cone",
-                      boost::make_shared<crocoddyl::CostModelContactFrictionCone>(
-                          state, activation, cone, state->get_pinocchio()->getFrameId("lf_foot"), actuation->get_nu()),
-                      0.1);
-        cost->addCost("rf_cone",
-                      boost::make_shared<crocoddyl::CostModelContactFrictionCone>(
-                          state, activation, cone, state->get_pinocchio()->getFrameId("rf_foot"), actuation->get_nu()),
-                      0.1);
-        cost->addCost("lh_cone",
-                      boost::make_shared<crocoddyl::CostModelContactFrictionCone>(
-                          state, activation, cone, state->get_pinocchio()->getFrameId("lh_foot"), actuation->get_nu()),
-                      0.1);
-        cost->addCost("rh_cone",
-                      boost::make_shared<crocoddyl::CostModelContactFrictionCone>(
-                          state, activation, cone, state->get_pinocchio()->getFrameId("rh_foot"), actuation->get_nu()),
-                      0.1);
+        cost->addCost(
+            "lf_cone",
+            boost::make_shared<crocoddyl::CostModelContactFrictionCone>(
+                state, activation, crocoddyl::FrameFrictionCone(state->get_pinocchio()->getFrameId("lf_foot"), cone),
+                actuation->get_nu()),
+            0.1);
+        cost->addCost(
+            "rf_cone",
+            boost::make_shared<crocoddyl::CostModelContactFrictionCone>(
+                state, activation, crocoddyl::FrameFrictionCone(state->get_pinocchio()->getFrameId("rf_foot"), cone),
+                actuation->get_nu()),
+            0.1);
+        cost->addCost(
+            "lh_cone",
+            boost::make_shared<crocoddyl::CostModelContactFrictionCone>(
+                state, activation, crocoddyl::FrameFrictionCone(state->get_pinocchio()->getFrameId("lh_foot"), cone),
+                actuation->get_nu()),
+            0.1);
+        cost->addCost(
+            "rh_cone",
+            boost::make_shared<crocoddyl::CostModelContactFrictionCone>(
+                state, activation, crocoddyl::FrameFrictionCone(state->get_pinocchio()->getFrameId("rh_foot"), cone),
+                actuation->get_nu()),
+            0.1);
       }
       break;
     case StateModelTypes::StateMultibody_Talos:
@@ -191,16 +199,18 @@ DifferentialActionModelFactory::create_contactFwdDynamics(StateModelTypes::Type 
                                                               pinocchio::SE3().Identity()),
                                     actuation->get_nu()));
       if (with_friction) {
-        cost->addCost(
-            "lf_cone",
-            boost::make_shared<crocoddyl::CostModelContactFrictionCone>(
-                state, activation, cone, state->get_pinocchio()->getFrameId("left_sole_link"), actuation->get_nu()),
-            0.001);
-        cost->addCost(
-            "rf_cone",
-            boost::make_shared<crocoddyl::CostModelContactFrictionCone>(
-                state, activation, cone, state->get_pinocchio()->getFrameId("right_sole_link"), actuation->get_nu()),
-            0.001);
+        cost->addCost("lf_cone",
+                      boost::make_shared<crocoddyl::CostModelContactFrictionCone>(
+                          state, activation,
+                          crocoddyl::FrameFrictionCone(state->get_pinocchio()->getFrameId("left_sole_link"), cone),
+                          actuation->get_nu()),
+                      0.001);
+        cost->addCost("rf_cone",
+                      boost::make_shared<crocoddyl::CostModelContactFrictionCone>(
+                          state, activation,
+                          crocoddyl::FrameFrictionCone(state->get_pinocchio()->getFrameId("right_sole_link"), cone),
+                          actuation->get_nu()),
+                      0.001);
       }
       break;
     default:


### PR DESCRIPTION
Currently, if we want to set a new reference value to a cost function (from an action model) we need to downcast cost to the specific one.
This creates a lot of code complexity for c++ developers due to tons of code dedicated to do downcasting.

With this PR, I proposed a solution to reduce this undesired complexity.
Now if you want to retrieve a reference from a cost abstraction, you could do:
```cpp
Eigen::VectorXd u_ref;
control_cost.get_reference(u_ref);

crocoddyl::FramePlacement M_ref;
frame_cost.get_reference(M_ref);
```
instead to set a reference value, you might do:
```cpp
control_cost.set_reference(u_ref);
frame_cost.set_reference(M_ref);
```

**Note that the old getter and setter functions are there**. So these modifications are back compatible and does not break the current API.

@wxmerkt and @proyan -- this features are for you. I will work in other aspects to make our life much easier.