### PR TITLE
Included status information of costs (active / inactive)

### DIFF
--- a/bindings/python/crocoddyl/multibody/contacts/multiple-contacts.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/multiple-contacts.cpp
@@ -125,6 +125,15 @@ void exposeContactMultiple() {
           "Create multicontact data.\n\n"
           ":param model: multicontact model\n"
           ":param data: Pinocchio data")[bp::with_custodian_and_ward<1, 2, bp::with_custodian_and_ward<1, 3> >()])
+      .add_property("Jc", bp::make_getter(&ContactDataMultiple::Jc, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_setter(&ContactDataMultiple::Jc), "Jacobian for all contacts (active and inactive)")
+      .add_property("a0", bp::make_getter(&ContactDataMultiple::a0, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_setter(&ContactDataMultiple::a0),
+                    "desired acceleration for all contacts (active and inactive)")
+      .add_property("da0_dx",
+                    bp::make_getter(&ContactDataMultiple::da0_dx, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_setter(&ContactDataMultiple::da0_dx),
+                    "Jacobian of the desired acceleration for all contacts (active and inactive)")
       .add_property("dv", bp::make_getter(&ContactDataMultiple::dv, bp::return_value_policy<bp::return_by_value>()),
                     bp::make_setter(&ContactDataMultiple::dv), "constrained acceleration in generalized coordinates")
       .add_property("ddv_dx",

--- a/bindings/python/crocoddyl/multibody/contacts/multiple-contacts.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/multiple-contacts.cpp
@@ -108,7 +108,11 @@ void exposeContactMultiple() {
           "state of the multibody system")
       .add_property("nc",
                     bp::make_function(&ContactModelMultiple::get_nc, bp::return_value_policy<bp::return_by_value>()),
-                    "dimension of the total contact vector")
+                    "dimension of the active contact vector")
+      .add_property(
+          "nc_total",
+          bp::make_function(&ContactModelMultiple::get_nc_total, bp::return_value_policy<bp::return_by_value>()),
+          "dimension of the total contact vector")
       .add_property("nu",
                     bp::make_function(&ContactModelMultiple::get_nu, bp::return_value_policy<bp::return_by_value>()),
                     "dimension of control vector");

--- a/bindings/python/crocoddyl/multibody/contacts/multiple-contacts.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/multiple-contacts.cpp
@@ -130,10 +130,10 @@ void exposeContactMultiple() {
       .add_property("a0", bp::make_getter(&ContactDataMultiple::a0, bp::return_internal_reference<>()),
                     bp::make_setter(&ContactDataMultiple::a0),
                     "desired acceleration for all contacts (active and inactive)")
-      .add_property("da0_dx",
-                    bp::make_getter(&ContactDataMultiple::da0_dx,  bp::return_internal_reference<>()),
+      .add_property("da0_dx", bp::make_getter(&ContactDataMultiple::da0_dx, bp::return_internal_reference<>()),
                     bp::make_setter(&ContactDataMultiple::da0_dx),
                     "Jacobian of the desired acceleration for all contacts (active and inactive)")
+      .add_property("dv", bp::make_getter(&ContactDataMultiple::dv, bp::return_internal_reference<>()),
                     bp::make_setter(&ContactDataMultiple::dv), "constrained acceleration in generalized coordinates")
       .add_property("ddv_dx", bp::make_getter(&ContactDataMultiple::ddv_dx, bp::return_internal_reference<>()),
                     bp::make_setter(&ContactDataMultiple::ddv_dx),

--- a/bindings/python/crocoddyl/multibody/contacts/multiple-contacts.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/multiple-contacts.cpp
@@ -35,14 +35,13 @@ void exposeContactMultiple() {
 
   bp::register_ptr_to_python<boost::shared_ptr<ContactItem> >();
 
-  bp::class_<ContactItem, boost::noncopyable>(
-      "ContactItem", "Describe a contact item.\n\n",
-      bp::init<std::string, boost::shared_ptr<ContactModelAbstract>, bp::optional<bool> >(
-          bp::args("self", "name", "contact", "active"),
-          "Initialize the contact item.\n\n"
-          ":param name: contact name\n"
-          ":param contact: contact model\n"
-          ":param active: True if the contact is activated (default true)"))
+  bp::class_<ContactItem>("ContactItem", "Describe a contact item.\n\n",
+                          bp::init<std::string, boost::shared_ptr<ContactModelAbstract>, bp::optional<bool> >(
+                              bp::args("self", "name", "contact", "active"),
+                              "Initialize the contact item.\n\n"
+                              ":param name: contact name\n"
+                              ":param contact: contact model\n"
+                              ":param active: True if the contact is activated (default true)"))
       .def_readwrite("name", &ContactItem::name, "contact name")
       .add_property("contact", bp::make_getter(&ContactItem::contact, bp::return_value_policy<bp::return_by_value>()),
                     "contact model")
@@ -50,7 +49,7 @@ void exposeContactMultiple() {
 
   bp::register_ptr_to_python<boost::shared_ptr<ContactModelMultiple> >();
 
-  bp::class_<ContactModelMultiple, boost::noncopyable>(
+  bp::class_<ContactModelMultiple>(
       "ContactModelMultiple",
       bp::init<boost::shared_ptr<StateMultibody>, bp::optional<int> >(bp::args("self", "state", "nu"),
                                                                       "Initialize the multiple contact model.\n\n"
@@ -117,7 +116,9 @@ void exposeContactMultiple() {
                     bp::make_function(&ContactModelMultiple::get_nu, bp::return_value_policy<bp::return_by_value>()),
                     "dimension of control vector");
 
-  bp::class_<ContactDataMultiple, boost::shared_ptr<ContactDataMultiple>, bp::bases<ContactDataAbstract> >(
+  bp::register_ptr_to_python<boost::shared_ptr<ContactDataMultiple> >();
+
+  bp::class_<ContactDataMultiple>(
       "ContactDataMultiple", "Data class for multiple contacts.\n\n",
       bp::init<ContactModelMultiple*, pinocchio::Data*>(
           bp::args("self", "model", "data"),

--- a/bindings/python/crocoddyl/multibody/costs/cost-sum.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/cost-sum.cpp
@@ -116,6 +116,9 @@ void exposeCostSum() {
       .add_property("nu", bp::make_function(&CostModelSum::get_nu, bp::return_value_policy<bp::return_by_value>()),
                     "dimension of control vector")
       .add_property("nr", bp::make_function(&CostModelSum::get_nr, bp::return_value_policy<bp::return_by_value>()),
+                    "dimension of the residual vector of active cost")
+      .add_property("nr_total",
+                    bp::make_function(&CostModelSum::get_nr_total, bp::return_value_policy<bp::return_by_value>()),
                     "dimension of the total residual vector");
 
   bp::class_<CostDataSum, boost::shared_ptr<CostDataSum>, boost::noncopyable>(

--- a/bindings/python/crocoddyl/multibody/costs/cost-sum.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/cost-sum.cpp
@@ -38,15 +38,14 @@ void exposeCostSum() {
 
   bp::register_ptr_to_python<boost::shared_ptr<CostItem> >();
 
-  bp::class_<CostItem, boost::noncopyable>(
-      "CostItem", "Describe a cost item.\n\n",
-      bp::init<std::string, boost::shared_ptr<CostModelAbstract>, double, bp::optional<bool> >(
-          bp::args("self", "name", "cost", "weight", "active"),
-          "Initialize the cost item.\n\n"
-          ":param name: cost name\n"
-          ":param cost: cost model\n"
-          ":param weight: cost weight\n"
-          ":param active: True if the cost is activated (default true)"))
+  bp::class_<CostItem>("CostItem", "Describe a cost item.\n\n",
+                       bp::init<std::string, boost::shared_ptr<CostModelAbstract>, double, bp::optional<bool> >(
+                           bp::args("self", "name", "cost", "weight", "active"),
+                           "Initialize the cost item.\n\n"
+                           ":param name: cost name\n"
+                           ":param cost: cost model\n"
+                           ":param weight: cost weight\n"
+                           ":param active: True if the cost is activated (default true)"))
       .def_readwrite("name", &CostItem::name, "cost name")
       .add_property("cost", bp::make_getter(&CostItem::cost, bp::return_value_policy<bp::return_by_value>()),
                     "cost model")
@@ -56,12 +55,11 @@ void exposeCostSum() {
 
   bp::register_ptr_to_python<boost::shared_ptr<CostModelSum> >();
 
-  bp::class_<CostModelSum, boost::noncopyable>(
-      "CostModelSum",
-      bp::init<boost::shared_ptr<StateMultibody>, std::size_t>(bp::args("self", "state", "nu"),
-                                                               "Initialize the total cost model.\n\n"
-                                                               ":param state: state of the multibody system\n"
-                                                               ":param nu: dimension of control vector"))
+  bp::class_<CostModelSum>("CostModelSum", bp::init<boost::shared_ptr<StateMultibody>, std::size_t>(
+                                               bp::args("self", "state", "nu"),
+                                               "Initialize the total cost model.\n\n"
+                                               ":param state: state of the multibody system\n"
+                                               ":param nu: dimension of control vector"))
       .def(bp::init<boost::shared_ptr<StateMultibody>, std::size_t>(
           bp::args("self", "state", "nu"),
           "Initialize the total cost model.\n\n"
@@ -121,7 +119,9 @@ void exposeCostSum() {
                     bp::make_function(&CostModelSum::get_nr_total, bp::return_value_policy<bp::return_by_value>()),
                     "dimension of the total residual vector");
 
-  bp::class_<CostDataSum, boost::shared_ptr<CostDataSum>, boost::noncopyable>(
+  bp::register_ptr_to_python<boost::shared_ptr<CostDataSum> >();
+
+  bp::class_<CostDataSum>(
       "CostDataSum", "Class for total cost data.\n\n",
       bp::init<CostModelSum*, DataCollectorAbstract*>(bp::args("self", "model", "data"),
                                                       "Create total cost data.\n\n"

--- a/bindings/python/crocoddyl/multibody/costs/cost-sum.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/cost-sum.cpp
@@ -20,6 +20,7 @@
 namespace crocoddyl {
 namespace python {
 
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(CostModelSum_addContact_wrap, CostModelSum::addCost, 3, 4)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(CostModelSum_calc_wraps, CostModelSum::calc_wrap, 2, 3)
 
 void exposeCostSum() {
@@ -39,15 +40,19 @@ void exposeCostSum() {
 
   bp::class_<CostItem, boost::noncopyable>(
       "CostItem", "Describe a cost item.\n\n",
-      bp::init<std::string, boost::shared_ptr<CostModelAbstract>, double>(bp::args("self", "name", "cost", "weight"),
-                                                                          "Initialize the cost item.\n\n"
-                                                                          ":param name: cost name\n"
-                                                                          ":param cost: cost model\n"
-                                                                          ":param weight: cost weight"))
+      bp::init<std::string, boost::shared_ptr<CostModelAbstract>, double, bp::optional<bool> >(
+          bp::args("self", "name", "cost", "weight", "active"),
+          "Initialize the cost item.\n\n"
+          ":param name: cost name\n"
+          ":param cost: cost model\n"
+          ":param weight: cost weight\n"
+          ":param active: True if the cost is activated (default true)"))
       .def_readwrite("name", &CostItem::name, "cost name")
       .add_property("cost", bp::make_getter(&CostItem::cost, bp::return_value_policy<bp::return_by_value>()),
                     "cost model")
-      .def_readwrite("weight", &CostItem::weight, "cost weight");
+      .def_readwrite("weight", &CostItem::weight, "cost weight")
+      .def_readwrite("active", &CostItem::active, "cost status");
+  ;
 
   bp::register_ptr_to_python<boost::shared_ptr<CostModelSum> >();
 
@@ -68,14 +73,20 @@ void exposeCostSum() {
                                                         "Initialize the total cost model.\n\n"
                                                         "For this case the default nu is equals to model.nv.\n"
                                                         ":param state: state of the multibody system"))
-      .def("addCost", &CostModelSum::addCost, bp::args("self", "name", "cost", "weight"),
-           "Add a cost item.\n\n"
-           ":param name: cost name\n"
-           ":param cost: cost model\n"
-           ":param weight: cost weight")
+      .def("addCost", &CostModelSum::addCost,
+           CostModelSum_addContact_wrap(bp::args("self", "name", "cost", "weight", "active"),
+                                        "Add a cost item.\n\n"
+                                        ":param name: cost name\n"
+                                        ":param cost: cost model\n"
+                                        ":param weight: cost weight\n"
+                                        ":param active: True if the cost is activated (default true)"))
       .def("removeCost", &CostModelSum::removeCost, bp::args("self", "name"),
            "Remove a cost item.\n\n"
            ":param name: cost name")
+      .def("changeCostStatus", &CostModelSum::changeCostStatus, bp::args("self", "name", "active"),
+           "Change the cost status.\n\n"
+           ":param name: cost name\n"
+           ":param active: cost status (true for active and false for inactive)")
       .def("calc", &CostModelSum::calc_wrap,
            CostModelSum_calc_wraps(bp::args("self", "data", "x", "u"),
                                    "Compute the total cost.\n\n"

--- a/bindings/python/crocoddyl/multibody/impulses/multiple-impulses.cpp
+++ b/bindings/python/crocoddyl/multibody/impulses/multiple-impulses.cpp
@@ -125,6 +125,12 @@ void exposeImpulseMultiple() {
           "Create multi-impulse data.\n\n"
           ":param model: multi-impulse model\n"
           ":param data: Pinocchio data")[bp::with_custodian_and_ward<1, 2, bp::with_custodian_and_ward<1, 3> >()])
+      .add_property("Jc", bp::make_getter(&ImpulseDataMultiple::Jc, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_setter(&ImpulseDataMultiple::Jc), "Jacobian for all impulses (active and inactive)")
+      .add_property("dv0_dq",
+                    bp::make_getter(&ImpulseDataMultiple::dv0_dq, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_setter(&ImpulseDataMultiple::dv0_dq),
+                    "Jacobian of the previous impulse velocity (active and inactive)")
       .add_property("vnext",
                     bp::make_getter(&ImpulseDataMultiple::vnext, bp::return_value_policy<bp::return_by_value>()),
                     bp::make_setter(&ImpulseDataMultiple::vnext), "impulse velocity")

--- a/bindings/python/crocoddyl/multibody/impulses/multiple-impulses.cpp
+++ b/bindings/python/crocoddyl/multibody/impulses/multiple-impulses.cpp
@@ -127,8 +127,7 @@ void exposeImpulseMultiple() {
           ":param data: Pinocchio data")[bp::with_custodian_and_ward<1, 2, bp::with_custodian_and_ward<1, 3> >()])
       .add_property("Jc", bp::make_getter(&ImpulseDataMultiple::Jc, bp::return_internal_reference<>()),
                     bp::make_setter(&ImpulseDataMultiple::Jc), "Jacobian for all impulses (active and inactive)")
-      .add_property("dv0_dq",
-                    bp::make_getter(&ImpulseDataMultiple::dv0_dq, bp::return_internal_reference<>()),
+      .add_property("dv0_dq", bp::make_getter(&ImpulseDataMultiple::dv0_dq, bp::return_internal_reference<>()),
                     bp::make_setter(&ImpulseDataMultiple::dv0_dq),
                     "Jacobian of the previous impulse velocity (active and inactive)")
       .add_property("vnext", bp::make_getter(&ImpulseDataMultiple::vnext, bp::return_internal_reference<>()),

--- a/bindings/python/crocoddyl/multibody/impulses/multiple-impulses.cpp
+++ b/bindings/python/crocoddyl/multibody/impulses/multiple-impulses.cpp
@@ -35,14 +35,13 @@ void exposeImpulseMultiple() {
 
   bp::register_ptr_to_python<boost::shared_ptr<ImpulseItem> >();
 
-  bp::class_<ImpulseItem, boost::noncopyable>(
-      "ImpulseItem", "Describe a impulse item.\n\n",
-      bp::init<std::string, boost::shared_ptr<ImpulseModelAbstract>, bp::optional<bool> >(
-          bp::args("self", "name", "impulse", "active"),
-          "Initialize the impulse item.\n\n"
-          ":param name: impulse name\n"
-          ":param impulse: impulse model\n"
-          ":param active: True if the impulse is activated (default true)"))
+  bp::class_<ImpulseItem>("ImpulseItem", "Describe a impulse item.\n\n",
+                          bp::init<std::string, boost::shared_ptr<ImpulseModelAbstract>, bp::optional<bool> >(
+                              bp::args("self", "name", "impulse", "active"),
+                              "Initialize the impulse item.\n\n"
+                              ":param name: impulse name\n"
+                              ":param impulse: impulse model\n"
+                              ":param active: True if the impulse is activated (default true)"))
       .def_readwrite("name", &ImpulseItem::name, "impulse name")
       .add_property("impulse", bp::make_getter(&ImpulseItem::impulse, bp::return_value_policy<bp::return_by_value>()),
                     "impulse model")
@@ -51,11 +50,10 @@ void exposeImpulseMultiple() {
 
   bp::register_ptr_to_python<boost::shared_ptr<ImpulseModelMultiple> >();
 
-  bp::class_<ImpulseModelMultiple, boost::noncopyable>(
-      "ImpulseModelMultiple",
-      bp::init<boost::shared_ptr<StateMultibody> >(bp::args("self", "state"),
-                                                   "Initialize the multiple impulse model.\n\n"
-                                                   ":param state: state of the multibody system"))
+  bp::class_<ImpulseModelMultiple>("ImpulseModelMultiple", bp::init<boost::shared_ptr<StateMultibody> >(
+                                                               bp::args("self", "state"),
+                                                               "Initialize the multiple impulse model.\n\n"
+                                                               ":param state: state of the multibody system"))
       .def("addImpulse", &ImpulseModelMultiple::addImpulse,
            ImpulseModelMultiple_addImpulse_wrap(bp::args("self", "name", "impulse", "active"),
                                                 "Add an impulse item.\n\n"
@@ -118,12 +116,14 @@ void exposeImpulseMultiple() {
           bp::make_function(&ImpulseModelMultiple::get_ni_total, bp::return_value_policy<bp::return_by_value>()),
           "dimension of the total impulse vector");
 
-  bp::class_<ImpulseDataMultiple, boost::shared_ptr<ImpulseDataMultiple>, bp::bases<ImpulseDataAbstract> >(
+  bp::register_ptr_to_python<boost::shared_ptr<ImpulseDataMultiple> >();
+
+  bp::class_<ImpulseDataMultiple>(
       "ImpulseDataMultiple", "Data class for multiple impulses.\n\n",
       bp::init<ImpulseModelMultiple*, pinocchio::Data*>(
           bp::args("self", "model", "data"),
-          "Create multiimpulse data.\n\n"
-          ":param model: multiimpulse model\n"
+          "Create multi-impulse data.\n\n"
+          ":param model: multi-impulse model\n"
           ":param data: Pinocchio data")[bp::with_custodian_and_ward<1, 2, bp::with_custodian_and_ward<1, 3> >()])
       .add_property("vnext",
                     bp::make_getter(&ImpulseDataMultiple::vnext, bp::return_value_policy<bp::return_by_value>()),

--- a/bindings/python/crocoddyl/multibody/impulses/multiple-impulses.cpp
+++ b/bindings/python/crocoddyl/multibody/impulses/multiple-impulses.cpp
@@ -112,7 +112,11 @@ void exposeImpulseMultiple() {
           "state of the multibody system")
       .add_property("ni",
                     bp::make_function(&ImpulseModelMultiple::get_ni, bp::return_value_policy<bp::return_by_value>()),
-                    "dimension of the total impulse vector");
+                    "dimension of the active impulse vector")
+      .add_property(
+          "ni_total",
+          bp::make_function(&ImpulseModelMultiple::get_ni_total, bp::return_value_policy<bp::return_by_value>()),
+          "dimension of the total impulse vector");
 
   bp::class_<ImpulseDataMultiple, boost::shared_ptr<ImpulseDataMultiple>, bp::bases<ImpulseDataAbstract> >(
       "ImpulseDataMultiple", "Data class for multiple impulses.\n\n",

--- a/include/crocoddyl/multibody/contacts/multiple-contacts.hpp
+++ b/include/crocoddyl/multibody/contacts/multiple-contacts.hpp
@@ -100,29 +100,27 @@ class ContactModelMultipleTpl {
 };
 
 template <typename _Scalar>
-struct ContactDataMultipleTpl : ContactDataAbstractTpl<_Scalar> {
+struct ContactDataMultipleTpl {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   typedef _Scalar Scalar;
   typedef MathBaseTpl<Scalar> MathBase;
-  typedef ContactDataAbstractTpl<Scalar> Base;
   typedef ContactModelMultipleTpl<Scalar> ContactModelMultiple;
   typedef ContactItemTpl<Scalar> ContactItem;
-
-  typedef typename MathBase::Vector2s Vector2s;
-  typedef typename MathBase::Vector3s Vector3s;
-  typedef typename MathBase::Matrix3s Matrix3s;
-  typedef typename MathBase::Matrix6xs Matrix6xs;
-  typedef typename MathBase::Matrix6s Matrix6s;
   typedef typename MathBase::VectorXs VectorXs;
   typedef typename MathBase::MatrixXs MatrixXs;
 
   template <template <typename Scalar> class Model>
   ContactDataMultipleTpl(Model<Scalar>* const model, pinocchio::DataTpl<Scalar>* const data)
-      : Base(model, data),
+      : Jc(model->get_nc_total(), model->get_state()->get_nv()),
+        a0(model->get_nc_total()),
+        da0_dx(model->get_nc_total(), model->get_state()->get_ndx()),
         dv(model->get_state()->get_nv()),
         ddv_dx(model->get_state()->get_nv(), model->get_state()->get_ndx()),
         fext(model->get_state()->get_pinocchio()->njoints, pinocchio::ForceTpl<Scalar>::Zero()) {
+    Jc.setZero();
+    a0.setZero();
+    da0_dx.setZero();
     dv.setZero();
     ddv_dx.setZero();
     for (typename ContactModelMultiple::ContactModelContainer::const_iterator it = model->get_contacts().begin();
@@ -132,6 +130,9 @@ struct ContactDataMultipleTpl : ContactDataAbstractTpl<_Scalar> {
     }
   }
 
+  MatrixXs Jc;
+  VectorXs a0;
+  MatrixXs da0_dx;
   VectorXs dv;
   MatrixXs ddv_dx;
   typename ContactModelMultiple::ContactDataContainer contacts;

--- a/include/crocoddyl/multibody/contacts/multiple-contacts.hpp
+++ b/include/crocoddyl/multibody/contacts/multiple-contacts.hpp
@@ -79,12 +79,14 @@ class ContactModelMultipleTpl {
   const boost::shared_ptr<StateMultibody>& get_state() const;
   const ContactModelContainer& get_contacts() const;
   const std::size_t& get_nc() const;
+  const std::size_t& get_nc_total() const;
   const std::size_t& get_nu() const;
 
  private:
   boost::shared_ptr<StateMultibody> state_;
   ContactModelContainer contacts_;
   std::size_t nc_;
+  std::size_t nc_total_;
   std::size_t nu_;
 
 #ifdef PYTHON_BINDINGS

--- a/include/crocoddyl/multibody/contacts/multiple-contacts.hpp
+++ b/include/crocoddyl/multibody/contacts/multiple-contacts.hpp
@@ -24,13 +24,14 @@ struct ContactItemTpl {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   typedef _Scalar Scalar;
+  typedef ContactModelAbstractTpl<Scalar> ContactModelAbstract;
+
   ContactItemTpl() {}
-  ContactItemTpl(const std::string& name, boost::shared_ptr<ContactModelAbstractTpl<Scalar> > contact,
-                 bool active = true)
+  ContactItemTpl(const std::string& name, boost::shared_ptr<ContactModelAbstract> contact, bool active = true)
       : name(name), contact(contact), active(active) {}
 
   std::string name;
-  boost::shared_ptr<ContactModelAbstractTpl<Scalar> > contact;
+  boost::shared_ptr<ContactModelAbstract> contact;
   bool active;
 };
 

--- a/include/crocoddyl/multibody/contacts/multiple-contacts.hxx
+++ b/include/crocoddyl/multibody/contacts/multiple-contacts.hxx
@@ -34,6 +34,8 @@ void ContactModelMultipleTpl<Scalar>::addContact(const std::string& name,
   } else if (active) {
     nc_ += contact->get_nc();
     nc_total_ += contact->get_nc();
+  } else if (!active) {
+    nc_total_ += contact->get_nc();
   }
 }
 

--- a/include/crocoddyl/multibody/contacts/multiple-contacts.hxx
+++ b/include/crocoddyl/multibody/contacts/multiple-contacts.hxx
@@ -11,11 +11,11 @@ namespace crocoddyl {
 template <typename Scalar>
 ContactModelMultipleTpl<Scalar>::ContactModelMultipleTpl(boost::shared_ptr<StateMultibody> state,
                                                          const std::size_t& nu)
-    : state_(state), nc_(0), nu_(nu) {}
+    : state_(state), nc_(0), nc_total_(0), nu_(nu) {}
 
 template <typename Scalar>
 ContactModelMultipleTpl<Scalar>::ContactModelMultipleTpl(boost::shared_ptr<StateMultibody> state)
-    : state_(state), nc_(0), nu_(state->get_nv()) {}
+    : state_(state), nc_(0), nc_total_(0), nu_(state->get_nv()) {}
 
 template <typename Scalar>
 ContactModelMultipleTpl<Scalar>::~ContactModelMultipleTpl() {}
@@ -33,6 +33,7 @@ void ContactModelMultipleTpl<Scalar>::addContact(const std::string& name,
     std::cout << "Warning: this contact item already existed, we cannot add it" << std::endl;
   } else if (active) {
     nc_ += contact->get_nc();
+    nc_total_ += contact->get_nc();
   }
 }
 
@@ -41,6 +42,7 @@ void ContactModelMultipleTpl<Scalar>::removeContact(const std::string& name) {
   typename ContactModelContainer::iterator it = contacts_.find(name);
   if (it != contacts_.end()) {
     nc_ -= it->second->contact->get_nc();
+    nc_total_ -= it->second->contact->get_nc();
     contacts_.erase(it);
   } else {
     std::cout << "Warning: this contact item doesn't exist, we cannot remove it" << std::endl;
@@ -232,6 +234,11 @@ const typename ContactModelMultipleTpl<Scalar>::ContactModelContainer& ContactMo
 template <typename Scalar>
 const std::size_t& ContactModelMultipleTpl<Scalar>::get_nc() const {
   return nc_;
+}
+
+template <typename Scalar>
+const std::size_t& ContactModelMultipleTpl<Scalar>::get_nc_total() const {
+  return nc_total_;
 }
 
 template <typename Scalar>

--- a/include/crocoddyl/multibody/costs/cost-sum.hpp
+++ b/include/crocoddyl/multibody/costs/cost-sum.hpp
@@ -27,12 +27,14 @@ struct CostItemTpl {
   typedef CostModelAbstractTpl<Scalar> CostModelAbstract;
 
   CostItemTpl() {}
-  CostItemTpl(const std::string& name, boost::shared_ptr<CostModelAbstractTpl<Scalar> > cost, const Scalar& weight)
-      : name(name), cost(cost), weight(weight) {}
+  CostItemTpl(const std::string& name, boost::shared_ptr<CostModelAbstract> cost, const Scalar& weight,
+              bool active = true)
+      : name(name), cost(cost), weight(weight), active(active) {}
 
   std::string name;
   boost::shared_ptr<CostModelAbstract> cost;
   Scalar weight;
+  bool active;
 };
 
 template <typename _Scalar>
@@ -57,8 +59,10 @@ class CostModelSumTpl {
   explicit CostModelSumTpl(boost::shared_ptr<StateMultibody> state);
   ~CostModelSumTpl();
 
-  void addCost(const std::string& name, boost::shared_ptr<CostModelAbstract> cost, const Scalar& weight);
+  void addCost(const std::string& name, boost::shared_ptr<CostModelAbstract> cost, const Scalar& weight,
+               bool active = true);
   void removeCost(const std::string& name);
+  void changeCostStatus(const std::string& name, bool active);
 
   void calc(const boost::shared_ptr<CostDataSumTpl<Scalar> >& data, const Eigen::Ref<const VectorXs>& x,
             const Eigen::Ref<const VectorXs>& u);

--- a/include/crocoddyl/multibody/costs/cost-sum.hpp
+++ b/include/crocoddyl/multibody/costs/cost-sum.hpp
@@ -77,12 +77,14 @@ class CostModelSumTpl {
   const CostModelContainer& get_costs() const;
   const std::size_t& get_nu() const;
   const std::size_t& get_nr() const;
+  const std::size_t& get_nr_total() const;
 
  private:
   boost::shared_ptr<StateMultibody> state_;
   CostModelContainer costs_;
   std::size_t nu_;
   std::size_t nr_;
+  std::size_t nr_total_;
   VectorXs unone_;
 
 #ifdef PYTHON_BINDINGS

--- a/include/crocoddyl/multibody/costs/cost-sum.hpp
+++ b/include/crocoddyl/multibody/costs/cost-sum.hpp
@@ -19,16 +19,19 @@
 
 namespace crocoddyl {
 
-template <typename Scalar>
+template <typename _Scalar>
 struct CostItemTpl {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  typedef _Scalar Scalar;
+  typedef CostModelAbstractTpl<Scalar> CostModelAbstract;
 
   CostItemTpl() {}
   CostItemTpl(const std::string& name, boost::shared_ptr<CostModelAbstractTpl<Scalar> > cost, const Scalar& weight)
       : name(name), cost(cost), weight(weight) {}
 
   std::string name;
-  boost::shared_ptr<CostModelAbstractTpl<Scalar> > cost;
+  boost::shared_ptr<CostModelAbstract> cost;
   Scalar weight;
 };
 

--- a/include/crocoddyl/multibody/costs/cost-sum.hpp
+++ b/include/crocoddyl/multibody/costs/cost-sum.hpp
@@ -115,9 +115,6 @@ struct CostDataSumTpl {
 
   typedef _Scalar Scalar;
   typedef MathBaseTpl<Scalar> MathBase;
-  typedef StateMultibodyTpl<Scalar> StateMultibody;
-  typedef CostModelAbstractTpl<Scalar> CostModelAbstract;
-  typedef CostDataAbstractTpl<Scalar> CostDataAbstract;
   typedef DataCollectorAbstractTpl<Scalar> DataCollectorAbstract;
   typedef CostItemTpl<Scalar> CostItem;
   typedef typename MathBase::VectorXs VectorXs;

--- a/include/crocoddyl/multibody/costs/cost-sum.hxx
+++ b/include/crocoddyl/multibody/costs/cost-sum.hxx
@@ -13,11 +13,11 @@ namespace crocoddyl {
 
 template <typename Scalar>
 CostModelSumTpl<Scalar>::CostModelSumTpl(boost::shared_ptr<StateMultibody> state, const std::size_t& nu)
-    : state_(state), nu_(nu), nr_(0) {}
+    : state_(state), nu_(nu), nr_(0), nr_total_(0) {}
 
 template <typename Scalar>
 CostModelSumTpl<Scalar>::CostModelSumTpl(boost::shared_ptr<StateMultibody> state)
-    : state_(state), nu_(state->get_nv()), nr_(0) {}
+    : state_(state), nu_(state->get_nv()), nr_(0), nr_total_(0) {}
 
 template <typename Scalar>
 CostModelSumTpl<Scalar>::~CostModelSumTpl() {}
@@ -34,6 +34,7 @@ void CostModelSumTpl<Scalar>::addCost(const std::string& name, boost::shared_ptr
     std::cout << "Warning: this cost item already existed, we cannot add it" << std::endl;
   } else if (active) {
     nr_ += cost->get_activation()->get_nr();
+    nr_total_ += cost->get_activation()->get_nr();
   }
 }
 
@@ -42,6 +43,7 @@ void CostModelSumTpl<Scalar>::removeCost(const std::string& name) {
   typename CostModelContainer::iterator it = costs_.find(name);
   if (it != costs_.end()) {
     nr_ -= it->second->cost->get_activation()->get_nr();
+    nr_total_ -= it->second->cost->get_activation()->get_nr();
     costs_.erase(it);
   } else {
     std::cout << "Warning: this cost item doesn't exist, we cannot remove it" << std::endl;
@@ -170,6 +172,11 @@ const std::size_t& CostModelSumTpl<Scalar>::get_nu() const {
 template <typename Scalar>
 const std::size_t& CostModelSumTpl<Scalar>::get_nr() const {
   return nr_;
+}
+
+template <typename Scalar>
+const std::size_t& CostModelSumTpl<Scalar>::get_nr_total() const {
+  return nr_total_;
 }
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/multibody/costs/cost-sum.hxx
+++ b/include/crocoddyl/multibody/costs/cost-sum.hxx
@@ -35,6 +35,8 @@ void CostModelSumTpl<Scalar>::addCost(const std::string& name, boost::shared_ptr
   } else if (active) {
     nr_ += cost->get_activation()->get_nr();
     nr_total_ += cost->get_activation()->get_nr();
+  } else if (!active) {
+    nr_total_ += cost->get_activation()->get_nr();
   }
 }
 

--- a/include/crocoddyl/multibody/impulses/multiple-impulses.hpp
+++ b/include/crocoddyl/multibody/impulses/multiple-impulses.hpp
@@ -77,11 +77,13 @@ class ImpulseModelMultipleTpl {
   const boost::shared_ptr<StateMultibody>& get_state() const;
   const ImpulseModelContainer& get_impulses() const;
   const std::size_t& get_ni() const;
+  const std::size_t& get_ni_total() const;
 
  private:
   boost::shared_ptr<StateMultibody> state_;
   ImpulseModelContainer impulses_;
   std::size_t ni_;
+  std::size_t ni_total_;
 
 #ifdef PYTHON_BINDINGS
 

--- a/include/crocoddyl/multibody/impulses/multiple-impulses.hpp
+++ b/include/crocoddyl/multibody/impulses/multiple-impulses.hpp
@@ -22,15 +22,16 @@ namespace crocoddyl {
 template <typename _Scalar>
 struct ImpulseItemTpl {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   typedef _Scalar Scalar;
+  typedef ImpulseModelAbstractTpl<Scalar> ImpulseModelAbstract;
 
   ImpulseItemTpl() {}
-  ImpulseItemTpl(const std::string& name, boost::shared_ptr<ImpulseModelAbstractTpl<Scalar> > impulse,
-                 bool active = true)
+  ImpulseItemTpl(const std::string& name, boost::shared_ptr<ImpulseModelAbstract> impulse, bool active = true)
       : name(name), impulse(impulse), active(active) {}
 
   std::string name;
-  boost::shared_ptr<ImpulseModelAbstractTpl<Scalar> > impulse;
+  boost::shared_ptr<ImpulseModelAbstract> impulse;
   bool active;
 };
 

--- a/include/crocoddyl/multibody/impulses/multiple-impulses.hpp
+++ b/include/crocoddyl/multibody/impulses/multiple-impulses.hpp
@@ -96,26 +96,25 @@ class ImpulseModelMultipleTpl {
 };
 
 template <typename _Scalar>
-struct ImpulseDataMultipleTpl : ImpulseDataAbstractTpl<_Scalar> {
+struct ImpulseDataMultipleTpl {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   typedef _Scalar Scalar;
   typedef MathBaseTpl<Scalar> MathBase;
-  typedef ImpulseDataAbstractTpl<Scalar> Base;
   typedef ImpulseModelMultipleTpl<Scalar> ImpulseModelMultiple;
-  typedef StateMultibodyTpl<Scalar> StateMultibody;
   typedef ImpulseItemTpl<Scalar> ImpulseItem;
-
-  typedef typename MathBase::Vector2s Vector2s;
-  typedef typename MathBase::Vector3s Vector3s;
   typedef typename MathBase::VectorXs VectorXs;
   typedef typename MathBase::MatrixXs MatrixXs;
 
   template <template <typename Scalar> class Model>
   ImpulseDataMultipleTpl(Model<Scalar>* const model, pinocchio::DataTpl<Scalar>* const data)
-      : Base(model, data),
+      : Jc(model->get_ni_total(), model->get_state()->get_nv()),
+        dv0_dq(model->get_ni_total(), model->get_state()->get_nv()),
         vnext(model->get_state()->get_nv()),
         dvnext_dx(model->get_state()->get_nv(), model->get_state()->get_ndx()),
         fext(model->get_state()->get_pinocchio()->njoints, pinocchio::ForceTpl<Scalar>::Zero()) {
+    Jc.setZero();
+    dv0_dq.setZero();
     vnext.setZero();
     dvnext_dx.setZero();
     for (typename ImpulseModelMultiple::ImpulseModelContainer::const_iterator it = model->get_impulses().begin();
@@ -125,14 +124,8 @@ struct ImpulseDataMultipleTpl : ImpulseDataAbstractTpl<_Scalar> {
     }
   }
 
-  using Base::df_dq;
-  using Base::dv0_dq;
-  using Base::f;
-  using Base::frame;
-  using Base::Jc;
-  using Base::joint;
-  using Base::pinocchio;
-
+  MatrixXs Jc;
+  MatrixXs dv0_dq;
   VectorXs vnext;
   MatrixXs dvnext_dx;
   typename ImpulseModelMultiple::ImpulseDataContainer impulses;

--- a/include/crocoddyl/multibody/impulses/multiple-impulses.hxx
+++ b/include/crocoddyl/multibody/impulses/multiple-impulses.hxx
@@ -13,7 +13,7 @@ namespace crocoddyl {
 
 template <typename Scalar>
 ImpulseModelMultipleTpl<Scalar>::ImpulseModelMultipleTpl(boost::shared_ptr<StateMultibody> state)
-    : state_(state), ni_(0) {}
+    : state_(state), ni_(0), ni_total_(0) {}
 
 template <typename Scalar>
 ImpulseModelMultipleTpl<Scalar>::~ImpulseModelMultipleTpl() {}
@@ -27,6 +27,7 @@ void ImpulseModelMultipleTpl<Scalar>::addImpulse(const std::string& name,
     std::cout << "Warning: this impulse item already existed, we cannot add it" << std::endl;
   } else if (active) {
     ni_ += impulse->get_ni();
+    ni_total_ += impulse->get_ni();
   }
 }
 
@@ -35,6 +36,7 @@ void ImpulseModelMultipleTpl<Scalar>::removeImpulse(const std::string& name) {
   typename ImpulseModelContainer::iterator it = impulses_.find(name);
   if (it != impulses_.end()) {
     ni_ -= it->second->impulse->get_ni();
+    ni_total_ -= it->second->impulse->get_ni();
     impulses_.erase(it);
   } else {
     std::cout << "Warning: this impulse item doesn't exist, we cannot remove it" << std::endl;
@@ -218,6 +220,11 @@ const typename ImpulseModelMultipleTpl<Scalar>::ImpulseModelContainer& ImpulseMo
 template <typename Scalar>
 const std::size_t& ImpulseModelMultipleTpl<Scalar>::get_ni() const {
   return ni_;
+}
+
+template <typename Scalar>
+const std::size_t& ImpulseModelMultipleTpl<Scalar>::get_ni_total() const {
+  return ni_total_;
 }
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/multibody/impulses/multiple-impulses.hxx
+++ b/include/crocoddyl/multibody/impulses/multiple-impulses.hxx
@@ -28,6 +28,8 @@ void ImpulseModelMultipleTpl<Scalar>::addImpulse(const std::string& name,
   } else if (active) {
     ni_ += impulse->get_ni();
     ni_total_ += impulse->get_ni();
+  } else if (!active) {
+    ni_total_ += impulse->get_ni();
   }
 }
 

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -27,6 +27,7 @@ SET(${PROJECT_NAME}_CPP_TESTS
   # test_actuation
   test_activations
   test_costs
+  test_cost_sum
   test_contacts
   test_impulses
   test_multiple_contacts

--- a/unittest/factory/cost.cpp
+++ b/unittest/factory/cost.cpp
@@ -16,6 +16,7 @@
 #include "crocoddyl/multibody/costs/frame-translation.hpp"
 #include "crocoddyl/multibody/costs/frame-velocity.hpp"
 #include "crocoddyl/multibody/costs/contact-friction-cone.hpp"
+#include "crocoddyl/multibody/costs/cost-sum.hpp"
 #include "crocoddyl/core/utils/exception.hpp"
 
 namespace crocoddyl {

--- a/unittest/factory/cost.cpp
+++ b/unittest/factory/cost.cpp
@@ -119,5 +119,18 @@ boost::shared_ptr<crocoddyl::CostModelAbstract> CostModelFactory::create(CostMod
   return cost;
 }
 
+boost::shared_ptr<crocoddyl::CostModelAbstract> create_random_cost() {
+  static bool once = true;
+  if (once) {
+    srand((unsigned)time(NULL));
+    once = false;
+  }
+
+  CostModelFactory factory;
+  CostModelTypes::Type rand_type = static_cast<CostModelTypes::Type>(rand() % CostModelTypes::NbCostModelTypes);
+  return factory.create(rand_type, StateModelTypes::StateMultibody_RandomHumanoid,
+                        ActivationModelTypes::ActivationModelQuad);
+}
+
 }  // namespace unittest
 }  // namespace crocoddyl

--- a/unittest/factory/cost.hpp
+++ b/unittest/factory/cost.hpp
@@ -58,6 +58,8 @@ class CostModelFactory {
       std::size_t nu = std::numeric_limits<std::size_t>::max()) const;
 };
 
+boost::shared_ptr<crocoddyl::CostModelAbstract> create_random_cost();
+
 }  // namespace unittest
 }  // namespace crocoddyl
 

--- a/unittest/test_cost_sum.cpp
+++ b/unittest/test_cost_sum.cpp
@@ -220,7 +220,7 @@ void test_calcDiff() {
   // check the cost against single cost computations
   double cost = 0;
   Eigen::VectorXd Lx = Eigen::VectorXd::Zero(state->get_ndx());
-  Eigen::VectorXd Lu = Eigen::VectorXd::Zero(model.get_nu());;
+  Eigen::VectorXd Lu = Eigen::VectorXd::Zero(model.get_nu());
   Eigen::MatrixXd Lxx = Eigen::MatrixXd::Zero(state->get_ndx(), state->get_ndx());
   Eigen::MatrixXd Lxu = Eigen::MatrixXd::Zero(state->get_ndx(), model.get_nu());
   Eigen::MatrixXd Luu = Eigen::MatrixXd::Zero(model.get_nu(), model.get_nu());
@@ -311,7 +311,7 @@ void test_calc_diff_no_recalc() {
 
   // check the cost against single cost computations
   Eigen::VectorXd Lx = Eigen::VectorXd::Zero(state->get_ndx());
-  Eigen::VectorXd Lu = Eigen::VectorXd::Zero(model.get_nu());;
+  Eigen::VectorXd Lu = Eigen::VectorXd::Zero(model.get_nu());
   Eigen::MatrixXd Lxx = Eigen::MatrixXd::Zero(state->get_ndx(), state->get_ndx());
   Eigen::MatrixXd Lxu = Eigen::MatrixXd::Zero(state->get_ndx(), model.get_nu());
   Eigen::MatrixXd Luu = Eigen::MatrixXd::Zero(model.get_nu(), model.get_nu());

--- a/unittest/test_cost_sum.cpp
+++ b/unittest/test_cost_sum.cpp
@@ -1,0 +1,190 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2018-2020, University of Edinburgh
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#include <pinocchio/algorithm/kinematics-derivatives.hpp>
+#include <pinocchio/algorithm/frames.hpp>
+
+#include "factory/cost.hpp"
+#include "unittest_common.hpp"
+
+using namespace boost::unit_test;
+using namespace crocoddyl::unittest;
+
+//----------------------------------------------------------------------------//
+
+void test_constructor() {
+  // Setup the test
+  StateModelFactory state_factory;
+  crocoddyl::CostModelSum model(boost::static_pointer_cast<crocoddyl::StateMultibody>(
+      state_factory.create(StateModelTypes::StateMultibody_RandomHumanoid)));
+
+  // Test the initial size of the map
+  BOOST_CHECK(model.get_costs().size() == 0);
+}
+
+void test_addCost() {
+  // Setup the test
+  StateModelFactory state_factory;
+  crocoddyl::CostModelSum model(boost::static_pointer_cast<crocoddyl::StateMultibody>(
+      state_factory.create(StateModelTypes::StateMultibody_RandomHumanoid)));
+
+  // add an active cost
+  boost::shared_ptr<crocoddyl::CostModelAbstract> rand_cost_1 = create_random_cost();
+  model.addCost("random_cost_1", rand_cost_1, 1.);
+  BOOST_CHECK(model.get_nr() == rand_cost_1->get_activation()->get_nr());
+
+  // add an inactive cost
+  boost::shared_ptr<crocoddyl::CostModelAbstract> rand_cost_2 = create_random_cost();
+  model.addCost("random_cost_2", rand_cost_2, 1., false);
+  BOOST_CHECK(model.get_nr() == rand_cost_1->get_activation()->get_nr());
+
+  // change the random cost 2 status
+  model.changeCostStatus("random_cost_2", true);
+  BOOST_CHECK(model.get_nr() == rand_cost_1->get_activation()->get_nr() + rand_cost_2->get_activation()->get_nr());
+
+  // change the random cost 1 status
+  model.changeCostStatus("random_cost_1", false);
+  BOOST_CHECK(model.get_nr() == rand_cost_2->get_activation()->get_nr());
+}
+
+void test_addCost_error_message() {
+  // Setup the test
+  StateModelFactory state_factory;
+  crocoddyl::CostModelSum model(boost::static_pointer_cast<crocoddyl::StateMultibody>(
+      state_factory.create(StateModelTypes::StateMultibody_RandomHumanoid)));
+
+  // create an cost object
+  boost::shared_ptr<crocoddyl::CostModelAbstract> rand_cost = create_random_cost();
+
+  // add twice the same cost object to the container
+  model.addCost("random_cost", rand_cost, 1.);
+
+  // test error message when we add a duplicate cost
+  CaptureIOStream capture_ios;
+  capture_ios.beginCapture();
+  model.addCost("random_cost", rand_cost, 1.);
+  capture_ios.endCapture();
+  std::stringstream expected_buffer;
+  expected_buffer << "Warning: this cost item already existed, we cannot add it" << std::endl;
+  BOOST_CHECK(capture_ios.str() == expected_buffer.str());
+
+  // test error message when we change the cost status of an inexistent cost
+  capture_ios.beginCapture();
+  model.changeCostStatus("no_exist_cost", true);
+  capture_ios.endCapture();
+  expected_buffer.clear();
+  expected_buffer << "Warning: this cost item doesn't exist, we cannot change its status" << std::endl;
+  BOOST_CHECK(capture_ios.str() == expected_buffer.str());
+}
+
+void test_removeCost() {
+  // Setup the test
+  StateModelFactory state_factory;
+  crocoddyl::CostModelSum model(boost::static_pointer_cast<crocoddyl::StateMultibody>(
+      state_factory.create(StateModelTypes::StateMultibody_RandomHumanoid)));
+
+  // add an active cost
+  boost::shared_ptr<crocoddyl::CostModelAbstract> rand_cost = create_random_cost();
+  model.addCost("random_cost", rand_cost, 1.);
+  BOOST_CHECK(model.get_nr() == rand_cost->get_activation()->get_nr());
+
+  // remove the cost
+  model.removeCost("random_cost");
+  BOOST_CHECK(model.get_nr() == 0);
+}
+
+void test_removeCost_error_message() {
+  // Setup the test
+  StateModelFactory state_factory;
+  crocoddyl::CostModelSum model(boost::static_pointer_cast<crocoddyl::StateMultibody>(
+      state_factory.create(StateModelTypes::StateMultibody_RandomHumanoid)));
+
+  // remove a none existing cost form the container, we expect a cout message here
+  CaptureIOStream capture_ios;
+  capture_ios.beginCapture();
+  model.removeCost("random_cost");
+  capture_ios.endCapture();
+
+  // Test that the error message is sent.
+  std::stringstream expected_buffer;
+  expected_buffer << "Warning: this cost item doesn't exist, we cannot remove it" << std::endl;
+  BOOST_CHECK(capture_ios.str() == expected_buffer.str());
+}
+
+void test_get_costs() {
+  // Setup the test
+  StateModelFactory state_factory;
+  crocoddyl::CostModelSum model(boost::static_pointer_cast<crocoddyl::StateMultibody>(
+      state_factory.create(StateModelTypes::StateMultibody_RandomHumanoid)));
+  // create the corresponding data object
+  pinocchio::Data pinocchio_data(*model.get_state()->get_pinocchio().get());
+
+  // create and add some contact objects
+  for (unsigned i = 0; i < 5; ++i) {
+    std::ostringstream os;
+    os << "random_cost_" << i;
+    model.addCost(os.str(), create_random_cost(), 1.);
+  }
+
+  // get the contacts
+  const crocoddyl::CostModelSum::CostModelContainer& costs = model.get_costs();
+
+  // test
+  crocoddyl::CostModelSum::CostModelContainer::const_iterator it_m, end_m;
+  unsigned i;
+  for (i = 0, it_m = costs.begin(), end_m = costs.end(); it_m != end_m; ++it_m, ++i) {
+    std::ostringstream os;
+    os << "random_cost_" << i;
+    BOOST_CHECK(it_m->first == os.str());
+  }
+}
+
+void test_get_nr() {
+  // Setup the test
+  StateModelFactory state_factory;
+  crocoddyl::CostModelSum model(boost::static_pointer_cast<crocoddyl::StateMultibody>(
+      state_factory.create(StateModelTypes::StateMultibody_RandomHumanoid)));
+
+  // create the corresponding data object
+  pinocchio::Data pinocchio_data(*model.get_state()->get_pinocchio().get());
+
+  // create and add some contact objects
+  for (unsigned i = 0; i < 5; ++i) {
+    std::ostringstream os;
+    os << "random_cost_" << i;
+    model.addCost(os.str(), create_random_cost(), 1.);
+  }
+
+  // compute ni
+  std::size_t nr = 0;
+  crocoddyl::CostModelSum::CostModelContainer::const_iterator it_m, end_m;
+  for (it_m = model.get_costs().begin(), end_m = model.get_costs().end(); it_m != end_m; ++it_m) {
+    nr += it_m->second->cost->get_activation()->get_nr();
+  }
+
+  BOOST_CHECK(nr == model.get_nr());
+}
+
+//----------------------------------------------------------------------------//
+
+void register_unit_tests() {
+  framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_constructor)));
+  framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_addCost)));
+  framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_addCost_error_message)));
+  framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_removeCost)));
+  framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_removeCost_error_message)));
+  framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_get_costs)));
+  framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_get_nr)));
+}
+
+bool init_function() {
+  register_unit_tests();
+  return true;
+}
+
+int main(int argc, char** argv) { return ::boost::unit_test::unit_test_main(&init_function, argc, argv); }

--- a/unittest/test_cost_sum.cpp
+++ b/unittest/test_cost_sum.cpp
@@ -173,6 +173,98 @@ void test_calc() {
   BOOST_CHECK(data->cost == cost);
 }
 
+void test_calcDiff() {
+  // setup the test
+  StateModelFactory state_factory;
+  crocoddyl::CostModelSum model(boost::static_pointer_cast<crocoddyl::StateMultibody>(
+      state_factory.create(StateModelTypes::StateMultibody_RandomHumanoid)));
+  // create the corresponding data object
+  const boost::shared_ptr<crocoddyl::StateMultibody>& state = model.get_state();
+  pinocchio::Model& pinocchio_model = *state->get_pinocchio().get();
+  pinocchio::Data pinocchio_data(pinocchio_model);
+  crocoddyl::DataCollectorMultibody shared_data(&pinocchio_data);
+
+  // create and add some cost objects
+  std::vector<boost::shared_ptr<crocoddyl::CostModelAbstract> > models;
+  std::vector<boost::shared_ptr<crocoddyl::CostDataAbstract> > datas;
+  for (std::size_t i = 0; i < 5; ++i) {
+    std::ostringstream os;
+    os << "random_cost_" << i;
+    const boost::shared_ptr<crocoddyl::CostModelAbstract>& m = create_random_cost();
+    model.addCost(os.str(), m, 1.);
+    models.push_back(m);
+    datas.push_back(m->createData(&shared_data));
+  }
+
+  // create the data of the cost sum
+  const boost::shared_ptr<crocoddyl::CostDataSum>& data = model.createData(&shared_data);
+
+  // compute the cost sum data for the case when all costs are defined as active
+  const Eigen::VectorXd& x1 = state->rand();
+  const Eigen::VectorXd& u1 = Eigen::VectorXd::Random(model.get_nu());
+  crocoddyl::unittest::updateAllPinocchio(&pinocchio_model, &pinocchio_data, x1);
+  model.calc(data, x1, u1);
+  model.calcDiff(data, x1, u1);
+
+  // check that the cost has been filled
+  BOOST_CHECK(data->cost != 0.);
+
+  // check the cost against single cost computations
+  double cost = 0;
+  Eigen::VectorXd Lx;
+  Eigen::VectorXd Lu;
+  Eigen::MatrixXd Lxx;
+  Eigen::MatrixXd Lxu;
+  Eigen::MatrixXd Luu;
+  for (std::size_t i = 0; i < 5; ++i) {
+    models[i]->calc(datas[i], x1, u1);
+    models[i]->calcDiff(datas[i], x1, u1);
+    cost += datas[i]->cost;
+    Lx += datas[i]->Lx;
+    Lu += datas[i]->Lu;
+    Lxx += datas[i]->Lxx;
+    Lxu += datas[i]->Lxu;
+    Luu += datas[i]->Luu;
+  }
+  BOOST_CHECK(data->cost == cost);
+  BOOST_CHECK(data->Lx == Lx);
+  BOOST_CHECK(data->Lu == Lu);
+  BOOST_CHECK(data->Lxx == Lxx);
+  BOOST_CHECK(data->Lxu == Lxu);
+  BOOST_CHECK(data->Luu == Luu);
+
+  // compute the cost sum data for the case when the first three costs are defined as active
+  model.changeCostStatus("random_cost_3", false);
+  model.changeCostStatus("random_cost_4", false);
+  const Eigen::VectorXd& x2 = state->rand();
+  const Eigen::VectorXd& u2 = Eigen::VectorXd::Random(model.get_nu());
+  crocoddyl::unittest::updateAllPinocchio(&pinocchio_model, &pinocchio_data, x1);
+  model.calc(data, x2, u2);
+  model.calcDiff(data, x2, u2);
+  cost = 0;
+  Lx.setZero();
+  Lu.setZero();
+  Lxx.setZero();
+  Lxu.setZero();
+  Luu.setZero();
+  for (std::size_t i = 0; i < 3; ++i) {  // we need to update data because this costs are active
+    models[i]->calc(datas[i], x2, u2);
+    models[i]->calcDiff(datas[i], x2, u2);
+    cost += datas[i]->cost;
+    Lx += datas[i]->Lx;
+    Lu += datas[i]->Lu;
+    Lxx += datas[i]->Lxx;
+    Lxu += datas[i]->Lxu;
+    Luu += datas[i]->Luu;
+  }
+  BOOST_CHECK(data->cost == cost);
+  BOOST_CHECK(data->Lx == Lx);
+  BOOST_CHECK(data->Lu == Lu);
+  BOOST_CHECK(data->Lxx == Lxx);
+  BOOST_CHECK(data->Lxu == Lxu);
+  BOOST_CHECK(data->Luu == Luu);
+}
+
 void test_get_costs() {
   // setup the test
   StateModelFactory state_factory;
@@ -236,6 +328,7 @@ void register_unit_tests() {
   framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_removeCost)));
   framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_removeCost_error_message)));
   framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_calc)));
+  framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_calcDiff)));
   framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_get_costs)));
   framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_get_nr)));
 }

--- a/unittest/test_cost_sum.cpp
+++ b/unittest/test_cost_sum.cpp
@@ -265,6 +265,90 @@ void test_calcDiff() {
   BOOST_CHECK(data->Luu == Luu);
 }
 
+void test_calc_diff_no_recalc() {
+  // setup the test
+  StateModelFactory state_factory;
+  crocoddyl::CostModelSum model(boost::static_pointer_cast<crocoddyl::StateMultibody>(
+      state_factory.create(StateModelTypes::StateMultibody_RandomHumanoid)));
+  // create the corresponding data object
+  const boost::shared_ptr<crocoddyl::StateMultibody>& state = model.get_state();
+  pinocchio::Model& pinocchio_model = *state->get_pinocchio().get();
+  pinocchio::Data pinocchio_data(pinocchio_model);
+  crocoddyl::DataCollectorMultibody shared_data(&pinocchio_data);
+
+  // create and add some cost objects
+  std::vector<boost::shared_ptr<crocoddyl::CostModelAbstract> > models;
+  std::vector<boost::shared_ptr<crocoddyl::CostDataAbstract> > datas;
+  for (std::size_t i = 0; i < 5; ++i) {
+    std::ostringstream os;
+    os << "random_cost_" << i;
+    const boost::shared_ptr<crocoddyl::CostModelAbstract>& m = create_random_cost();
+    model.addCost(os.str(), m, 1.);
+    models.push_back(m);
+    datas.push_back(m->createData(&shared_data));
+  }
+
+  // create the data of the cost sum
+  const boost::shared_ptr<crocoddyl::CostDataSum>& data = model.createData(&shared_data);
+
+  // compute the cost sum data for the case when all costs are defined as active
+  const Eigen::VectorXd& x1 = state->rand();
+  const Eigen::VectorXd& u1 = Eigen::VectorXd::Random(model.get_nu());
+  crocoddyl::unittest::updateAllPinocchio(&pinocchio_model, &pinocchio_data, x1);
+  model.calcDiff(data, x1, u1);
+
+  // check that the cost has been filled
+  BOOST_CHECK(data->cost == 0.);
+
+  // check the cost against single cost computations
+  Eigen::VectorXd Lx;
+  Eigen::VectorXd Lu;
+  Eigen::MatrixXd Lxx;
+  Eigen::MatrixXd Lxu;
+  Eigen::MatrixXd Luu;
+  for (std::size_t i = 0; i < 5; ++i) {
+    models[i]->calcDiff(datas[i], x1, u1);
+    Lx += datas[i]->Lx;
+    Lu += datas[i]->Lu;
+    Lxx += datas[i]->Lxx;
+    Lxu += datas[i]->Lxu;
+    Luu += datas[i]->Luu;
+  }
+  BOOST_CHECK(data->cost == 0);
+  BOOST_CHECK(data->Lx == Lx);
+  BOOST_CHECK(data->Lu == Lu);
+  BOOST_CHECK(data->Lxx == Lxx);
+  BOOST_CHECK(data->Lxu == Lxu);
+  BOOST_CHECK(data->Luu == Luu);
+
+  // compute the cost sum data for the case when the first three costs are defined as active
+  model.changeCostStatus("random_cost_3", false);
+  model.changeCostStatus("random_cost_4", false);
+  const Eigen::VectorXd& x2 = state->rand();
+  const Eigen::VectorXd& u2 = Eigen::VectorXd::Random(model.get_nu());
+  crocoddyl::unittest::updateAllPinocchio(&pinocchio_model, &pinocchio_data, x1);
+  model.calcDiff(data, x2, u2);
+  Lx.setZero();
+  Lu.setZero();
+  Lxx.setZero();
+  Lxu.setZero();
+  Luu.setZero();
+  for (std::size_t i = 0; i < 3; ++i) {  // we need to update data because this costs are active
+    models[i]->calcDiff(datas[i], x2, u2);
+    Lx += datas[i]->Lx;
+    Lu += datas[i]->Lu;
+    Lxx += datas[i]->Lxx;
+    Lxu += datas[i]->Lxu;
+    Luu += datas[i]->Luu;
+  }
+  BOOST_CHECK(data->cost == 0.);
+  BOOST_CHECK(data->Lx == Lx);
+  BOOST_CHECK(data->Lu == Lu);
+  BOOST_CHECK(data->Lxx == Lxx);
+  BOOST_CHECK(data->Lxu == Lxu);
+  BOOST_CHECK(data->Luu == Luu);
+}
+
 void test_get_costs() {
   // setup the test
   StateModelFactory state_factory;
@@ -329,6 +413,7 @@ void register_unit_tests() {
   framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_removeCost_error_message)));
   framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_calc)));
   framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_calcDiff)));
+  framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_calc_diff_no_recalc)));
   framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_get_costs)));
   framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_get_nr)));
 }

