### PR TITLE
Templatized activation data

### DIFF
--- a/include/crocoddyl/core/activation-base.hpp
+++ b/include/crocoddyl/core/activation-base.hpp
@@ -68,7 +68,7 @@ struct ActivationDataAbstractTpl {
   typedef typename MathBase::VectorXs VectorXs;
   typedef typename MathBase::MatrixXs MatrixXs;
 
-  template <template <typename Scalar> typename Activation>
+  template <template <typename Scalar> class Activation>
   explicit ActivationDataAbstractTpl(Activation<Scalar>* const activation)
       : a_value(0.),
         Ar(VectorXs::Zero(activation->get_nr())),

--- a/include/crocoddyl/core/activation-base.hpp
+++ b/include/crocoddyl/core/activation-base.hpp
@@ -63,17 +63,17 @@ template <typename _Scalar>
 struct ActivationDataAbstractTpl {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  template <typename Activation>
-  explicit ActivationDataAbstractTpl(Activation* const activation)
-      : a_value(0.),
-        Ar(VectorXs::Zero(activation->get_nr())),
-        Arr(MatrixXs::Zero(activation->get_nr(), activation->get_nr())) {}
-  virtual ~ActivationDataAbstractTpl() {}
-
   typedef _Scalar Scalar;
   typedef MathBaseTpl<Scalar> MathBase;
   typedef typename MathBase::VectorXs VectorXs;
   typedef typename MathBase::MatrixXs MatrixXs;
+
+  template <template <typename Scalar> typename Activation>
+  explicit ActivationDataAbstractTpl(Activation<Scalar>* const activation)
+      : a_value(0.),
+        Ar(VectorXs::Zero(activation->get_nr())),
+        Arr(MatrixXs::Zero(activation->get_nr(), activation->get_nr())) {}
+  virtual ~ActivationDataAbstractTpl() {}
 
   Scalar a_value;
   VectorXs Ar;


### PR DESCRIPTION
Added templatized activation declaration, which was missing in the following line:

https://github.com/loco-3d/crocoddyl/blob/cdac522ec37a885f559794ef57c3244e70926621/include/crocoddyl/core/activation-base.hpp#L67