### PR TITLE
Printing a message that shows all the unittest cases

### DIFF
--- a/unittest/test_actions.cpp
+++ b/unittest/test_actions.cpp
@@ -113,7 +113,7 @@ void register_action_model_unit_tests(ActionModelTypes::Type action_model_type, 
 
 bool init_function() {
   for (size_t i = 0; i < ActionModelTypes::all.size(); ++i) {
-    std::ostringstream test_name;
+    boost::test_tools::output_test_stream test_name;
     test_name << "test_" << ActionModelTypes::all[i];
     test_suite* ts = BOOST_TEST_SUITE(test_name.str());
     std::cout << "Running " << test_name.str() << std::endl;

--- a/unittest/test_activations.cpp
+++ b/unittest/test_activations.cpp
@@ -84,7 +84,7 @@ void register_unit_tests(ActivationModelTypes::Type activation_type, test_suite&
 
 bool init_function() {
   for (size_t i = 0; i < ActivationModelTypes::all.size(); ++i) {
-    std::ostringstream test_name;
+    boost::test_tools::output_test_stream test_name;
     test_name << "test_" << ActivationModelTypes::all[i];
     test_suite* ts = BOOST_TEST_SUITE(test_name.str());
     std::cout << "Running " << test_name.str() << std::endl;

--- a/unittest/test_contacts.cpp
+++ b/unittest/test_contacts.cpp
@@ -192,7 +192,7 @@ void register_contact_model_unit_tests(ContactModelTypes::Type contact_type, Pin
 bool init_function() {
   for (size_t contact_type = 0; contact_type < ContactModelTypes::all.size(); ++contact_type) {
     for (size_t model_type = 0; model_type < PinocchioModelTypes::all.size(); ++model_type) {
-      std::ostringstream test_name;
+      boost::test_tools::output_test_stream test_name;
       test_name << "test_" << ContactModelTypes::all[contact_type] << "_" << PinocchioModelTypes::all[model_type];
       test_suite* ts = BOOST_TEST_SUITE(test_name.str());
       std::cout << "Running " << test_name.str() << std::endl;

--- a/unittest/test_costs.cpp
+++ b/unittest/test_costs.cpp
@@ -241,7 +241,7 @@ bool init_function() {
     for (size_t state_type = StateModelTypes::all[StateModelTypes::StateMultibody_TalosArm];
          state_type < StateModelTypes::all.size(); ++state_type) {
       for (size_t activation_type = 0; activation_type < ActivationModelTypes::all.size(); ++activation_type) {
-        std::ostringstream test_name;
+        boost::test_tools::output_test_stream test_name;
         test_name << "test_" << CostModelTypes::all[cost_type] << "_" << ActivationModelTypes::all[activation_type]
                   << "_" << StateModelTypes::all[state_type];
         test_suite* ts = BOOST_TEST_SUITE(test_name.str());

--- a/unittest/test_diff_actions.cpp
+++ b/unittest/test_diff_actions.cpp
@@ -112,7 +112,7 @@ void register_action_model_unit_tests(DifferentialActionModelTypes::Type action_
 
 bool init_function() {
   for (size_t i = 0; i < DifferentialActionModelTypes::all.size(); ++i) {
-    std::ostringstream test_name;
+    boost::test_tools::output_test_stream test_name;
     test_name << "test_" << DifferentialActionModelTypes::all[i];
     test_suite* ts = BOOST_TEST_SUITE(test_name.str());
     std::cout << "Running " << test_name.str() << std::endl;

--- a/unittest/test_impulses.cpp
+++ b/unittest/test_impulses.cpp
@@ -145,7 +145,7 @@ void register_impulse_model_unit_tests(ImpulseModelTypes::Type impulse_type, Pin
 bool init_function() {
   for (size_t impulse_type = 0; impulse_type < ImpulseModelTypes::all.size(); ++impulse_type) {
     for (size_t model_type = 0; model_type < PinocchioModelTypes::all.size(); ++model_type) {
-      std::ostringstream test_name;
+      boost::test_tools::output_test_stream test_name;
       test_name << "test_" << ImpulseModelTypes::all[impulse_type] << "_" << PinocchioModelTypes::all[model_type];
       test_suite* ts = BOOST_TEST_SUITE(test_name.str());
       std::cout << "Running " << test_name.str() << std::endl;

--- a/unittest/test_solvers.cpp
+++ b/unittest/test_solvers.cpp
@@ -125,7 +125,7 @@ bool init_function() {
   // We start from 1 as 0 is the kkt solver
   for (size_t solver_type = 1; solver_type < SolverTypes::all.size(); ++solver_type) {
     for (size_t action_type = 0; action_type < ActionModelTypes::all.size(); ++action_type) {
-      std::ostringstream test_name;
+      boost::test_tools::output_test_stream test_name;
       test_name << "test_" << SolverTypes::all[solver_type] << "_" << ActionModelTypes::all[action_type];
       test_suite* ts = BOOST_TEST_SUITE(test_name.str());
       std::cout << "Running " << test_name.str() << std::endl;

--- a/unittest/test_states.cpp
+++ b/unittest/test_states.cpp
@@ -298,7 +298,7 @@ void register_state_unit_tests(StateModelTypes::Type state_type, test_suite& ts)
 
 bool init_function() {
   for (size_t i = 0; i < StateModelTypes::all.size(); ++i) {
-    std::ostringstream test_name;
+    boost::test_tools::output_test_stream test_name;
     test_name << "test_" << StateModelTypes::all[i];
     test_suite* ts = BOOST_TEST_SUITE(test_name.str());
     std::cout << "Running " << test_name.str() << std::endl;


### PR DESCRIPTION
This PR uses `boost::test_tools::output_test_stream` to print properly the message that shows all the unittest cases.

It helps the developers to understand the unittest cases.