--- a/unittest/test_cost_sum.cpp
+++ b/unittest/test_cost_sum.cpp
@@ -156,7 +156,7 @@ void test_calc() {
   model.calc(data, x1, u1);
 
   // check that the cost has been filled
-  BOOST_CHECK(data->cost != 0.);
+  BOOST_CHECK(data->cost > 0.);
 
   // check the cost against single cost computations
   double cost = 0;
@@ -215,15 +215,15 @@ void test_calcDiff() {
   model.calcDiff(data, x1, u1);
 
   // check that the cost has been filled
-  BOOST_CHECK(data->cost != 0.);
+  BOOST_CHECK(data->cost > 0.);
 
   // check the cost against single cost computations
   double cost = 0;
-  Eigen::VectorXd Lx;
-  Eigen::VectorXd Lu;
-  Eigen::MatrixXd Lxx;
-  Eigen::MatrixXd Lxu;
-  Eigen::MatrixXd Luu;
+  Eigen::VectorXd Lx = Eigen::VectorXd::Zero(state->get_ndx());
+  Eigen::VectorXd Lu = Eigen::VectorXd::Zero(model.get_nu());;
+  Eigen::MatrixXd Lxx = Eigen::MatrixXd::Zero(state->get_ndx(), state->get_ndx());
+  Eigen::MatrixXd Lxu = Eigen::MatrixXd::Zero(state->get_ndx(), model.get_nu());
+  Eigen::MatrixXd Luu = Eigen::MatrixXd::Zero(model.get_nu(), model.get_nu());
   for (std::size_t i = 0; i < 5; ++i) {
     models[i]->calc(datas[i], x1, u1);
     models[i]->calcDiff(datas[i], x1, u1);
@@ -234,12 +234,13 @@ void test_calcDiff() {
     Lxu += datas[i]->Lxu;
     Luu += datas[i]->Luu;
   }
+  double tol = 1e-9;
   BOOST_CHECK(data->cost == cost);
-  BOOST_CHECK(data->Lx == Lx);
-  BOOST_CHECK(data->Lu == Lu);
-  BOOST_CHECK(data->Lxx == Lxx);
-  BOOST_CHECK(data->Lxu == Lxu);
-  BOOST_CHECK(data->Luu == Luu);
+  BOOST_CHECK((data->Lx - Lx).isMuchSmallerThan(tol));
+  BOOST_CHECK((data->Lu - Lu).isMuchSmallerThan(tol));
+  BOOST_CHECK((data->Lxx - Lxx).isMuchSmallerThan(tol));
+  BOOST_CHECK((data->Lxu - Lxu).isMuchSmallerThan(tol));
+  BOOST_CHECK((data->Luu - Luu).isMuchSmallerThan(tol));
 
   // compute the cost sum data for the case when the first three costs are defined as active
   model.changeCostStatus("random_cost_3", false);
@@ -266,11 +267,11 @@ void test_calcDiff() {
     Luu += datas[i]->Luu;
   }
   BOOST_CHECK(data->cost == cost);
-  BOOST_CHECK(data->Lx == Lx);
-  BOOST_CHECK(data->Lu == Lu);
-  BOOST_CHECK(data->Lxx == Lxx);
-  BOOST_CHECK(data->Lxu == Lxu);
-  BOOST_CHECK(data->Luu == Luu);
+  BOOST_CHECK((data->Lx - Lx).isMuchSmallerThan(tol));
+  BOOST_CHECK((data->Lu - Lu).isMuchSmallerThan(tol));
+  BOOST_CHECK((data->Lxx - Lxx).isMuchSmallerThan(tol));
+  BOOST_CHECK((data->Lxu - Lxu).isMuchSmallerThan(tol));
+  BOOST_CHECK((data->Luu - Luu).isMuchSmallerThan(tol));
 }
 
 void test_calc_diff_no_recalc() {
@@ -309,11 +310,11 @@ void test_calc_diff_no_recalc() {
   BOOST_CHECK(data->cost == 0.);
 
   // check the cost against single cost computations
-  Eigen::VectorXd Lx;
-  Eigen::VectorXd Lu;
-  Eigen::MatrixXd Lxx;
-  Eigen::MatrixXd Lxu;
-  Eigen::MatrixXd Luu;
+  Eigen::VectorXd Lx = Eigen::VectorXd::Zero(state->get_ndx());
+  Eigen::VectorXd Lu = Eigen::VectorXd::Zero(model.get_nu());;
+  Eigen::MatrixXd Lxx = Eigen::MatrixXd::Zero(state->get_ndx(), state->get_ndx());
+  Eigen::MatrixXd Lxu = Eigen::MatrixXd::Zero(state->get_ndx(), model.get_nu());
+  Eigen::MatrixXd Luu = Eigen::MatrixXd::Zero(model.get_nu(), model.get_nu());
   for (std::size_t i = 0; i < 5; ++i) {
     models[i]->calcDiff(datas[i], x1, u1);
     Lx += datas[i]->Lx;
@@ -322,12 +323,13 @@ void test_calc_diff_no_recalc() {
     Lxu += datas[i]->Lxu;
     Luu += datas[i]->Luu;
   }
+  double tol = 1e-9;
   BOOST_CHECK(data->cost == 0);
-  BOOST_CHECK(data->Lx == Lx);
-  BOOST_CHECK(data->Lu == Lu);
-  BOOST_CHECK(data->Lxx == Lxx);
-  BOOST_CHECK(data->Lxu == Lxu);
-  BOOST_CHECK(data->Luu == Luu);
+  BOOST_CHECK((data->Lx - Lx).isMuchSmallerThan(tol));
+  BOOST_CHECK((data->Lu - Lu).isMuchSmallerThan(tol));
+  BOOST_CHECK((data->Lxx - Lxx).isMuchSmallerThan(tol));
+  BOOST_CHECK((data->Lxu - Lxu).isMuchSmallerThan(tol));
+  BOOST_CHECK((data->Luu - Luu).isMuchSmallerThan(tol));
 
   // compute the cost sum data for the case when the first three costs are defined as active
   model.changeCostStatus("random_cost_3", false);
@@ -350,11 +352,11 @@ void test_calc_diff_no_recalc() {
     Luu += datas[i]->Luu;
   }
   BOOST_CHECK(data->cost == 0.);
-  BOOST_CHECK(data->Lx == Lx);
-  BOOST_CHECK(data->Lu == Lu);
-  BOOST_CHECK(data->Lxx == Lxx);
-  BOOST_CHECK(data->Lxu == Lxu);
-  BOOST_CHECK(data->Luu == Luu);
+  BOOST_CHECK((data->Lx - Lx).isMuchSmallerThan(tol));
+  BOOST_CHECK((data->Lu - Lu).isMuchSmallerThan(tol));
+  BOOST_CHECK((data->Lxx - Lxx).isMuchSmallerThan(tol));
+  BOOST_CHECK((data->Lxu - Lxu).isMuchSmallerThan(tol));
+  BOOST_CHECK((data->Luu - Luu).isMuchSmallerThan(tol));
 }
 
 void test_get_costs() {

--- a/unittest/test_cost_sum.cpp
+++ b/unittest/test_cost_sum.cpp
@@ -36,19 +36,26 @@ void test_addCost() {
   boost::shared_ptr<crocoddyl::CostModelAbstract> rand_cost_1 = create_random_cost();
   model.addCost("random_cost_1", rand_cost_1, 1.);
   BOOST_CHECK(model.get_nr() == rand_cost_1->get_activation()->get_nr());
+  BOOST_CHECK(model.get_nr_total() == rand_cost_1->get_activation()->get_nr());
 
   // add an inactive cost
   boost::shared_ptr<crocoddyl::CostModelAbstract> rand_cost_2 = create_random_cost();
   model.addCost("random_cost_2", rand_cost_2, 1., false);
   BOOST_CHECK(model.get_nr() == rand_cost_1->get_activation()->get_nr());
+  BOOST_CHECK(model.get_nr_total() ==
+              rand_cost_1->get_activation()->get_nr() + rand_cost_2->get_activation()->get_nr());
 
   // change the random cost 2 status
   model.changeCostStatus("random_cost_2", true);
   BOOST_CHECK(model.get_nr() == rand_cost_1->get_activation()->get_nr() + rand_cost_2->get_activation()->get_nr());
+  BOOST_CHECK(model.get_nr_total() ==
+              rand_cost_1->get_activation()->get_nr() + rand_cost_2->get_activation()->get_nr());
 
   // change the random cost 1 status
   model.changeCostStatus("random_cost_1", false);
   BOOST_CHECK(model.get_nr() == rand_cost_2->get_activation()->get_nr());
+  BOOST_CHECK(model.get_nr_total() ==
+              rand_cost_1->get_activation()->get_nr() + rand_cost_2->get_activation()->get_nr());
 }
 
 void test_addCost_error_message() {
@@ -95,6 +102,7 @@ void test_removeCost() {
   // remove the cost
   model.removeCost("random_cost");
   BOOST_CHECK(model.get_nr() == 0);
+  BOOST_CHECK(model.get_nr_total() == 0);
 }
 
 void test_removeCost_error_message() {

--- a/unittest/test_multiple_contacts.cpp
+++ b/unittest/test_multiple_contacts.cpp
@@ -74,19 +74,23 @@ void test_addContact() {
   boost::shared_ptr<crocoddyl::ContactModelAbstract> rand_contact_1 = create_random_contact();
   model.addContact("random_contact_1", rand_contact_1);
   BOOST_CHECK(model.get_nc() == rand_contact_1->get_nc());
+  BOOST_CHECK(model.get_nc_total() == rand_contact_1->get_nc());
 
   // add an inactive contact
   boost::shared_ptr<crocoddyl::ContactModelAbstract> rand_contact_2 = create_random_contact();
   model.addContact("random_contact_2", rand_contact_2, false);
   BOOST_CHECK(model.get_nc() == rand_contact_1->get_nc());
+  BOOST_CHECK(model.get_nc_total() == rand_contact_1->get_nc() + rand_contact_2->get_nc());
 
   // change the random contact 2 status
   model.changeContactStatus("random_contact_2", true);
   BOOST_CHECK(model.get_nc() == rand_contact_1->get_nc() + rand_contact_2->get_nc());
+  BOOST_CHECK(model.get_nc_total() == rand_contact_1->get_nc() + rand_contact_2->get_nc());
 
   // change the random contact 1 status
   model.changeContactStatus("random_contact_1", false);
   BOOST_CHECK(model.get_nc() == rand_contact_2->get_nc());
+  BOOST_CHECK(model.get_nc_total() == rand_contact_1->get_nc() + rand_contact_2->get_nc());
 }
 
 void test_addContact_error_message() {
@@ -129,10 +133,12 @@ void test_removeContact() {
   boost::shared_ptr<crocoddyl::ContactModelAbstract> rand_contact = create_random_contact();
   model.addContact("random_contact", rand_contact);
   BOOST_CHECK(model.get_nc() == rand_contact->get_nc());
+  BOOST_CHECK(model.get_nc_total() == rand_contact->get_nc());
 
   // remove the contact
   model.removeContact("random_contact");
   BOOST_CHECK(model.get_nc() == 0);
+  BOOST_CHECK(model.get_nc_total() == 0);
 }
 
 void test_removeContact_error_message() {

--- a/unittest/test_multiple_contacts.cpp
+++ b/unittest/test_multiple_contacts.cpp
@@ -572,6 +572,7 @@ void register_unit_tests() {
   framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_removeContact_error_message)));
   framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_calc)));
   framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_calc_diff)));
+  framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_calc_diff_no_recalc)));
   framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_updateForce)));
   framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_updateAccelerationDiff)));
   framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_get_contacts)));

--- a/unittest/test_multiple_contacts.cpp
+++ b/unittest/test_multiple_contacts.cpp
@@ -291,32 +291,65 @@ void test_calc_diff_no_recalc() {
   StateModelFactory state_factory;
   crocoddyl::ContactModelMultiple model(boost::static_pointer_cast<crocoddyl::StateMultibody>(
       state_factory.create(StateModelTypes::StateMultibody_RandomHumanoid)));
-
   // create the corresponding data object
   pinocchio::Model& pinocchio_model = *model.get_state()->get_pinocchio().get();
   pinocchio::Data pinocchio_data(*model.get_state()->get_pinocchio().get());
 
   // create and add some contact objects
-  for (unsigned i = 0; i < 5; ++i) {
+  std::vector<boost::shared_ptr<crocoddyl::ContactModelAbstract> > models;
+  std::vector<boost::shared_ptr<crocoddyl::ContactDataAbstract> > datas;
+  for (std::size_t i = 0; i < 5; ++i) {
     std::ostringstream os;
     os << "random_contact_" << i;
-    model.addContact(os.str(), create_random_contact());
+    const boost::shared_ptr<crocoddyl::ContactModelAbstract>& m = create_random_contact();
+    model.addContact(os.str(), m);
+    models.push_back(m);
+    datas.push_back(m->createData(&pinocchio_data));
   }
 
   // create the data of the multiple-contacts
   boost::shared_ptr<crocoddyl::ContactDataMultiple> data = model.createData(&pinocchio_data);
 
-  // Compute the jacobian and check that the contact models fetch it.
-  Eigen::VectorXd x = model.get_state()->rand();
-  crocoddyl::unittest::updateAllPinocchio(&pinocchio_model, &pinocchio_data, x);
+  // compute the multiple contact data for the case when all contacts are defined as active
+  Eigen::VectorXd x1 = model.get_state()->rand();
+  crocoddyl::unittest::updateAllPinocchio(&pinocchio_model, &pinocchio_data, x1);
+  model.calcDiff(data, x1);
 
-  // pinocchio data have not been filled so the results of this operation are null matrices
-  model.calcDiff(data, x);
-
-  // Check that nothing has been computed and that all value are initialized to 0
+  // check that nothing has been computed and that all value are initialized to 0
   BOOST_CHECK(data->Jc.isZero());
   BOOST_CHECK(data->a0.isZero());
   BOOST_CHECK(!data->da0_dx.isZero());
+
+  // check Jc and a0 against single contact computations
+  std::size_t nc = 0;
+  const std::size_t& nv = model.get_state()->get_nv();
+  const std::size_t& ndx = model.get_state()->get_ndx();
+  for (std::size_t i = 0; i < 5; ++i) {
+    const std::size_t& nc_i = models[i]->get_nc();
+    models[i]->calcDiff(datas[i], x1);
+    BOOST_CHECK(data->Jc.block(nc, 0, nc_i, nv).isZero());
+    BOOST_CHECK(data->a0.segment(nc, nc_i).isZero());
+    BOOST_CHECK(data->da0_dx.block(nc, 0, nc_i, ndx) == datas[i]->da0_dx);
+    nc += nc_i;
+  }
+  nc = 0;
+
+  // compute the multiple contact data for the case when the first three contacts are defined as active
+  model.changeContactStatus("random_contact_3", false);
+  model.changeContactStatus("random_contact_4", false);
+  Eigen::VectorXd x2 = model.get_state()->rand();
+  crocoddyl::unittest::updateAllPinocchio(&pinocchio_model, &pinocchio_data, x2);
+  model.calcDiff(data, x2);
+  for (std::size_t i = 0; i < 5; ++i) {
+    const std::size_t& nc_i = models[i]->get_nc();
+    if (i < 3) {  // we need to update data because this contacts are active
+      models[i]->calcDiff(datas[i], x2);
+    }
+    BOOST_CHECK(data->Jc.block(nc, 0, nc_i, nv).isZero());
+    BOOST_CHECK(data->a0.segment(nc, nc_i).isZero());
+    BOOST_CHECK(data->da0_dx.block(nc, 0, nc_i, ndx) == datas[i]->da0_dx);
+    nc += nc_i;
+  }
 }
 
 void test_updateForce() {

--- a/unittest/test_multiple_contacts.cpp
+++ b/unittest/test_multiple_contacts.cpp
@@ -184,9 +184,6 @@ void test_calc() {
   BOOST_CHECK(!data->Jc.isZero());
   BOOST_CHECK(!data->a0.isZero());
   BOOST_CHECK(data->da0_dx.isZero());
-  BOOST_CHECK(data->f.toVector().isZero());
-  BOOST_CHECK(data->df_dx.isZero());
-  BOOST_CHECK(data->df_du.isZero());
 }
 
 void test_calc_diff() {
@@ -221,9 +218,6 @@ void test_calc_diff() {
   BOOST_CHECK(!data->Jc.isZero());
   BOOST_CHECK(!data->a0.isZero());
   BOOST_CHECK(!data->da0_dx.isZero());
-  BOOST_CHECK(data->f.toVector().isZero());
-  BOOST_CHECK(data->df_dx.isZero());
-  BOOST_CHECK(data->df_du.isZero());
 }
 
 void test_calc_diff_no_recalc() {
@@ -257,9 +251,6 @@ void test_calc_diff_no_recalc() {
   BOOST_CHECK(data->Jc.isZero());
   BOOST_CHECK(data->a0.isZero());
   BOOST_CHECK(!data->da0_dx.isZero());
-  BOOST_CHECK(data->f.toVector().isZero());
-  BOOST_CHECK(data->df_dx.isZero());
-  BOOST_CHECK(data->df_du.isZero());
 }
 
 void test_updateForce() {
@@ -300,13 +291,10 @@ void test_updateForce() {
   BOOST_CHECK(data->Jc.isZero());
   BOOST_CHECK(data->a0.isZero());
   BOOST_CHECK(data->da0_dx.isZero());
-  BOOST_CHECK(data->f.toVector().isZero());
   crocoddyl::ContactModelMultiple::ContactDataContainer::iterator it_d, end_d;
   for (it_d = data->contacts.begin(), end_d = data->contacts.end(); it_d != end_d; ++it_d) {
     BOOST_CHECK(!it_d->second->f.toVector().isZero());
   }
-  BOOST_CHECK(data->df_dx.isZero());
-  BOOST_CHECK(data->df_du.isZero());
 }
 
 void test_updateAccelerationDiff() {

--- a/unittest/test_multiple_contacts.cpp
+++ b/unittest/test_multiple_contacts.cpp
@@ -163,27 +163,57 @@ void test_calc() {
   pinocchio::Data pinocchio_data(*model.get_state()->get_pinocchio().get());
 
   // create and add some contact objects
-  for (unsigned i = 0; i < 5; ++i) {
+  std::vector<boost::shared_ptr<crocoddyl::ContactModelAbstract> > models;
+  std::vector<boost::shared_ptr<crocoddyl::ContactDataAbstract> > datas;
+  for (std::size_t i = 0; i < 5; ++i) {
     std::ostringstream os;
     os << "random_contact_" << i;
-    model.addContact(os.str(), create_random_contact());
+    const boost::shared_ptr<crocoddyl::ContactModelAbstract>& m = create_random_contact();
+    model.addContact(os.str(), m);
+    models.push_back(m);
+    datas.push_back(m->createData(&pinocchio_data));
   }
 
   // create the data of the multiple-contacts
   boost::shared_ptr<crocoddyl::ContactDataMultiple> data = model.createData(&pinocchio_data);
 
-  // Compute the jacobian and check that the contact models fetch it.
-  Eigen::VectorXd x = model.get_state()->rand();
-  crocoddyl::unittest::updateAllPinocchio(&pinocchio_model, &pinocchio_data, x);
+  // compute the multiple contact data for the case when all contacts are defined as active
+  Eigen::VectorXd x1 = model.get_state()->rand();
+  crocoddyl::unittest::updateAllPinocchio(&pinocchio_model, &pinocchio_data, x1);
+  model.calc(data, x1);
 
-  // pinocchio data have not been filled so the results of this operation are
-  // null matrices
-  model.calc(data, x);
-
-  // Check that only the Jacobian has been filled
+  // check that only the Jacobian has been filled
   BOOST_CHECK(!data->Jc.isZero());
   BOOST_CHECK(!data->a0.isZero());
   BOOST_CHECK(data->da0_dx.isZero());
+
+  // check Jc and a0 against single contact computations
+  std::size_t nc = 0;
+  const std::size_t& nv = model.get_state()->get_nv();
+  for (std::size_t i = 0; i < 5; ++i) {
+    const std::size_t& nc_i = models[i]->get_nc();
+    models[i]->calc(datas[i], x1);
+    BOOST_CHECK(data->Jc.block(nc, 0, nc_i, nv) == datas[i]->Jc);
+    BOOST_CHECK(data->a0.segment(nc, nc_i) == datas[i]->a0);
+    nc += nc_i;
+  }
+  nc = 0;
+
+  // compute the multiple contact data for the case when the first three contacts are defined as active
+  model.changeContactStatus("random_contact_3", false);
+  model.changeContactStatus("random_contact_4", false);
+  Eigen::VectorXd x2 = model.get_state()->rand();
+  crocoddyl::unittest::updateAllPinocchio(&pinocchio_model, &pinocchio_data, x2);
+  model.calc(data, x2);
+  for (std::size_t i = 0; i < 5; ++i) {
+    const std::size_t& nc_i = models[i]->get_nc();
+    if (i < 3) {  // we need to update data because this contacts are active
+      models[i]->calc(datas[i], x2);
+    }
+    BOOST_CHECK(data->Jc.block(nc, 0, nc_i, nv) == datas[i]->Jc);
+    BOOST_CHECK(data->a0.segment(nc, nc_i) == datas[i]->a0);
+    nc += nc_i;
+  }
 }
 
 void test_calc_diff() {

--- a/unittest/test_multiple_impulses.cpp
+++ b/unittest/test_multiple_impulses.cpp
@@ -562,6 +562,7 @@ void register_unit_tests() {
   framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_removeImpulse_error_message)));
   framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_calc)));
   framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_calc_diff)));
+  framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_calc_diff_no_recalc)));
   framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_updateForce)));
   framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_updateVelocityDiff)));
   framework::master_test_suite().add(BOOST_TEST_CASE(boost::bind(&test_get_impulses)));

--- a/unittest/test_multiple_impulses.cpp
+++ b/unittest/test_multiple_impulses.cpp
@@ -184,8 +184,6 @@ void test_calc() {
   // Check that only the Jacobian has been filled
   BOOST_CHECK(!data->Jc.isZero());
   BOOST_CHECK(data->dv0_dq.isZero());
-  BOOST_CHECK(data->f.toVector().isZero());
-  BOOST_CHECK(data->df_dq.isZero());
 }
 
 void test_calc_diff() {
@@ -220,8 +218,6 @@ void test_calc_diff() {
   // Check that nothing has been computed and that all value are initialized to 0
   BOOST_CHECK(!data->Jc.isZero());
   BOOST_CHECK(!data->dv0_dq.isZero());
-  BOOST_CHECK(data->f.toVector().isZero());
-  BOOST_CHECK(data->df_dq.isZero());
 }
 
 void test_calc_diff_no_recalc() {
@@ -255,8 +251,6 @@ void test_calc_diff_no_recalc() {
   // Check that nothing has been computed and that all value are initialized to 0
   BOOST_CHECK(data->Jc.isZero());
   BOOST_CHECK(!data->dv0_dq.isZero());
-  BOOST_CHECK(data->f.toVector().isZero());
-  BOOST_CHECK(data->df_dq.isZero());
 }
 
 void test_updateForce() {
@@ -292,12 +286,10 @@ void test_updateForce() {
   // Check that nothing has been computed and that all value are initialized to 0
   BOOST_CHECK(data->Jc.isZero());
   BOOST_CHECK(data->dv0_dq.isZero());
-  BOOST_CHECK(data->f.toVector().isZero());
   crocoddyl::ImpulseModelMultiple::ImpulseDataContainer::iterator it_d, end_d;
   for (it_d = data->impulses.begin(), end_d = data->impulses.end(); it_d != end_d; ++it_d) {
     BOOST_CHECK(!it_d->second->f.toVector().isZero());
   }
-  BOOST_CHECK(data->df_dq.isZero());
 }
 
 void test_updateVelocityDiff() {

--- a/unittest/test_multiple_impulses.cpp
+++ b/unittest/test_multiple_impulses.cpp
@@ -75,19 +75,23 @@ void test_addImpulse() {
   boost::shared_ptr<crocoddyl::ImpulseModelAbstract> rand_impulse_1 = create_random_impulse();
   model.addImpulse("random_impulse_1", rand_impulse_1);
   BOOST_CHECK(model.get_ni() == rand_impulse_1->get_ni());
+  BOOST_CHECK(model.get_ni_total() == rand_impulse_1->get_ni());
 
   // add an inactive impulse
   boost::shared_ptr<crocoddyl::ImpulseModelAbstract> rand_impulse_2 = create_random_impulse();
   model.addImpulse("random_impulse_2", rand_impulse_2, false);
   BOOST_CHECK(model.get_ni() == rand_impulse_1->get_ni());
+  BOOST_CHECK(model.get_ni_total() == rand_impulse_1->get_ni() + rand_impulse_2->get_ni());
 
   // change the random impulse 2 status
   model.changeImpulseStatus("random_impulse_2", true);
   BOOST_CHECK(model.get_ni() == rand_impulse_1->get_ni() + rand_impulse_2->get_ni());
+  BOOST_CHECK(model.get_ni_total() == rand_impulse_1->get_ni() + rand_impulse_2->get_ni());
 
   // change the random impulse 1 status
   model.changeImpulseStatus("random_impulse_1", false);
   BOOST_CHECK(model.get_ni() == rand_impulse_2->get_ni());
+  BOOST_CHECK(model.get_ni_total() == rand_impulse_1->get_ni() + rand_impulse_2->get_ni());
 }
 
 void test_addImpulse_error_message() {

--- a/unittest/test_multiple_impulses.cpp
+++ b/unittest/test_multiple_impulses.cpp
@@ -164,26 +164,54 @@ void test_calc() {
   pinocchio::Data pinocchio_data(*model.get_state()->get_pinocchio().get());
 
   // create and add some impulse objects
-  for (unsigned i = 0; i < 5; ++i) {
+  std::vector<boost::shared_ptr<crocoddyl::ImpulseModelAbstract> > models;
+  std::vector<boost::shared_ptr<crocoddyl::ImpulseDataAbstract> > datas;
+  for (std::size_t i = 0; i < 5; ++i) {
     std::ostringstream os;
     os << "random_impulse_" << i;
-    model.addImpulse(os.str(), create_random_impulse());
+    const boost::shared_ptr<crocoddyl::ImpulseModelAbstract>& m = create_random_impulse();
+    model.addImpulse(os.str(), m);
+    models.push_back(m);
+    datas.push_back(m->createData(&pinocchio_data));
   }
 
   // create the data of the multiple-impulses
   boost::shared_ptr<crocoddyl::ImpulseDataMultiple> data = model.createData(&pinocchio_data);
 
-  // Compute the jacobian and check that the impulse models fetch it.
-  Eigen::VectorXd x = model.get_state()->rand();
-  crocoddyl::unittest::updateAllPinocchio(&pinocchio_model, &pinocchio_data, x);
+  // compute the multiple contact data for the case when all impulses are defined as active
+  Eigen::VectorXd x1 = model.get_state()->rand();
+  crocoddyl::unittest::updateAllPinocchio(&pinocchio_model, &pinocchio_data, x1);
+  model.calc(data, x1);
 
-  // pinocchio data have not been filled so the results of this operation are
-  // null matrices
-  model.calc(data, x);
-
-  // Check that only the Jacobian has been filled
+  // check that only the Jacobian has been filled
   BOOST_CHECK(!data->Jc.isZero());
   BOOST_CHECK(data->dv0_dq.isZero());
+
+  // check Jc against single impulse computations
+  std::size_t ni = 0;
+  const std::size_t& nv = model.get_state()->get_nv();
+  for (std::size_t i = 0; i < 5; ++i) {
+    const std::size_t& ni_i = models[i]->get_ni();
+    models[i]->calc(datas[i], x1);
+    BOOST_CHECK(data->Jc.block(ni, 0, ni_i, nv) == datas[i]->Jc);
+    ni += ni_i;
+  }
+  ni = 0;
+
+  // compute the multiple impulse data for the case when the first three impulses are defined as active
+  model.changeImpulseStatus("random_impulse_3", false);
+  model.changeImpulseStatus("random_impulse_4", false);
+  Eigen::VectorXd x2 = model.get_state()->rand();
+  crocoddyl::unittest::updateAllPinocchio(&pinocchio_model, &pinocchio_data, x2);
+  model.calc(data, x2);
+  for (std::size_t i = 0; i < 5; ++i) {
+    const std::size_t& ni_i = models[i]->get_ni();
+    if (i < 3) {  // we need to update data because this impulses are active
+      models[i]->calc(datas[i], x2);
+    }
+    BOOST_CHECK(data->Jc.block(ni, 0, ni_i, nv) == datas[i]->Jc);
+    ni += ni_i;
+  }
 }
 
 void test_calc_diff() {

--- a/unittest/test_multiple_impulses.cpp
+++ b/unittest/test_multiple_impulses.cpp
@@ -225,27 +225,60 @@ void test_calc_diff() {
   pinocchio::Data pinocchio_data(*model.get_state()->get_pinocchio().get());
 
   // create and add some impulse objects
-  for (unsigned i = 0; i < 5; ++i) {
+  std::vector<boost::shared_ptr<crocoddyl::ImpulseModelAbstract> > models;
+  std::vector<boost::shared_ptr<crocoddyl::ImpulseDataAbstract> > datas;
+  for (std::size_t i = 0; i < 5; ++i) {
     std::ostringstream os;
     os << "random_impulse_" << i;
-    model.addImpulse(os.str(), create_random_impulse());
+    const boost::shared_ptr<crocoddyl::ImpulseModelAbstract>& m = create_random_impulse();
+    model.addImpulse(os.str(), m);
+    models.push_back(m);
+    datas.push_back(m->createData(&pinocchio_data));
   }
 
   // create the data of the multiple-impulses
   boost::shared_ptr<crocoddyl::ImpulseDataMultiple> data = model.createData(&pinocchio_data);
 
-  // Compute the jacobian and check that the impulse models fetch it.
-  Eigen::VectorXd x = model.get_state()->rand();
-  crocoddyl::unittest::updateAllPinocchio(&pinocchio_model, &pinocchio_data, x);
-
-  // pinocchio data have been filled so the results of this operation are
-  // none null matrices
-  model.calc(data, x);
-  model.calcDiff(data, x);
+  // compute the multiple contact data for the case when all impulses are defined as active
+  Eigen::VectorXd x1 = model.get_state()->rand();
+  crocoddyl::unittest::updateAllPinocchio(&pinocchio_model, &pinocchio_data, x1);
+  model.calc(data, x1);
+  model.calcDiff(data, x1);
 
   // Check that nothing has been computed and that all value are initialized to 0
   BOOST_CHECK(!data->Jc.isZero());
   BOOST_CHECK(!data->dv0_dq.isZero());
+
+  // check Jc against single impulse computations
+  std::size_t ni = 0;
+  const std::size_t& nv = model.get_state()->get_nv();
+  for (std::size_t i = 0; i < 5; ++i) {
+    const std::size_t& ni_i = models[i]->get_ni();
+    models[i]->calc(datas[i], x1);
+    models[i]->calcDiff(datas[i], x1);
+    BOOST_CHECK(data->Jc.block(ni, 0, ni_i, nv) == datas[i]->Jc);
+    BOOST_CHECK(data->dv0_dq.block(ni, 0, ni_i, nv) == datas[i]->dv0_dq);
+    ni += ni_i;
+  }
+  ni = 0;
+
+  // compute the multiple impulse data for the case when the first three impulses are defined as active
+  model.changeImpulseStatus("random_impulse_3", false);
+  model.changeImpulseStatus("random_impulse_4", false);
+  Eigen::VectorXd x2 = model.get_state()->rand();
+  crocoddyl::unittest::updateAllPinocchio(&pinocchio_model, &pinocchio_data, x2);
+  model.calc(data, x2);
+  model.calcDiff(data, x2);
+  for (std::size_t i = 0; i < 5; ++i) {
+    const std::size_t& ni_i = models[i]->get_ni();
+    if (i < 3) {  // we need to update data because this impulses are active
+      models[i]->calc(datas[i], x2);
+      models[i]->calcDiff(datas[i], x2);
+    }
+    BOOST_CHECK(data->Jc.block(ni, 0, ni_i, nv) == datas[i]->Jc);
+    BOOST_CHECK(data->dv0_dq.block(ni, 0, ni_i, nv) == datas[i]->dv0_dq);
+    ni += ni_i;
+  }
 }
 
 void test_calc_diff_no_recalc() {


### PR DESCRIPTION
This PR includes the cost status as proposed in #720.

As mentioned in previous pull request, the idea behind of this is to have a global mechanism allocation.

Additionally, this PR includes unittest code for cost sum.

**Note the changes of this PR are still back compatible with previous code.**