### PR TITLE
Python bindings with Eigen::Ref #202

### DIFF
--- a/bindings/python/crocoddyl/core/action-base.cpp
+++ b/bindings/python/crocoddyl/core/action-base.cpp
@@ -38,6 +38,9 @@ void exposeActionAbstract() {
            ":param data: action data\n"
            ":param x: time-discrete state vector\n"
            ":param u: time-discrete control input")
+      .def<void (ActionModelAbstract::*)(const boost::shared_ptr<ActionDataAbstract>&,
+                                         const Eigen::Ref<const Eigen::VectorXd>&)>("calc", &ActionModelAbstract::calc,
+                                                                                    bp::args("self", "data", "x"))
       .def("calcDiff", pure_virtual(&ActionModelAbstract_wrap::calcDiff), bp::args("self", "data", "x", "u"),
            "Compute the derivatives of the dynamics and cost functions.\n\n"
            "It computes the partial derivatives of the dynamical system and the\n"
@@ -47,12 +50,15 @@ void exposeActionAbstract() {
            ":param data: action data\n"
            ":param x: time-discrete state vector\n"
            ":param u: time-discrete control input\n")
+      .def<void (ActionModelAbstract::*)(const boost::shared_ptr<ActionDataAbstract>&,
+                                         const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &ActionModelAbstract::calcDiff, bp::args("self", "data", "x"))
       .def("createData", &ActionModelAbstract_wrap::createData, bp::args("self"),
            "Create the action data.\n\n"
            "Each action model (AM) has its own data that needs to be allocated.\n"
            "This function returns the allocated data for a predefined AM.\n"
            ":return AM data.")
-      .def("quasiStatic", &ActionModelAbstract_wrap::quasiStatic_wrap,
+      .def("quasiStatic", &ActionModelAbstract_wrap::quasiStatic_x,
            ActionModel_quasiStatic_wraps(
                bp::args("self", "data", "x", "maxiter", "tol"),
                "Compute the quasic-static control given a state.\n\n"

--- a/bindings/python/crocoddyl/core/action-base.hpp
+++ b/bindings/python/crocoddyl/core/action-base.hpp
@@ -47,8 +47,7 @@ class ActionModelAbstract_wrap : public ActionModelAbstract, public bp::wrapper<
   }
 };
 
-BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(ActionModel_calc_wraps, ActionModelAbstract::calc_wrap, 2, 3)
-BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(ActionModel_quasiStatic_wraps, ActionModelAbstract::quasiStatic_wrap, 2, 4)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(ActionModel_quasiStatic_wraps, ActionModelAbstract::quasiStatic_x, 2, 4)
 
 }  // namespace python
 }  // namespace crocoddyl

--- a/bindings/python/crocoddyl/core/actions/diff-lqr.cpp
+++ b/bindings/python/crocoddyl/core/actions/diff-lqr.cpp
@@ -32,17 +32,23 @@ void exposeDifferentialActionLQR() {
           ":param nx: dimension of the state vector\n"
           ":param nu: dimension of the control vector\n"
           ":param driftFree: enable/disable the bias term of the linear dynamics (default True)"))
-      .def("calc", &DifferentialActionModelLQR::calc_wrap,
-           DiffActionModel_calc_wraps(bp::args("self", "data", "x", "u"),
-                                      "Compute the next state and cost value.\n\n"
-                                      "It describes the time-continuous evolution of the LQR system. Additionally it\n"
-                                      "computes the cost value associated to this discrete state and control pair.\n"
-                                      ":param data: action data\n"
-                                      ":param x: time-continuous state vector\n"
-                                      ":param u: time-continuous control input"))
       .def<void (DifferentialActionModelLQR::*)(const boost::shared_ptr<DifferentialActionDataAbstract>&,
-                                                const Eigen::VectorXd&, const Eigen::VectorXd&)>(
-          "calcDiff", &DifferentialActionModelLQR::calcDiff_wrap, bp::args("self", "data", "x", "u"),
+                                                const Eigen::Ref<const Eigen::VectorXd>&,
+                                                const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &DifferentialActionModelLQR::calc, bp::args("self", "data", "x", "u"),
+          "Compute the next state and cost value.\n\n"
+          "It describes the time-continuous evolution of the LQR system. Additionally it\n"
+          "computes the cost value associated to this discrete state and control pair.\n"
+          ":param data: action data\n"
+          ":param x: time-continuous state vector\n"
+          ":param u: time-continuous control input")
+      .def<void (DifferentialActionModelLQR::*)(const boost::shared_ptr<DifferentialActionDataAbstract>&,
+                                                const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &DifferentialActionModelAbstract::calc, bp::args("self", "data", "x"))
+      .def<void (DifferentialActionModelLQR::*)(const boost::shared_ptr<DifferentialActionDataAbstract>&,
+                                                const Eigen::Ref<const Eigen::VectorXd>&,
+                                                const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &DifferentialActionModelLQR::calcDiff, bp::args("self", "data", "x", "u"),
           "Compute the derivatives of the differential LQR dynamics and cost functions.\n\n"
           "It computes the partial derivatives of the differential LQR system and the\n"
           "cost function. It assumes that calc has been run first.\n"
@@ -52,8 +58,8 @@ void exposeDifferentialActionLQR() {
           ":param x: time-continuous state vector\n"
           ":param u: time-continuous control input\n")
       .def<void (DifferentialActionModelLQR::*)(const boost::shared_ptr<DifferentialActionDataAbstract>&,
-                                                const Eigen::VectorXd&)>(
-          "calcDiff", &DifferentialActionModelLQR::calcDiff_wrap, bp::args("self", "data", "x"))
+                                                const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &DifferentialActionModelAbstract::calcDiff, bp::args("self", "data", "x"))
       .def("createData", &DifferentialActionModelLQR::createData, bp::args("self"),
            "Create the differential LQR action data.")
       .add_property("Fq", bp::make_function(&DifferentialActionModelLQR::get_Fq, bp::return_internal_reference<>()),

--- a/bindings/python/crocoddyl/core/actions/lqr.cpp
+++ b/bindings/python/crocoddyl/core/actions/lqr.cpp
@@ -26,18 +26,24 @@ void exposeActionLQR() {
           ":param nx: dimension of the state vector\n"
           ":param nu: dimension of the control vector\n"
           ":param driftFree: enable/disable the bias term of the linear dynamics (default True)"))
-      .def("calc", &ActionModelLQR::calc_wrap,
-           ActionModel_calc_wraps(bp::args("self", "data", "x", "u"),
-                                  "Compute the next state and cost value.\n\n"
-                                  "It describes the time-discrete evolution of the LQR system. Additionally it\n"
-                                  "computes the cost value associated to this discrete\n"
-                                  "state and control pair.\n"
-                                  ":param data: action data\n"
-                                  ":param x: time-discrete state vector\n"
-                                  ":param u: time-discrete control input"))
-      .def<void (ActionModelLQR::*)(const boost::shared_ptr<ActionDataAbstract>&, const Eigen::VectorXd&,
-                                    const Eigen::VectorXd&)>(
-          "calcDiff", &ActionModelLQR::calcDiff_wrap, bp::args("self", "data", "x", "u"),
+      .def<void (ActionModelLQR::*)(const boost::shared_ptr<ActionDataAbstract>&,
+                                    const Eigen::Ref<const Eigen::VectorXd>&,
+                                    const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &ActionModelLQR::calc, bp::args("self", "data", "x", "u"),
+          "Compute the next state and cost value.\n\n"
+          "It describes the time-discrete evolution of the LQR system. Additionally it\n"
+          "computes the cost value associated to this discrete\n"
+          "state and control pair.\n"
+          ":param data: action data\n"
+          ":param x: time-discrete state vector\n"
+          ":param u: time-discrete control input")
+      .def<void (ActionModelLQR::*)(const boost::shared_ptr<ActionDataAbstract>&,
+                                    const Eigen::Ref<const Eigen::VectorXd>&)>("calc", &ActionModelAbstract::calc,
+                                                                               bp::args("self", "data", "x"))
+      .def<void (ActionModelLQR::*)(const boost::shared_ptr<ActionDataAbstract>&,
+                                    const Eigen::Ref<const Eigen::VectorXd>&,
+                                    const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &ActionModelLQR::calcDiff, bp::args("self", "data", "x", "u"),
           "Compute the derivatives of the LQR dynamics and cost functions.\n\n"
           "It computes the partial derivatives of the LQR system and the\n"
           "cost function. It assumes that calc has been run first.\n"
@@ -46,8 +52,9 @@ void exposeActionLQR() {
           ":param data: action data\n"
           ":param x: time-discrete state vector\n"
           ":param u: time-discrete control input\n")
-      .def<void (ActionModelLQR::*)(const boost::shared_ptr<ActionDataAbstract>&, const Eigen::VectorXd&)>(
-          "calcDiff", &ActionModelLQR::calcDiff_wrap, bp::args("self", "data", "x"))
+      .def<void (ActionModelLQR::*)(const boost::shared_ptr<ActionDataAbstract>&,
+                                    const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &ActionModelAbstract::calcDiff, bp::args("self", "data", "x"))
       .def("createData", &ActionModelLQR::createData, bp::args("self"), "Create the LQR action data.")
       .add_property("Fx", bp::make_function(&ActionModelLQR::get_Fx, bp::return_internal_reference<>()),
                     &ActionModelLQR::set_Fx, "Jacobian of the dynamics")

--- a/bindings/python/crocoddyl/core/actions/unicycle.cpp
+++ b/bindings/python/crocoddyl/core/actions/unicycle.cpp
@@ -24,18 +24,24 @@ void exposeActionUnicycle() {
       "other hand, we define the quadratic cost functions for the state and\n"
       "control.",
       bp::init<>(bp::args("self"), "Initialize the unicycle action model."))
-      .def("calc", &ActionModelUnicycle::calc_wrap,
-           ActionModel_calc_wraps(bp::args("self", "data", "x", "u"),
-                                  "Compute the next state and cost value.\n\n"
-                                  "It describes the time-discrete evolution of the unicycle system.\n"
-                                  "Additionally it computes the cost value associated to this discrete\n"
-                                  "state and control pair.\n"
-                                  ":param data: action data\n"
-                                  ":param x: time-discrete state vector\n"
-                                  ":param u: time-discrete control input"))
-      .def<void (ActionModelUnicycle::*)(const boost::shared_ptr<ActionDataAbstract>&, const Eigen::VectorXd&,
-                                         const Eigen::VectorXd&)>(
-          "calcDiff", &ActionModelUnicycle::calcDiff_wrap, bp::args("self", "data", "x", "u"),
+      .def<void (ActionModelUnicycle::*)(const boost::shared_ptr<ActionDataAbstract>&,
+                                         const Eigen::Ref<const Eigen::VectorXd>&,
+                                         const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &ActionModelUnicycle::calc, bp::args("self", "data", "x", "u"),
+          "Compute the next state and cost value.\n\n"
+          "It describes the time-discrete evolution of the unicycle system.\n"
+          "Additionally it computes the cost value associated to this discrete\n"
+          "state and control pair.\n"
+          ":param data: action data\n"
+          ":param x: time-discrete state vector\n"
+          ":param u: time-discrete control input")
+      .def<void (ActionModelUnicycle::*)(const boost::shared_ptr<ActionDataAbstract>&,
+                                         const Eigen::Ref<const Eigen::VectorXd>&)>("calc", &ActionModelAbstract::calc,
+                                                                                    bp::args("self", "data", "x"))
+      .def<void (ActionModelUnicycle::*)(const boost::shared_ptr<ActionDataAbstract>&,
+                                         const Eigen::Ref<const Eigen::VectorXd>&,
+                                         const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &ActionModelUnicycle::calcDiff, bp::args("self", "data", "x", "u"),
           "Compute the derivatives of the unicycle dynamics and cost functions.\n\n"
           "It computes the partial derivatives of the unicycle system and the\n"
           "cost function. It assumes that calc has been run first.\n"
@@ -44,9 +50,9 @@ void exposeActionUnicycle() {
           ":param data: action data\n"
           ":param x: time-discrete state vector\n"
           ":param u: time-discrete control input\n")
-
-      .def<void (ActionModelUnicycle::*)(const boost::shared_ptr<ActionDataAbstract>&, const Eigen::VectorXd&)>(
-          "calcDiff", &ActionModelUnicycle::calcDiff_wrap, bp::args("self", "data", "x"))
+      .def<void (ActionModelUnicycle::*)(const boost::shared_ptr<ActionDataAbstract>&,
+                                         const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &ActionModelAbstract::calcDiff, bp::args("self", "data", "x"))
       .def("createData", &ActionModelUnicycle::createData, bp::args("self"), "Create the unicycle action data.")
       .add_property("costWeights",
                     bp::make_function(&ActionModelUnicycle::get_cost_weights, bp::return_internal_reference<>()),

--- a/bindings/python/crocoddyl/core/activations/quadratic-barrier.cpp
+++ b/bindings/python/crocoddyl/core/activations/quadratic-barrier.cpp
@@ -40,17 +40,15 @@ void exposeActivationQuadraticBarrier() {
       bp::init<ActivationBounds>(bp::args("self", "bounds"),
                                  "Initialize the activation model.\n\n"
                                  ":param bounds: activation bounds"))
-      .def("calc", &ActivationModelQuadraticBarrier::calc_wrap, bp::args("self", "data", "r"),
+      .def("calc", &ActivationModelQuadraticBarrier::calc, bp::args("self", "data", "r"),
            "Compute the inequality activation.\n\n"
            ":param data: activation data\n"
            ":param r: residual vector")
-      .def<void (ActivationModelQuadraticBarrier::*)(const boost::shared_ptr<ActivationDataAbstract>&,
-                                                     const Eigen::VectorXd&)>(
-          "calcDiff", &ActivationModelQuadraticBarrier::calcDiff_wrap, bp::args("self", "data", "r"),
-          "Compute the derivatives of inequality activation.\n\n"
-          ":param data: activation data\n"
-          "Note that the Hessian is constant, so we don't write again this value.\n"
-          ":param r: residual vector \n")
+      .def("calcDiff", &ActivationModelQuadraticBarrier::calcDiff, bp::args("self", "data", "r"),
+           "Compute the derivatives of inequality activation.\n\n"
+           ":param data: activation data\n"
+           "Note that the Hessian is constant, so we don't write again this value.\n"
+           ":param r: residual vector \n")
       .def("createData", &ActivationModelQuadraticBarrier::createData, bp::args("self"),
            "Create the weighted quadratic action data.")
       .add_property("bounds",

--- a/bindings/python/crocoddyl/core/activations/quadratic.cpp
+++ b/bindings/python/crocoddyl/core/activations/quadratic.cpp
@@ -22,16 +22,15 @@ void exposeActivationQuad() {
       bp::init<int>(bp::args("self", "nr"),
                     "Initialize the activation model.\n\n"
                     ":param nr: dimension of the cost-residual vector"))
-      .def("calc", &ActivationModelQuad::calc_wrap, bp::args("self", "data", "r"),
+      .def("calc", &ActivationModelQuad::calc, bp::args("self", "data", "r"),
            "Compute the 0.5 * ||r||^2.\n\n"
            ":param data: activation data\n"
            ":param r: residual vector")
-      .def<void (ActivationModelQuad::*)(const boost::shared_ptr<ActivationDataAbstract>&, const Eigen::VectorXd&)>(
-          "calcDiff", &ActivationModelQuad::calcDiff_wrap, bp::args("self", "data", "r"),
-          "Compute the derivatives of a quadratic function.\n\n"
-          "Note that the Hessian is constant, so we don't write again this value.\n"
-          ":param data: activation data\n"
-          ":param r: residual vector \n")
+      .def("calcDiff", &ActivationModelQuad::calcDiff, bp::args("self", "data", "r"),
+           "Compute the derivatives of a quadratic function.\n\n"
+           "Note that the Hessian is constant, so we don't write again this value.\n"
+           ":param data: activation data\n"
+           ":param r: residual vector \n")
       .def("createData", &ActivationModelQuad::createData, bp::args("self"),
            "Create the quadratic activation data.\n\n");
 }

--- a/bindings/python/crocoddyl/core/activations/smooth-abs.cpp
+++ b/bindings/python/crocoddyl/core/activations/smooth-abs.cpp
@@ -22,16 +22,14 @@ void exposeActivationSmoothAbs() {
       bp::init<int>(bp::args("self", "nr"),
                     "Initialize the activation model.\n\n"
                     ":param nr: dimension of the cost-residual vector"))
-      .def("calc", &ActivationModelSmoothAbs::calc_wrap, bp::args("self", "data", "r"),
+      .def("calc", &ActivationModelSmoothAbs::calc, bp::args("self", "data", "r"),
            "Compute the sqrt{1 + ||r||^2}.\n\n"
            ":param data: activation data\n"
            ":param r: residual vector")
-      .def<void (ActivationModelSmoothAbs::*)(const boost::shared_ptr<ActivationDataAbstract>&,
-                                              const Eigen::VectorXd&)>(
-          "calcDiff", &ActivationModelSmoothAbs::calcDiff_wrap, bp::args("self", "data", "r"),
-          "Compute the derivatives of a smooth-abs function.\n\n"
-          ":param data: activation data\n"
-          ":param r: residual vector \n")
+      .def("calcDiff", &ActivationModelSmoothAbs::calcDiff, bp::args("self", "data", "r"),
+           "Compute the derivatives of a smooth-abs function.\n\n"
+           ":param data: activation data\n"
+           ":param r: residual vector \n")
 
       .def("createData", &ActivationModelSmoothAbs::createData, bp::args("self"),
            "Create the smooth-abs activation data.\n\n");

--- a/bindings/python/crocoddyl/core/activations/weighted-quadratic-barrier.cpp
+++ b/bindings/python/crocoddyl/core/activations/weighted-quadratic-barrier.cpp
@@ -27,17 +27,15 @@ void exposeActivationWeightedQuadraticBarrier() {
                                                   "Initialize the activation model.\n\n"
                                                   ":param bounds: activation bounds\n"
                                                   ":param weights: weights"))
-      .def("calc", &ActivationModelWeightedQuadraticBarrier::calc_wrap, bp::args("self", "data", "r"),
+      .def("calc", &ActivationModelWeightedQuadraticBarrier::calc, bp::args("self", "data", "r"),
            "Compute the inequality activation.\n\n"
            ":param data: activation data\n"
            ":param r: residual vector")
-      .def<void (ActivationModelWeightedQuadraticBarrier::*)(const boost::shared_ptr<ActivationDataAbstract>&,
-                                                             const Eigen::VectorXd&)>(
-          "calcDiff", &ActivationModelWeightedQuadraticBarrier::calcDiff_wrap, bp::args("self", "data", "r"),
-          "Compute the derivatives of inequality activation.\n\n"
-          ":param data: activation data\n"
-          "Note that the Hessian is constant, so we don't write again this value.\n"
-          ":param r: residual vector \n")
+      .def("calcDiff", &ActivationModelWeightedQuadraticBarrier::calcDiff, bp::args("self", "data", "r"),
+           "Compute the derivatives of inequality activation.\n\n"
+           ":param data: activation data\n"
+           "Note that the Hessian is constant, so we don't write again this value.\n"
+           ":param r: residual vector \n")
       .def("createData", &ActivationModelWeightedQuadraticBarrier::createData, bp::args("self"),
            "Create the weighted quadratic action data.")
       .add_property("bounds",

--- a/bindings/python/crocoddyl/core/activations/weighted-quadratic.cpp
+++ b/bindings/python/crocoddyl/core/activations/weighted-quadratic.cpp
@@ -22,17 +22,15 @@ void exposeActivationWeightedQuad() {
       bp::init<Eigen::VectorXd>(bp::args("self", "weights"),
                                 "Initialize the activation model.\n\n"
                                 ":param weights: weights vector, note that nr=weights.size()"))
-      .def("calc", &ActivationModelWeightedQuad::calc_wrap, bp::args("self", "data", "r"),
+      .def("calc", &ActivationModelWeightedQuad::calc, bp::args("self", "data", "r"),
            "Compute the 0.5 * ||r||_w^2.\n\n"
            ":param data: activation data\n"
            ":param r: residual vector")
-      .def<void (ActivationModelWeightedQuad::*)(const boost::shared_ptr<ActivationDataAbstract>&,
-                                                 const Eigen::VectorXd&)>(
-          "calcDiff", &ActivationModelWeightedQuad::calcDiff_wrap, bp::args("self", "data", "r"),
-          "Compute the derivatives of a quadratic function.\n\n"
-          ":param data: activation data\n"
-          "Note that the Hessian is constant, so we don't write again this value.\n"
-          ":param r: residual vector \n")
+      .def("calcDiff", &ActivationModelWeightedQuad::calcDiff, bp::args("self", "data", "r"),
+           "Compute the derivatives of a quadratic function.\n\n"
+           ":param data: activation data\n"
+           "Note that the Hessian is constant, so we don't write again this value.\n"
+           ":param r: residual vector \n")
       .def("createData", &ActivationModelWeightedQuad::createData, bp::args("self"),
            "Create the weighted quadratic action data.")
       .add_property("weights",

--- a/bindings/python/crocoddyl/core/actuation/actuation-squashing.cpp
+++ b/bindings/python/crocoddyl/core/actuation/actuation-squashing.cpp
@@ -23,7 +23,7 @@ void exposeActuationSquashing() {
           bp::args("self", "actuation", "squashing", "nu"),
           "Initialize the actuation model with squashing function.\n\n"
           ":param actuation: actuation model to be squashed,\n"
-          ":param squashing: squashjng function,\n"
+          ":param squashing: squashing function,\n"
           ":param nu: number of controls"))
       .def("calc", &ActuationSquashingModel::calc, bp::args("self", "data", "x", "u"),
            "Compute the actuation signal from the squashing input u.\n\n"

--- a/bindings/python/crocoddyl/core/diff-action-base.cpp
+++ b/bindings/python/crocoddyl/core/diff-action-base.cpp
@@ -40,6 +40,9 @@ void exposeDifferentialActionAbstract() {
            ":param data: differential action data\n"
            ":param x: state vector\n"
            ":param u: control input")
+      .def<void (DifferentialActionModelAbstract::*)(const boost::shared_ptr<DifferentialActionDataAbstract>&,
+                                                     const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &DifferentialActionModelAbstract::calc, bp::args("self", "data", "x"))
       .def("calcDiff", pure_virtual(&DifferentialActionModelAbstract_wrap::calcDiff),
            bp::args("self", "data", "x", "u"),
            "Compute the derivatives of the dynamics and cost functions.\n\n"
@@ -50,6 +53,9 @@ void exposeDifferentialActionAbstract() {
            ":param data: differential action data\n"
            ":param x: state vector\n"
            ":param u: control input\n")
+      .def<void (DifferentialActionModelAbstract::*)(const boost::shared_ptr<DifferentialActionDataAbstract>&,
+                                                     const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &DifferentialActionModelAbstract::calcDiff, bp::args("self", "data", "x"))
       .def("createData", &DifferentialActionModelAbstract_wrap::createData, bp::args("self"),
            "Create the differential action data.\n\n"
            "Each differential action model has its own data that needs to be\n"

--- a/bindings/python/crocoddyl/core/diff-action-base.hpp
+++ b/bindings/python/crocoddyl/core/diff-action-base.hpp
@@ -49,8 +49,6 @@ class DifferentialActionModelAbstract_wrap : public DifferentialActionModelAbstr
   }
 };
 
-BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(DiffActionModel_calc_wraps, DifferentialActionModelAbstract::calc_wrap, 2, 3)
-
 }  // namespace python
 }  // namespace crocoddyl
 

--- a/bindings/python/crocoddyl/core/integrator/euler.cpp
+++ b/bindings/python/crocoddyl/core/integrator/euler.cpp
@@ -26,16 +26,22 @@ void exposeIntegratedActionEuler() {
           ":param diffModel: differential action model\n"
           ":param stepTime: step time\n"
           ":param withCostResidual: includes the cost residuals and derivatives."))
-      .def("calc", &IntegratedActionModelEuler::calc_wrap,
-           ActionModel_calc_wraps(bp::args("self", "data", "x", "u"),
-                                  "Compute the time-discrete evolution of a differential action model.\n\n"
-                                  "It describes the time-discrete evolution of action model.\n"
-                                  ":param data: action data\n"
-                                  ":param x: state vector\n"
-                                  ":param u: control input"))
-      .def<void (IntegratedActionModelEuler::*)(const boost::shared_ptr<ActionDataAbstract>&, const Eigen::VectorXd&,
-                                                const Eigen::VectorXd&)>(
-          "calcDiff", &IntegratedActionModelEuler::calcDiff_wrap, bp::args("self", "data", "x", "u"),
+      .def<void (IntegratedActionModelEuler::*)(const boost::shared_ptr<ActionDataAbstract>&,
+                                                const Eigen::Ref<const Eigen::VectorXd>&,
+                                                const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &IntegratedActionModelEuler::calc, bp::args("self", "data", "x", "u"),
+          "Compute the time-discrete evolution of a differential action model.\n\n"
+          "It describes the time-discrete evolution of action model.\n"
+          ":param data: action data\n"
+          ":param x: state vector\n"
+          ":param u: control input")
+      .def<void (IntegratedActionModelEuler::*)(const boost::shared_ptr<ActionDataAbstract>&,
+                                                const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &ActionModelAbstract::calc, bp::args("self", "data", "x"))
+      .def<void (IntegratedActionModelEuler::*)(const boost::shared_ptr<ActionDataAbstract>&,
+                                                const Eigen::Ref<const Eigen::VectorXd>&,
+                                                const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &IntegratedActionModelEuler::calcDiff, bp::args("self", "data", "x", "u"),
           "Compute the time-discrete derivatives of a differential action model.\n\n"
           "It computes the time-discrete partial derivatives of a differential\n"
           "action model. It assumes that calc has been run first.\n"
@@ -44,10 +50,9 @@ void exposeIntegratedActionEuler() {
           ":param data: action data\n"
           ":param x: state vector\n"
           ":param u: control input\n")
-
-      .def<void (IntegratedActionModelEuler::*)(const boost::shared_ptr<ActionDataAbstract>&, const Eigen::VectorXd&)>(
-          "calcDiff", &IntegratedActionModelEuler::calcDiff_wrap, bp::args("self", "data", "x"))
-
+      .def<void (IntegratedActionModelEuler::*)(const boost::shared_ptr<ActionDataAbstract>&,
+                                                const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &ActionModelAbstract::calcDiff, bp::args("self", "data", "x"))
       .def("createData", &IntegratedActionModelEuler::createData, bp::args("self"),
            "Create the Euler integrator data.")
       .add_property("differential",

--- a/bindings/python/crocoddyl/core/numdiff/action.cpp
+++ b/bindings/python/crocoddyl/core/numdiff/action.cpp
@@ -20,23 +20,30 @@ void exposeActionNumDiff() {
           bp::args("self", "model"),
           "Initialize the action model NumDiff.\n\n"
           ":param model: action model where we compute the derivatives through NumDiff"))
-      .def("calc", &ActionModelNumDiff::calc_wrap,
-           ActionModel_calc_wraps(bp::args("self", "data", "x", "u"),
-                                  "Compute the next state and cost value.\n\n"
-                                  "The system evolution is described in model.\n"
-                                  ":param data: NumDiff action data\n"
-                                  ":param x: time-discrete state vector\n"
-                                  ":param u: time-discrete control input"))
-      .def<void (ActionModelNumDiff::*)(const boost::shared_ptr<ActionDataAbstract>&, const Eigen::VectorXd&,
-                                        const Eigen::VectorXd&)>(
-          "calcDiff", &ActionModelNumDiff::calcDiff_wrap, bp::args("self", "data", "x", "u"),
+      .def<void (ActionModelNumDiff::*)(const boost::shared_ptr<ActionDataAbstract>&,
+                                        const Eigen::Ref<const Eigen::VectorXd>&,
+                                        const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &ActionModelNumDiff::calc, bp::args("self", "data", "x", "u"),
+          "Compute the next state and cost value.\n\n"
+          "The system evolution is described in model.\n"
+          ":param data: NumDiff action data\n"
+          ":param x: time-discrete state vector\n"
+          ":param u: time-discrete control input")
+      .def<void (ActionModelNumDiff::*)(const boost::shared_ptr<ActionDataAbstract>&,
+                                        const Eigen::Ref<const Eigen::VectorXd>&)>("calc", &ActionModelAbstract::calc,
+                                                                                   bp::args("self", "data", "x"))
+      .def<void (ActionModelNumDiff::*)(const boost::shared_ptr<ActionDataAbstract>&,
+                                        const Eigen::Ref<const Eigen::VectorXd>&,
+                                        const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &ActionModelNumDiff::calcDiff, bp::args("self", "data", "x", "u"),
           "Compute the derivatives of the dynamics and cost functions.\n\n"
           "It computes the Jacobian and Hessian using numerical differentiation.\n"
           ":param data: NumDiff action data\n"
           ":param x: time-discrete state vector\n"
           ":param u: time-discrete control input\n")
-      .def<void (ActionModelNumDiff::*)(const boost::shared_ptr<ActionDataAbstract>&, const Eigen::VectorXd&)>(
-          "calcDiff", &ActionModelNumDiff::calcDiff_wrap, bp::args("self", "data", "x"))
+      .def<void (ActionModelNumDiff::*)(const boost::shared_ptr<ActionDataAbstract>&,
+                                        const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &ActionModelAbstract::calcDiff, bp::args("self", "data", "x"))
       .def("createData", &ActionModelNumDiff::createData, bp::args("self"),
            "Create the action data.\n\n"
            "Each action model (AM) has its own data that needs to be allocated.\n"

--- a/bindings/python/crocoddyl/core/numdiff/activation.cpp
+++ b/bindings/python/crocoddyl/core/numdiff/activation.cpp
@@ -20,17 +20,16 @@ void exposeActivationNumDiff() {
           bp::args("self", "model"),
           "Initialize the activation model NumDiff.\n\n"
           ":param model: activation model where we compute the derivatives through NumDiff"))
-      .def("calc", &ActivationModelNumDiff::calc_wrap, bp::args("self", "data", "r"),
+      .def("calc", &ActivationModelNumDiff::calc, bp::args("self", "data", "r"),
            "Compute the activation value.\n\n"
            "The activation evolution is described in model.\n"
            ":param data: NumDiff action data\n"
            ":param r: residual vector")
-      .def<void (ActivationModelNumDiff::*)(const boost::shared_ptr<ActivationDataAbstract>&, const Eigen::VectorXd&)>(
-          "calcDiff", &ActivationModelNumDiff::calcDiff_wrap, bp::args("self", "data", "r"),
-          "Compute the derivatives of the residual.\n\n"
-          "It computes the Jacobian and Hessian using numerical differentiation.\n"
-          ":param data: NumDiff action data\n"
-          ":param r: residual vector\n")
+      .def("calcDiff", &ActivationModelNumDiff::calcDiff, bp::args("self", "data", "r"),
+           "Compute the derivatives of the residual.\n\n"
+           "It computes the Jacobian and Hessian using numerical differentiation.\n"
+           ":param data: NumDiff action data\n"
+           ":param r: residual vector\n")
       .def("createData", &ActivationModelNumDiff::createData, bp::args("self"),
            "Create the activation data.\n\n"
            "Each activation model (AM) has its own data that needs to be allocated.\n"

--- a/bindings/python/crocoddyl/core/numdiff/diff-action.cpp
+++ b/bindings/python/crocoddyl/core/numdiff/diff-action.cpp
@@ -33,24 +33,30 @@ void exposeDifferentialActionNumDiff() {
           "Initialize the action model NumDiff.\n\n"
           ":param model: action model where we compute the derivatives through NumDiff,\n"
           ":param gaussApprox: compute the Hessian using Gauss approximation (default False)"))
-      .def("calc", &DifferentialActionModelNumDiff::calc_wrap,
-           DiffActionModel_calc_wraps(bp::args("self", "data", "x", "u"),
-                                      "Compute the next state and cost value.\n\n"
-                                      "The system evolution is described in model.\n"
-                                      ":param data: NumDiff action data\n"
-                                      ":param x: time-discrete state vector\n"
-                                      ":param u: time-discrete control input"))
       .def<void (DifferentialActionModelNumDiff::*)(const boost::shared_ptr<DifferentialActionDataAbstract>&,
-                                                    const Eigen::VectorXd&, const Eigen::VectorXd&)>(
-          "calcDiff", &DifferentialActionModelNumDiff::calcDiff_wrap, bp::args("self", "data", "x", "u"),
+                                                    const Eigen::Ref<const Eigen::VectorXd>&,
+                                                    const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &DifferentialActionModelNumDiff::calc, bp::args("self", "data", "x", "u"),
+          "Compute the next state and cost value.\n\n"
+          "The system evolution is described in model.\n"
+          ":param data: NumDiff action data\n"
+          ":param x: time-discrete state vector\n"
+          ":param u: time-discrete control input")
+      .def<void (DifferentialActionModelNumDiff::*)(const boost::shared_ptr<DifferentialActionDataAbstract>&,
+                                                    const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &DifferentialActionModelAbstract::calc, bp::args("self", "data", "x"))
+      .def<void (DifferentialActionModelNumDiff::*)(const boost::shared_ptr<DifferentialActionDataAbstract>&,
+                                                    const Eigen::Ref<const Eigen::VectorXd>&,
+                                                    const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &DifferentialActionModelNumDiff::calcDiff, bp::args("self", "data", "x", "u"),
           "Compute the derivatives of the dynamics and cost functions.\n\n"
           "It computes the Jacobian and Hessian using numerical differentiation.\n"
           ":param data: NumDiff action data\n"
           ":param x: time-discrete state vector\n"
           ":param u: time-discrete control input\n")
       .def<void (DifferentialActionModelNumDiff::*)(const boost::shared_ptr<DifferentialActionDataAbstract>&,
-                                                    const Eigen::VectorXd&)>(
-          "calcDiff", &DifferentialActionModelNumDiff::calcDiff_wrap, bp::args("self", "data", "x"))
+                                                    const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &DifferentialActionModelAbstract::calcDiff, bp::args("self", "data", "x"))
       .def("createData", &DifferentialActionModelNumDiff::createData, bp::args("self"),
            "Create the action data.\n\n"
            "Each action model (AM) has its own data that needs to be allocated.\n"

--- a/bindings/python/crocoddyl/core/state-base.cpp
+++ b/bindings/python/crocoddyl/core/state-base.cpp
@@ -14,6 +14,12 @@ namespace python {
 void exposeStateAbstract() {
   bp::register_ptr_to_python<boost::shared_ptr<StateAbstract> >();
 
+  bp::enum_<Jcomponent>("Jcomponent")
+      .value("both", both)
+      .value("first", first)
+      .export_values()
+      .value("second", second);
+
   bp::class_<StateAbstract_wrap, boost::noncopyable>(
       "StateAbstract",
       "Abstract class for the state representation.\n\n"

--- a/bindings/python/crocoddyl/core/state-base.hpp
+++ b/bindings/python/crocoddyl/core/state-base.hpp
@@ -176,8 +176,8 @@ class StateAbstract_wrap : public StateAbstract, public bp::wrapper<StateAbstrac
   }
 };
 
-BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Jdiffs, StateAbstract::Jdiff_wrap, 2, 3)
-BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Jintegrates, StateAbstract::Jintegrate_wrap, 2, 3)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Jdiffs, StateAbstract::Jdiff_Js, 2, 3)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Jintegrates, StateAbstract::Jintegrate_Js, 2, 3)
 
 }  // namespace python
 }  // namespace crocoddyl

--- a/bindings/python/crocoddyl/core/states/euclidean.cpp
+++ b/bindings/python/crocoddyl/core/states/euclidean.cpp
@@ -30,14 +30,14 @@ void exposeStateEuclidean() {
       .def("rand", &StateVector::rand, bp::args("self"),
            "Return a random reference state.\n\n"
            ":return random reference state")
-      .def("diff", &StateVector::diff_wrap, bp::args("self", "x0", "x1"),
+      .def("diff", &StateVector::diff_dx, bp::args("self", "x0", "x1"),
            "Operator that differentiates the two state points.\n\n"
            "It returns the value of x1 [-] x0 operation. Due to a state vector lies in\n"
            "the Euclidean space, this operator is defined with arithmetic subtraction.\n"
            ":param x0: current state (dim state.nx()).\n"
            ":param x1: next state (dim state.nx()).\n"
            ":return x1 - x0 value (dim state.nx()).")
-      .def("integrate", &StateVector::integrate_wrap, bp::args("self", "x", "dx"),
+      .def("integrate", &StateVector::integrate_x, bp::args("self", "x", "dx"),
            "Operator that integrates the current state.\n\n"
            "It returns the value of x [+] dx operation. Due to a state vector lies in\n"
            "the Euclidean space, this operator is defined with arithmetic addition.\n"
@@ -46,7 +46,7 @@ void exposeStateEuclidean() {
            ":param x: current state (dim state.nx()).\n"
            ":param dx: displacement of the state (dim state.nx()).\n"
            ":return x + dx value (dim state.nx()).")
-      .def("Jdiff", &StateVector::Jdiff_wrap,
+      .def("Jdiff", &StateVector::Jdiff_Js,
            Jdiffs(bp::args("self", "x0", "x1", "firstsecond"),
                   "Compute the partial derivatives of arithmetic substraction.\n\n"
                   "Both Jacobian matrices are represented throught an identity matrix, with the exception\n"
@@ -58,7 +58,7 @@ void exposeStateEuclidean() {
                   ":param x1: next state (dim state.nx()).\n"
                   ":param firstsecond: desired partial derivative\n"
                   ":return the partial derivative(s) of the diff(x0, x1) function"))
-      .def("Jintegrate", &StateVector::Jintegrate_wrap,
+      .def("Jintegrate", &StateVector::Jintegrate_Js,
            Jintegrates(bp::args("self", "x", "dx", "firstsecond"),
                        "Compute the partial derivatives of arithmetic addition.\n\n"
                        "Both Jacobian matrices are represented throught an identity matrix. By default, this\n"

--- a/bindings/python/crocoddyl/fwd.hpp
+++ b/bindings/python/crocoddyl/fwd.hpp
@@ -5,6 +5,7 @@
 
 #include <eigenpy/eigenpy.hpp>
 #include <boost/python.hpp>
+#include <boost/python/enum.hpp>
 
 namespace crocoddyl {
 namespace python {

--- a/bindings/python/crocoddyl/fwd.hpp
+++ b/bindings/python/crocoddyl/fwd.hpp
@@ -1,7 +1,13 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2018-2020, University of Edinburgh
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
 #ifndef BINDINGS_PYTHON_CROCODDYL_CORE_FWD_HPP_
 #define BINDINGS_PYTHON_CROCODDYL_CORE_FWD_HPP_
-
-#define PYTHON_BINDINGS
 
 #include <eigenpy/eigenpy.hpp>
 #include <boost/python.hpp>

--- a/bindings/python/crocoddyl/multibody/actions/contact-fwddyn.cpp
+++ b/bindings/python/crocoddyl/multibody/actions/contact-fwddyn.cpp
@@ -34,19 +34,24 @@ void exposeDifferentialActionContactFwdDynamics() {
           ":param costs: stack of cost functions\n"
           ":param inv_damping: Damping factor for cholesky decomposition of JMinvJt (default 0.)\n"
           ":param enable_force: Enable the computation of force Jacobians (default False)"))
-      .def("calc", &DifferentialActionModelContactFwdDynamics::calc_wrap,
-           DiffActionModel_calc_wraps(
-               bp::args("self", "data", "x", "u"),
-               "Compute the next state and cost value.\n\n"
-               "It describes the time-continuous evolution of the multibody system with contact. The\n"
-               "contacts are modelled as holonomic constraints.\n"
-               "Additionally it computes the cost value associated to this state and control pair.\n"
-               ":param data: contact forward-dynamics action data\n"
-               ":param x: time-continuous state vector\n"
-               ":param u: time-continuous control input"))
       .def<void (DifferentialActionModelContactFwdDynamics::*)(
-          const boost::shared_ptr<DifferentialActionDataAbstract>&, const Eigen::VectorXd&, const Eigen::VectorXd&)>(
-          "calcDiff", &DifferentialActionModelContactFwdDynamics::calcDiff_wrap, bp::args("self", "data", "x", "u"),
+          const boost::shared_ptr<DifferentialActionDataAbstract>&, const Eigen::Ref<const Eigen::VectorXd>&,
+          const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &DifferentialActionModelContactFwdDynamics::calc, bp::args("self", "data", "x", "u"),
+          "Compute the next state and cost value.\n\n"
+          "It describes the time-continuous evolution of the multibody system with contact. The\n"
+          "contacts are modelled as holonomic constraints.\n"
+          "Additionally it computes the cost value associated to this state and control pair.\n"
+          ":param data: contact forward-dynamics action data\n"
+          ":param x: time-continuous state vector\n"
+          ":param u: time-continuous control input")
+      .def<void (DifferentialActionModelContactFwdDynamics::*)(
+          const boost::shared_ptr<DifferentialActionDataAbstract>&, const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &DifferentialActionModelAbstract::calc, bp::args("self", "data", "x"))
+      .def<void (DifferentialActionModelContactFwdDynamics::*)(
+          const boost::shared_ptr<DifferentialActionDataAbstract>&, const Eigen::Ref<const Eigen::VectorXd>&,
+          const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &DifferentialActionModelContactFwdDynamics::calcDiff, bp::args("self", "data", "x", "u"),
           "Compute the derivatives of the differential multibody system and its cost\n"
           "functions.\n\n"
           "It computes the partial derivatives of the differential multibody system and the\n"
@@ -57,11 +62,8 @@ void exposeDifferentialActionContactFwdDynamics() {
           ":param x: time-continuous state vector\n"
           ":param u: time-continuous control input\n")
       .def<void (DifferentialActionModelContactFwdDynamics::*)(
-          const boost::shared_ptr<DifferentialActionDataAbstract>&, const Eigen::VectorXd&, const Eigen::VectorXd&)>(
-          "calcDiff", &DifferentialActionModelContactFwdDynamics::calcDiff_wrap, bp::args("self", "data", "x", "u"))
-      .def<void (DifferentialActionModelContactFwdDynamics::*)(
-          const boost::shared_ptr<DifferentialActionDataAbstract>&, const Eigen::VectorXd&)>(
-          "calcDiff", &DifferentialActionModelContactFwdDynamics::calcDiff_wrap, bp::args("self", "data", "x"))
+          const boost::shared_ptr<DifferentialActionDataAbstract>&, const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &DifferentialActionModelAbstract::calcDiff, bp::args("self", "data", "x"))
       .def("createData", &DifferentialActionModelContactFwdDynamics::createData, bp::args("self"),
            "Create the contact forward dynamics differential action data.")
       .add_property("pinocchio",

--- a/bindings/python/crocoddyl/multibody/actions/free-fwddyn.cpp
+++ b/bindings/python/crocoddyl/multibody/actions/free-fwddyn.cpp
@@ -27,18 +27,23 @@ void exposeDifferentialActionFreeFwdDynamics() {
                                                  ":param state: multibody state\n"
                                                  ":param actuation: abstract actuation model\n"
                                                  ":param costs: stack of cost functions"))
-      .def("calc", &DifferentialActionModelFreeFwdDynamics::calc_wrap,
-           DiffActionModel_calc_wraps(
-               bp::args("self", "data", "x", "u"),
-               "Compute the next state and cost value.\n\n"
-               "It describes the time-continuous evolution of the multibody system without any contact.\n"
-               "Additionally it computes the cost value associated to this state and control pair.\n"
-               ":param data: free forward-dynamics action data\n"
-               ":param x: time-continuous state vector\n"
-               ":param u: time-continuous control input"))
       .def<void (DifferentialActionModelFreeFwdDynamics::*)(const boost::shared_ptr<DifferentialActionDataAbstract>&,
-                                                            const Eigen::VectorXd&, const Eigen::VectorXd&)>(
-          "calcDiff", &DifferentialActionModelFreeFwdDynamics::calcDiff_wrap, bp::args("self", "data", "x", "u"),
+                                                            const Eigen::Ref<const Eigen::VectorXd>&,
+                                                            const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &DifferentialActionModelFreeFwdDynamics::calc, bp::args("self", "data", "x", "u"),
+          "Compute the next state and cost value.\n\n"
+          "It describes the time-continuous evolution of the multibody system without any contact.\n"
+          "Additionally it computes the cost value associated to this state and control pair.\n"
+          ":param data: free forward-dynamics action data\n"
+          ":param x: time-continuous state vector\n"
+          ":param u: time-continuous control input")
+      .def<void (DifferentialActionModelFreeFwdDynamics::*)(const boost::shared_ptr<DifferentialActionDataAbstract>&,
+                                                            const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &DifferentialActionModelAbstract::calc, bp::args("self", "data", "x"))
+      .def<void (DifferentialActionModelFreeFwdDynamics::*)(const boost::shared_ptr<DifferentialActionDataAbstract>&,
+                                                            const Eigen::Ref<const Eigen::VectorXd>&,
+                                                            const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &DifferentialActionModelFreeFwdDynamics::calcDiff, bp::args("self", "data", "x", "u"),
           "Compute the derivatives of the differential multibody system (free of contact) and\n"
           "its cost functions.\n\n"
           "It computes the partial derivatives of the differential multibody system and the\n"
@@ -49,8 +54,8 @@ void exposeDifferentialActionFreeFwdDynamics() {
           ":param x: time-continuous state vector\n"
           ":param u: time-continuous control input\n")
       .def<void (DifferentialActionModelFreeFwdDynamics::*)(const boost::shared_ptr<DifferentialActionDataAbstract>&,
-                                                            const Eigen::VectorXd&)>(
-          "calcDiff", &DifferentialActionModelFreeFwdDynamics::calcDiff_wrap, bp::args("self", "data", "x"))
+                                                            const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &DifferentialActionModelAbstract::calcDiff, bp::args("self", "data", "x"))
       .def("createData", &DifferentialActionModelFreeFwdDynamics::createData, bp::args("self"),
            "Create the free forward dynamics differential action data.")
       .add_property(

--- a/bindings/python/crocoddyl/multibody/actions/impulse-fwddyn.cpp
+++ b/bindings/python/crocoddyl/multibody/actions/impulse-fwddyn.cpp
@@ -35,19 +35,24 @@ void exposeActionImpulseFwdDynamics() {
           ":param inv_damping: Damping factor for cholesky decomposition of JMinvJt (default 0.)\n"
           ":param enable_force: Enable the computation of force Jacobians (default False)")
           [bp::with_custodian_and_ward<1, 3>()])
-      .def("calc", &ActionModelImpulseFwdDynamics::calc_wrap,
-           ActionModel_calc_wraps(
-               bp::args("self", "data", "x", "u"),
-               "Compute the next state and cost value.\n\n"
-               "It describes the time-continuous evolution of the multibody system with impulse. The\n"
-               "impulses are modelled as holonomic constraints.\n"
-               "Additionally it computes the cost value associated to this state and control pair.\n"
-               ":param data: impulse forward-dynamics action data\n"
-               ":param x: time-continuous state vector\n"
-               ":param u: time-continuous control input"))
       .def<void (ActionModelImpulseFwdDynamics::*)(const boost::shared_ptr<ActionDataAbstract>&,
-                                                   const Eigen::VectorXd&, const Eigen::VectorXd&)>(
-          "calcDiff", &ActionModelImpulseFwdDynamics::calcDiff_wrap, bp::args("self", "data", "x", "u"),
+                                                   const Eigen::Ref<const Eigen::VectorXd>&,
+                                                   const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &ActionModelImpulseFwdDynamics::calc, bp::args("self", "data", "x", "u"),
+          "Compute the next state and cost value.\n\n"
+          "It describes the time-continuous evolution of the multibody system with impulse. The\n"
+          "impulses are modelled as holonomic constraints.\n"
+          "Additionally it computes the cost value associated to this state and control pair.\n"
+          ":param data: impulse forward-dynamics action data\n"
+          ":param x: time-continuous state vector\n"
+          ":param u: time-continuous control input")
+      .def<void (ActionModelImpulseFwdDynamics::*)(const boost::shared_ptr<ActionDataAbstract>&,
+                                                   const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &ActionModelAbstract::calc, bp::args("self", "data", "x"))
+      .def<void (ActionModelImpulseFwdDynamics::*)(const boost::shared_ptr<ActionDataAbstract>&,
+                                                   const Eigen::Ref<const Eigen::VectorXd>&,
+                                                   const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &ActionModelImpulseFwdDynamics::calcDiff, bp::args("self", "data", "x", "u"),
           "Compute the derivatives of the differential multibody system and its cost\n"
           "functions.\n\n"
           "It computes the partial derivatives of the differential multibody system and the\n"
@@ -59,8 +64,8 @@ void exposeActionImpulseFwdDynamics() {
           ":param u: time-continuous control input\n"
           "")
       .def<void (ActionModelImpulseFwdDynamics::*)(const boost::shared_ptr<ActionDataAbstract>&,
-                                                   const Eigen::VectorXd&)>(
-          "calcDiff", &ActionModelImpulseFwdDynamics::calcDiff_wrap, bp::args("self", "data", "x"))
+                                                   const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &ActionModelAbstract::calcDiff, bp::args("self", "data", "x"))
       .def("createData", &ActionModelImpulseFwdDynamics::createData, bp::args("self"),
            "Create the impulse forward dynamics differential action data.")
       .add_property(

--- a/bindings/python/crocoddyl/multibody/actuations/floating-base.cpp
+++ b/bindings/python/crocoddyl/multibody/actuations/floating-base.cpp
@@ -20,13 +20,13 @@ void exposeActuationFloatingBase() {
       bp::init<boost::shared_ptr<StateMultibody> >(bp::args("self", "state"),
                                                    "Initialize the floating-base actuation model.\n\n"
                                                    ":param state: state of multibody system"))
-      .def("calc", &ActuationModelFloatingBase::calc_wrap, bp::args("self", "data", "x", "u"),
+      .def("calc", &ActuationModelFloatingBase::calc, bp::args("self", "data", "x", "u"),
            "Compute the actuation signal from the control input u.\n\n"
            "It describes the time-continuos evolution of the floating-base actuation model.\n"
            ":param data: floating-base actuation data\n"
            ":param x: state vector\n"
            ":param u: control input")
-      .def("calcDiff", &ActuationModelFloatingBase::calcDiff_wrap, bp::args("self", "data", "x", "u"),
+      .def("calcDiff", &ActuationModelFloatingBase::calcDiff, bp::args("self", "data", "x", "u"),
            "Compute the derivatives of the actuation model.\n\n"
            "It computes the partial derivatives of the floating-base actuation. It assumes that you\n"
            "create the data using this class. The reason is that the derivatives are constant and\n"

--- a/bindings/python/crocoddyl/multibody/actuations/full.cpp
+++ b/bindings/python/crocoddyl/multibody/actuations/full.cpp
@@ -18,12 +18,12 @@ void exposeActuationFull() {
       bp::init<boost::shared_ptr<StateMultibody> >(bp::args("self", "state"),
                                                    "Initialize the full actuation model.\n\n"
                                                    ":param state: state of multibody system"))
-      .def("calc", &ActuationModelFull::calc_wrap, bp::args("self", "data", "x", "u"),
+      .def("calc", &ActuationModelFull::calc, bp::args("self", "data", "x", "u"),
            "Compute the actuation signal from the control input u.\n\n"
            ":param data: full actuation data\n"
            ":param x: state vector\n"
            ":param u: control input")
-      .def("calcDiff", &ActuationModelFull::calcDiff_wrap, bp::args("self", "data", "x", "u"),
+      .def("calcDiff", &ActuationModelFull::calcDiff, bp::args("self", "data", "x", "u"),
            "Compute the derivatives of the actuation model.\n\n"
            "It computes the partial derivatives of the full actuation. It assumes that you\n"
            "create the data using this class. The reason is that the derivatives are constant and\n"

--- a/bindings/python/crocoddyl/multibody/contacts/contact-3d.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/contact-3d.cpp
@@ -32,13 +32,13 @@ void exposeContact3D() {
           ":param state: state of the multibody system\n"
           ":param Mref: reference frame translation\n"
           ":param gains: gains of the contact model (default np.matrix([ [0.],[0.] ]))"))
-      .def("calc", &ContactModel3D::calc_wrap, bp::args("self", "data", "x"),
+      .def("calc", &ContactModel3D::calc, bp::args("self", "data", "x"),
            "Compute the 3D contact Jacobian and drift.\n\n"
            "The rigid contact model throught acceleration-base holonomic constraint\n"
            "of the contact frame placement.\n"
            ":param data: contact data\n"
            ":param x: state vector")
-      .def("calcDiff", &ContactModel3D::calcDiff_wrap, bp::args("self", "data", "x"),
+      .def("calcDiff", &ContactModel3D::calcDiff, bp::args("self", "data", "x"),
            "Compute the derivatives of the 3D contact holonomic constraint.\n\n"
            "The rigid contact model throught acceleration-base holonomic constraint\n"
            "of the contact frame placement.\n"

--- a/bindings/python/crocoddyl/multibody/contacts/contact-6d.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/contact-6d.cpp
@@ -32,13 +32,13 @@ void exposeContact6D() {
           ":param state: state of the multibody system\n"
           ":param Mref: reference frame placement\n"
           ":param gains = gains of the contact model"))
-      .def("calc", &ContactModel6D::calc_wrap, bp::args("self", "data", "x"),
+      .def("calc", &ContactModel6D::calc, bp::args("self", "data", "x"),
            "Compute the 6D contact Jacobian and drift.\n\n"
            "The rigid contact model throught acceleration-base holonomic constraint\n"
            "of the contact frame placement.\n"
            ":param data: contact data\n"
            ":param x: state vector")
-      .def("calcDiff", &ContactModel6D::calcDiff_wrap, bp::args("self", "data", "x"),
+      .def("calcDiff", &ContactModel6D::calcDiff, bp::args("self", "data", "x"),
            "Compute the derivatives of the 6D contact holonomic constraint.\n\n"
            "The rigid contact model throught acceleration-base holonomic constraint\n"
            "of the contact frame placement.\n"

--- a/bindings/python/crocoddyl/multibody/contacts/multiple-contacts.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/multiple-contacts.cpp
@@ -68,13 +68,13 @@ void exposeContactMultiple() {
            "Change the contact status.\n\n"
            ":param name: contact name\n"
            ":param active: contact status (true for active and false for inactive)")
-      .def("calc", &ContactModelMultiple::calc_wrap, bp::args("self", "data", "x"),
+      .def("calc", &ContactModelMultiple::calc, bp::args("self", "data", "x"),
            "Compute the total contact Jacobian and drift.\n\n"
            "The rigid contact model throught acceleration-base holonomic constraint\n"
            "of the contact frame placement.\n"
            ":param data: contact data\n"
            ":param x: state vector")
-      .def("calcDiff", &ContactModelMultiple::calcDiff_wrap, bp::args("self", "data", "x"),
+      .def("calcDiff", &ContactModelMultiple::calcDiff, bp::args("self", "data", "x"),
            "Compute the derivatives of the total contact holonomic constraint.\n\n"
            "The rigid contact model throught acceleration-base holonomic constraint\n"
            "of the contact frame placement.\n"

--- a/bindings/python/crocoddyl/multibody/cost-base.cpp
+++ b/bindings/python/crocoddyl/multibody/cost-base.cpp
@@ -49,11 +49,17 @@ void exposeCostAbstract() {
            ":param data: cost data\n"
            ":param x: state vector\n"
            ":param u: control input")
+      .def<void (CostModelAbstract::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                       const Eigen::Ref<const Eigen::VectorXd>&)>("calc", &CostModelAbstract::calc,
+                                                                                  bp::args("self", "data", "x"))
       .def("calcDiff", pure_virtual(&CostModelAbstract_wrap::calcDiff), bp::args("self", "data", "x", "u"),
            "Compute the derivatives of the cost function and its residuals.\n\n"
            ":param data: cost data\n"
            ":param x: state vector\n"
            ":param u: control input\n")
+      .def<void (CostModelAbstract::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                       const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &CostModelAbstract::calcDiff, bp::args("self", "data", "x"))
       .def("createData", &CostModelAbstract_wrap::createData, bp::with_custodian_and_ward_postcall<0, 2>(),
            bp::args("self", "data"),
            "Create the cost data.\n\n"

--- a/bindings/python/crocoddyl/multibody/cost-base.hpp
+++ b/bindings/python/crocoddyl/multibody/cost-base.hpp
@@ -46,8 +46,6 @@ class CostModelAbstract_wrap : public CostModelAbstract, public bp::wrapper<Cost
   }
 };
 
-BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(CostModel_calc_wraps, CostModelAbstract::calc_wrap, 2, 3)
-
 }  // namespace python
 }  // namespace crocoddyl
 

--- a/bindings/python/crocoddyl/multibody/costs/centroidal-momentum.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/centroidal-momentum.cpp
@@ -46,23 +46,28 @@ void exposeCostCentroidalMomentum() {
           "crocoddyl.ActivationModelQuad(3), and nu is equals to model.nv.\n"
           ":param state: state of the multibody system\n"
           ":param ref: reference centroidal momentum"))
-      .def("calc", &CostModelCentroidalMomentum::calc_wrap,
-           CostModel_calc_wraps(bp::args("self", "data", "x", "u"),
-                                "Compute the centroidal momentum cost.\n\n"
-                                ":param data: cost data\n"
-                                ":param x: time-discrete state vector\n"
-                                ":param u: time-discrete control input"))
-      .def<void (CostModelCentroidalMomentum::*)(const boost::shared_ptr<CostDataAbstract>&, const Eigen::VectorXd&,
-                                                 const Eigen::VectorXd&)>(
-          "calcDiff", &CostModelCentroidalMomentum::calcDiff_wrap, bp::args("self", "data", "x", "u"),
+      .def<void (CostModelCentroidalMomentum::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                                 const Eigen::Ref<const Eigen::VectorXd>&,
+                                                 const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &CostModelCentroidalMomentum::calc, bp::args("self", "data", "x", "u"),
+          "Compute the centroidal momentum cost.\n\n"
+          ":param data: cost data\n"
+          ":param x: time-discrete state vector\n"
+          ":param u: time-discrete control input")
+      .def<void (CostModelCentroidalMomentum::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                                 const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &CostModelAbstract::calc, bp::args("self", "data", "x"))
+      .def<void (CostModelCentroidalMomentum::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                                 const Eigen::Ref<const Eigen::VectorXd>&,
+                                                 const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &CostModelCentroidalMomentum::calcDiff, bp::args("self", "data", "x", "u"),
           "Compute the derivatives of the centroidal momentum cost.\n\n"
           ":param data: action data\n"
           ":param x: time-discrete state vector\n"
           ":param u: time-discrete control input\n")
-      .def<void (CostModelCentroidalMomentum::*)(const boost::shared_ptr<CostDataAbstract>&, const Eigen::VectorXd&)>(
-          "calcDiff", &CostModelCentroidalMomentum::calcDiff_wrap, bp::args("self", "data", "x"))
-      .def<void (CostModelCentroidalMomentum::*)(const boost::shared_ptr<CostDataAbstract>&, const Eigen::VectorXd&)>(
-          "calcDiff", &CostModelCentroidalMomentum::calcDiff_wrap, bp::args("self", "data", "x"))
+      .def<void (CostModelCentroidalMomentum::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                                 const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &CostModelAbstract::calcDiff, bp::args("self", "data", "x"))
       .def("createData", &CostModelCentroidalMomentum::createData, bp::with_custodian_and_ward_postcall<0, 2>(),
            bp::args("self", "data"),
            "Create the centroidal momentum cost data.\n\n"

--- a/bindings/python/crocoddyl/multibody/costs/com-position.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/com-position.cpp
@@ -45,22 +45,28 @@ void exposeCostCoMPosition() {
           "crocoddyl.ActivationModelQuad(3), and nu is equals to model.nv.\n"
           ":param state: state of the multibody system\n"
           ":param cref: reference CoM position"))
-      .def("calc", &CostModelCoMPosition::calc_wrap,
-           CostModel_calc_wraps(bp::args("self", "data", "x", "u"),
-                                "Compute the CoM position cost.\n\n"
-                                ":param data: cost data\n"
-                                ":param x: time-discrete state vector\n"
-                                ":param u: time-discrete control input"))
-      .def<void (CostModelCoMPosition::*)(const boost::shared_ptr<CostDataAbstract>&, const Eigen::VectorXd&,
-                                          const Eigen::VectorXd&)>(
-          "calcDiff", &CostModelCoMPosition::calcDiff_wrap, bp::args("self", "data", "x", "u"),
+      .def<void (CostModelCoMPosition::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                          const Eigen::Ref<const Eigen::VectorXd>&,
+                                          const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &CostModelCoMPosition::calc, bp::args("self", "data", "x", "u"),
+          "Compute the CoM position cost.\n\n"
+          ":param data: cost data\n"
+          ":param x: time-discrete state vector\n"
+          ":param u: time-discrete control input")
+      .def<void (CostModelCoMPosition::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                          const Eigen::Ref<const Eigen::VectorXd>&)>("calc", &CostModelAbstract::calc,
+                                                                                     bp::args("self", "data", "x"))
+      .def<void (CostModelCoMPosition::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                          const Eigen::Ref<const Eigen::VectorXd>&,
+                                          const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &CostModelCoMPosition::calcDiff, bp::args("self", "data", "x", "u"),
           "Compute the derivatives of the CoM position cost.\n\n"
           ":param data: action data\n"
           ":param x: time-discrete state vector\n"
           ":param u: time-discrete control input\n")
-
-      .def<void (CostModelCoMPosition::*)(const boost::shared_ptr<CostDataAbstract>&, const Eigen::VectorXd&)>(
-          "calcDiff", &CostModelCoMPosition::calcDiff_wrap, bp::args("self", "data", "x"))
+      .def<void (CostModelCoMPosition::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                          const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &CostModelAbstract::calcDiff, bp::args("self", "data", "x"))
       .def("createData", &CostModelCoMPosition::createData, bp::with_custodian_and_ward_postcall<0, 2>(),
            bp::args("self", "data"),
            "Create the CoM position cost data.\n\n"

--- a/bindings/python/crocoddyl/multibody/costs/contact-force.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/contact-force.cpp
@@ -45,21 +45,28 @@ void exposeCostContactForce() {
           "crocoddyl.ActivationModelQuad(6), and nu is equals to model.nv.\n"
           ":param state: state of the multibody system\n"
           ":param fref: reference force\n"))
-      .def("calc", &CostModelContactForce::calc_wrap,
-           CostModel_calc_wraps(bp::args("self", "data", "x", "u"),
-                                "Compute the contact force cost.\n\n"
-                                ":param data: cost data\n"
-                                ":param x: time-discrete state vector\n"
-                                ":param u: time-discrete control input"))
-      .def<void (CostModelContactForce::*)(const boost::shared_ptr<CostDataAbstract>&, const Eigen::VectorXd&,
-                                           const Eigen::VectorXd&)>(
-          "calcDiff", &CostModelContactForce::calcDiff_wrap, bp::args("self", "data", "x", "u"),
+      .def<void (CostModelContactForce::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                           const Eigen::Ref<const Eigen::VectorXd>&,
+                                           const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &CostModelContactForce::calc, bp::args("self", "data", "x", "u"),
+          "Compute the contact force cost.\n\n"
+          ":param data: cost data\n"
+          ":param x: time-discrete state vector\n"
+          ":param u: time-discrete control input")
+      .def<void (CostModelContactForce::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                           const Eigen::Ref<const Eigen::VectorXd>&)>("calc", &CostModelAbstract::calc,
+                                                                                      bp::args("self", "data", "x"))
+      .def<void (CostModelContactForce::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                           const Eigen::Ref<const Eigen::VectorXd>&,
+                                           const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &CostModelContactForce::calcDiff, bp::args("self", "data", "x", "u"),
           "Compute the derivatives of the contact force cost.\n\n"
           ":param data: action data\n"
           ":param x: time-discrete state vector\n"
           ":param u: time-discrete control input\n")
-      .def<void (CostModelContactForce::*)(const boost::shared_ptr<CostDataAbstract>&, const Eigen::VectorXd&)>(
-          "calcDiff", &CostModelContactForce::calcDiff_wrap, bp::args("self", "data", "x"))
+      .def<void (CostModelContactForce::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                           const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &CostModelAbstract::calcDiff, bp::args("self", "data", "x"))
       .def("createData", &CostModelContactForce::createData, bp::with_custodian_and_ward_postcall<0, 2>(),
            bp::args("self", "data"),
            "Create the contact force cost data.\n\n"

--- a/bindings/python/crocoddyl/multibody/costs/contact-friction-cone.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/contact-friction-cone.cpp
@@ -45,21 +45,28 @@ void exposeCostContactFrictionCone() {
           "crocoddyl.ActivationModelQuad(6), and nu is equals to model.nv.\n"
           ":param state: state of the multibody system\n"
           ":param fref: frame friction cone"))
-      .def("calc", &CostModelContactFrictionCone::calc_wrap,
-           CostModel_calc_wraps(bp::args("self", "data", "x", "u"),
-                                "Compute the contact force cost.\n\n"
-                                ":param data: cost data\n"
-                                ":param x: time-discrete state vector\n"
-                                ":param u: time-discrete control input"))
-      .def<void (CostModelContactFrictionCone::*)(const boost::shared_ptr<CostDataAbstract>&, const Eigen::VectorXd&,
-                                                  const Eigen::VectorXd&)>(
-          "calcDiff", &CostModelContactFrictionCone::calcDiff_wrap, bp::args("self", "data", "x", "u"),
+      .def<void (CostModelContactFrictionCone::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                                  const Eigen::Ref<const Eigen::VectorXd>&,
+                                                  const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &CostModelContactFrictionCone::calc, bp::args("self", "data", "x", "u"),
+          "Compute the contact force cost.\n\n"
+          ":param data: cost data\n"
+          ":param x: time-discrete state vector\n"
+          ":param u: time-discrete control input")
+      .def<void (CostModelContactFrictionCone::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                                  const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &CostModelAbstract::calc, bp::args("self", "data", "x"))
+      .def<void (CostModelContactFrictionCone::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                                  const Eigen::Ref<const Eigen::VectorXd>&,
+                                                  const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &CostModelContactFrictionCone::calcDiff, bp::args("self", "data", "x", "u"),
           "Compute the derivatives of the contact force cost.\n\n"
           ":param data: action data\n"
           ":param x: time-discrete state vector\n"
           ":param u: time-discrete control input\n")
-      .def<void (CostModelContactFrictionCone::*)(const boost::shared_ptr<CostDataAbstract>&, const Eigen::VectorXd&)>(
-          "calcDiff", &CostModelContactFrictionCone::calcDiff_wrap, bp::args("self", "data", "x"))
+      .def<void (CostModelContactFrictionCone::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                                  const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &CostModelAbstract::calcDiff, bp::args("self", "data", "x"))
       .def("createData", &CostModelContactFrictionCone::createData, bp::with_custodian_and_ward_postcall<0, 2>(),
            bp::args("self", "data"),
            "Create the contact force cost data.\n\n"

--- a/bindings/python/crocoddyl/multibody/costs/control.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/control.cpp
@@ -54,22 +54,28 @@ void exposeCostControl() {
           "model is quadratic, i.e. crocoddyl.ActivationModelQuad(nu)\n"
           ":param state: state of the multibody system\n"
           ":param nu: dimension of control vector"))
-      .def("calc", &CostModelControl::calc_wrap,
-           CostModel_calc_wraps(bp::args("self", "data", "x", "u"),
-                                "Compute the control cost.\n\n"
-                                ":param data: cost data\n"
-                                ":param x: time-discrete state vector\n"
-                                ":param u: time-discrete control input"))
-      .def<void (CostModelControl::*)(const boost::shared_ptr<CostDataAbstract>&, const Eigen::VectorXd&,
-                                      const Eigen::VectorXd&)>("calcDiff", &CostModelControl::calcDiff_wrap,
-                                                               bp::args("self", "data", "x", "u"),
-                                                               "Compute the derivatives of the control cost.\n\n"
-                                                               ":param data: action data\n"
-                                                               ":param x: time-discrete state vector\n"
-                                                               ":param u: time-discrete control input\n")
-
-      .def<void (CostModelControl::*)(const boost::shared_ptr<CostDataAbstract>&, const Eigen::VectorXd&)>(
-          "calcDiff", &CostModelControl::calcDiff_wrap, bp::args("self", "data", "x"))
+      .def<void (CostModelControl::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                      const Eigen::Ref<const Eigen::VectorXd>&,
+                                      const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &CostModelControl::calc, bp::args("self", "data", "x", "u"),
+          "Compute the control cost.\n\n"
+          ":param data: cost data\n"
+          ":param x: time-discrete state vector\n"
+          ":param u: time-discrete control input")
+      .def<void (CostModelControl::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                      const Eigen::Ref<const Eigen::VectorXd>&)>("calc", &CostModelAbstract::calc,
+                                                                                 bp::args("self", "data", "x"))
+      .def<void (CostModelControl::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                      const Eigen::Ref<const Eigen::VectorXd>&,
+                                      const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &CostModelControl::calcDiff, bp::args("self", "data", "x", "u"),
+          "Compute the derivatives of the control cost.\n\n"
+          ":param data: action data\n"
+          ":param x: time-discrete state vector\n"
+          ":param u: time-discrete control input\n")
+      .def<void (CostModelControl::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                      const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &CostModelAbstract::calcDiff, bp::args("self", "data", "x"))
       .add_property("reference", bp::make_function(&CostModelControl::get_uref, bp::return_internal_reference<>()),
                     &CostModelControl::set_reference<Eigen::VectorXd>, "reference control vector")
       .add_property("uref", bp::make_function(&CostModelControl::get_uref, bp::return_internal_reference<>()),

--- a/bindings/python/crocoddyl/multibody/costs/cost-sum.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/cost-sum.cpp
@@ -21,7 +21,6 @@ namespace crocoddyl {
 namespace python {
 
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(CostModelSum_addContact_wrap, CostModelSum::addCost, 3, 4)
-BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(CostModelSum_calc_wraps, CostModelSum::calc_wrap, 2, 3)
 
 void exposeCostSum() {
   // Register custom converters between std::map and Python dict
@@ -85,21 +84,24 @@ void exposeCostSum() {
            "Change the cost status.\n\n"
            ":param name: cost name\n"
            ":param active: cost status (true for active and false for inactive)")
-      .def("calc", &CostModelSum::calc_wrap,
-           CostModelSum_calc_wraps(bp::args("self", "data", "x", "u"),
-                                   "Compute the total cost.\n\n"
-                                   ":param data: cost-sum data\n"
-                                   ":param x: time-discrete state vector\n"
-                                   ":param u: time-discrete control input"))
-      .def<void (CostModelSum::*)(const boost::shared_ptr<CostDataSum>&, const Eigen::VectorXd&,
-                                  const Eigen::VectorXd&)>("calcDiff", &CostModelSum::calcDiff_wrap,
-                                                           bp::args("self", "data", "x", "u"),
-                                                           "Compute the derivatives of the total cost.\n\n"
-                                                           ":param data: action data\n"
-                                                           ":param x: time-discrete state vector\n"
-                                                           ":param u: time-discrete control input\n")
-      .def<void (CostModelSum::*)(const boost::shared_ptr<CostDataSum>&, const Eigen::VectorXd&)>(
-          "calcDiff", &CostModelSum::calcDiff_wrap, bp::args("self", "data", "x"))
+      .def<void (CostModelSum::*)(const boost::shared_ptr<CostDataSum>&, const Eigen::Ref<const Eigen::VectorXd>&,
+                                  const Eigen::Ref<const Eigen::VectorXd>&)>("calc", &CostModelSum::calc,
+                                                                             bp::args("self", "data", "x", "u"),
+                                                                             "Compute the total cost.\n\n"
+                                                                             ":param data: cost-sum data\n"
+                                                                             ":param x: time-discrete state vector\n"
+                                                                             ":param u: time-discrete control input")
+      .def<void (CostModelSum::*)(const boost::shared_ptr<CostDataSum>&, const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &CostModelSum::calc, bp::args("self", "data", "x"))
+      .def<void (CostModelSum::*)(const boost::shared_ptr<CostDataSum>&, const Eigen::Ref<const Eigen::VectorXd>&,
+                                  const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &CostModelSum::calcDiff, bp::args("self", "data", "x", "u"),
+          "Compute the derivatives of the total cost.\n\n"
+          ":param data: action data\n"
+          ":param x: time-discrete state vector\n"
+          ":param u: time-discrete control input\n")
+      .def<void (CostModelSum::*)(const boost::shared_ptr<CostDataSum>&, const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &CostModelSum::calcDiff, bp::args("self", "data", "x"))
       .def("createData", &CostModelSum::createData, bp::with_custodian_and_ward_postcall<0, 2>(),
            bp::args("self", "data"),
            "Create the total cost data.\n\n"

--- a/bindings/python/crocoddyl/multibody/costs/frame-placement.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-placement.cpp
@@ -45,22 +45,28 @@ void exposeCostFramePlacement() {
           "crocoddyl.ActivationModelQuad(6), and nu is equals to model.nv.\n"
           ":param state: state of the multibody system\n"
           ":param Mref: reference frame placement"))
-      .def("calc", &CostModelFramePlacement::calc_wrap,
-           CostModel_calc_wraps(bp::args("self", "data", "x", "u"),
-                                "Compute the frame placement cost.\n\n"
-                                ":param data: cost data\n"
-                                ":param x: time-discrete state vector\n"
-                                ":param u: time-discrete control input"))
-      .def<void (CostModelFramePlacement::*)(const boost::shared_ptr<CostDataAbstract>&, const Eigen::VectorXd&,
-                                             const Eigen::VectorXd&)>(
-          "calcDiff", &CostModelFramePlacement::calcDiff_wrap, bp::args("self", "data", "x", "u"),
+      .def<void (CostModelFramePlacement::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                             const Eigen::Ref<const Eigen::VectorXd>&,
+                                             const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &CostModelFramePlacement::calc, bp::args("self", "data", "x", "u"),
+          "Compute the frame placement cost.\n\n"
+          ":param data: cost data\n"
+          ":param x: time-discrete state vector\n"
+          ":param u: time-discrete control input")
+      .def<void (CostModelFramePlacement::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                             const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &CostModelAbstract::calc, bp::args("self", "data", "x"))
+      .def<void (CostModelFramePlacement::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                             const Eigen::Ref<const Eigen::VectorXd>&,
+                                             const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &CostModelFramePlacement::calcDiff, bp::args("self", "data", "x", "u"),
           "Compute the derivatives of the frame placement cost.\n\n"
           ":param data: action data\n"
           ":param x: time-discrete state vector\n"
           ":param u: time-discrete control input\n")
-      .def<void (CostModelFramePlacement::*)(const boost::shared_ptr<CostDataAbstract>&, const Eigen::VectorXd&)>(
-          "calcDiff", &CostModelFramePlacement::calcDiff_wrap, bp::args("self", "data", "x"))
-
+      .def<void (CostModelFramePlacement::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                             const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &CostModelAbstract::calcDiff, bp::args("self", "data", "x"))
       .def("createData", &CostModelFramePlacement::createData, bp::with_custodian_and_ward_postcall<0, 2>(),
            bp::args("self", "data"),
            "Create the frame placement cost data.\n\n"

--- a/bindings/python/crocoddyl/multibody/costs/frame-rotation.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-rotation.cpp
@@ -45,21 +45,28 @@ void exposeCostFrameRotation() {
           "crocoddyl.ActivationModelQuad(6), and nu is equals to model.nv.\n"
           ":param state: state of the multibody system\n"
           ":param Rref: reference frame rotation"))
-      .def("calc", &CostModelFrameRotation::calc_wrap,
-           CostModel_calc_wraps(bp::args("self", "data", "x", "u"),
-                                "Compute the frame rotation cost.\n\n"
-                                ":param data: cost data\n"
-                                ":param x: time-discrete state vector\n"
-                                ":param u: time-discrete control input"))
-      .def<void (CostModelFrameRotation::*)(const boost::shared_ptr<CostDataAbstract>&, const Eigen::VectorXd&,
-                                            const Eigen::VectorXd&)>(
-          "calcDiff", &CostModelFrameRotation::calcDiff_wrap, bp::args("self", "data", "x", "u"),
+      .def<void (CostModelFrameRotation::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                            const Eigen::Ref<const Eigen::VectorXd>&,
+                                            const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &CostModelFrameRotation::calc, bp::args("self", "data", "x", "u"),
+          "Compute the frame rotation cost.\n\n"
+          ":param data: cost data\n"
+          ":param x: time-discrete state vector\n"
+          ":param u: time-discrete control input")
+      .def<void (CostModelFrameRotation::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                            const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &CostModelAbstract::calc, bp::args("self", "data", "x"))
+      .def<void (CostModelFrameRotation::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                            const Eigen::Ref<const Eigen::VectorXd>&,
+                                            const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &CostModelFrameRotation::calcDiff, bp::args("self", "data", "x", "u"),
           "Compute the derivatives of the frame rotation cost.\n\n"
           ":param data: action data\n"
           ":param x: time-discrete state vector\n"
           ":param u: time-discrete control input\n")
-      .def<void (CostModelFrameRotation::*)(const boost::shared_ptr<CostDataAbstract>&, const Eigen::VectorXd&)>(
-          "calcDiff", &CostModelFrameRotation::calcDiff_wrap, bp::args("self", "data", "x"))
+      .def<void (CostModelFrameRotation::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                            const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &CostModelAbstract::calcDiff, bp::args("self", "data", "x"))
       .def("createData", &CostModelFrameRotation::createData, bp::with_custodian_and_ward_postcall<0, 2>(),
            bp::args("self", "data"),
            "Create the frame rotation cost data.\n\n"

--- a/bindings/python/crocoddyl/multibody/costs/frame-translation.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-translation.cpp
@@ -45,21 +45,28 @@ void exposeCostFrameTranslation() {
           "crocoddyl.ActivationModelQuad(3), and nu is equals to model.nv.\n"
           ":param state: state of the multibody system\n"
           ":param xref: reference frame translation"))
-      .def("calc", &CostModelFrameTranslation::calc_wrap,
-           CostModel_calc_wraps(bp::args("self", "data", "x", "u"),
-                                "Compute the frame translation cost.\n\n"
-                                ":param data: cost data\n"
-                                ":param x: time-discrete state vector\n"
-                                ":param u: time-discrete control input"))
-      .def<void (CostModelFrameTranslation::*)(const boost::shared_ptr<CostDataAbstract>&, const Eigen::VectorXd&,
-                                               const Eigen::VectorXd&)>(
-          "calcDiff", &CostModelFrameTranslation::calcDiff_wrap, bp::args("self", "data", "x", "u"),
+      .def<void (CostModelFrameTranslation::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                               const Eigen::Ref<const Eigen::VectorXd>&,
+                                               const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &CostModelFrameTranslation::calc, bp::args("self", "data", "x", "u"),
+          "Compute the frame translation cost.\n\n"
+          ":param data: cost data\n"
+          ":param x: time-discrete state vector\n"
+          ":param u: time-discrete control input")
+      .def<void (CostModelFrameTranslation::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                               const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &CostModelAbstract::calc, bp::args("self", "data", "x"))
+      .def<void (CostModelFrameTranslation::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                               const Eigen::Ref<const Eigen::VectorXd>&,
+                                               const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &CostModelFrameTranslation::calcDiff, bp::args("self", "data", "x", "u"),
           "Compute the derivatives of the frame translation cost.\n\n"
           ":param data: action data\n"
           ":param x: time-discrete state vector\n"
           ":param u: time-discrete control input\n")
-      .def<void (CostModelFrameTranslation::*)(const boost::shared_ptr<CostDataAbstract>&, const Eigen::VectorXd&)>(
-          "calcDiff", &CostModelFrameTranslation::calcDiff_wrap, bp::args("self", "data", "x"))
+      .def<void (CostModelFrameTranslation::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                               const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &CostModelAbstract::calcDiff, bp::args("self", "data", "x"))
       .def("createData", &CostModelFrameTranslation::createData, bp::with_custodian_and_ward_postcall<0, 2>(),
            bp::args("self", "data"),
            "Create the frame translation cost data.\n\n"

--- a/bindings/python/crocoddyl/multibody/costs/frame-velocity.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-velocity.cpp
@@ -45,21 +45,28 @@ void exposeCostFrameVelocity() {
           "crocoddyl.ActivationModelQuad(6), and nu is equals to model.nv.\n"
           ":param state: state of the multibody system\n"
           ":param vref: reference frame velocity"))
-      .def("calc", &CostModelFrameVelocity::calc_wrap,
-           CostModel_calc_wraps(bp::args("self", "data", "x", "u"),
-                                "Compute the frame velocity cost.\n\n"
-                                ":param data: cost data\n"
-                                ":param x: time-discrete state vector\n"
-                                ":param u: time-discrete control input"))
-      .def<void (CostModelFrameVelocity::*)(const boost::shared_ptr<CostDataAbstract>&, const Eigen::VectorXd&,
-                                            const Eigen::VectorXd&)>(
-          "calcDiff", &CostModelFrameVelocity::calcDiff_wrap, bp::args("self", "data", "x", "u"),
+      .def<void (CostModelFrameVelocity::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                            const Eigen::Ref<const Eigen::VectorXd>&,
+                                            const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &CostModelFrameVelocity::calc, bp::args("self", "data", "x", "u"),
+          "Compute the frame velocity cost.\n\n"
+          ":param data: cost data\n"
+          ":param x: time-discrete state vector\n"
+          ":param u: time-discrete control input")
+      .def<void (CostModelFrameVelocity::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                            const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &CostModelAbstract::calc, bp::args("self", "data", "x"))
+      .def<void (CostModelFrameVelocity::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                            const Eigen::Ref<const Eigen::VectorXd>&,
+                                            const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &CostModelFrameVelocity::calcDiff, bp::args("self", "data", "x", "u"),
           "Compute the derivatives of the frame velocity cost.\n\n"
           ":param data: action data\n"
           ":param x: time-discrete state vector\n"
           ":param u: time-discrete control input\n")
-      .def<void (CostModelFrameVelocity::*)(const boost::shared_ptr<CostDataAbstract>&, const Eigen::VectorXd&)>(
-          "calcDiff", &CostModelFrameVelocity::calcDiff_wrap, bp::args("self", "data", "x"))
+      .def<void (CostModelFrameVelocity::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                            const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &CostModelAbstract::calcDiff, bp::args("self", "data", "x"))
       .def("createData", &CostModelFrameVelocity::createData, bp::with_custodian_and_ward_postcall<0, 2>(),
            bp::args("self", "data"),
            "Create the frame velocity cost data.\n\n"

--- a/bindings/python/crocoddyl/multibody/costs/impulse-com.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/impulse-com.cpp
@@ -30,15 +30,25 @@ void exposeCostImpulseCoM() {
           "For this case the default activation model is quadratic, i.e.\n"
           "crocoddyl.ActivationModelQuad(3), and nu is equals to model.nv.\n"
           ":param state: state of the multibody system"))
-      .def("calc", &CostModelImpulseCoM::calc_wrap, bp::args("self", "data", "x"),
-           "Compute the CoM position cost.\n\n"
-           ":param data: cost data\n"
-           ":param x: time-discrete state vector")
-      .def<void (CostModelImpulseCoM::*)(const boost::shared_ptr<CostDataAbstract>&, const Eigen::VectorXd&)>(
-          "calcDiff", &CostModelImpulseCoM::calcDiff_wrap, bp::args("self", "data", "x"),
+      .def<void (CostModelImpulseCoM::*)(
+          const boost::shared_ptr<CostDataAbstract>&, const Eigen::Ref<const Eigen::VectorXd>&,
+          const Eigen::Ref<const Eigen::VectorXd>&)>("calc", &CostModelImpulseCoM::calc, bp::args("self", "data", "x"),
+                                                     "Compute the CoM position cost.\n\n"
+                                                     ":param data: cost data\n"
+                                                     ":param x: time-discrete state vector")
+      .def<void (CostModelImpulseCoM::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                         const Eigen::Ref<const Eigen::VectorXd>&)>("calc", &CostModelAbstract::calc,
+                                                                                    bp::args("self", "data", "x"))
+      .def<void (CostModelImpulseCoM::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                         const Eigen::Ref<const Eigen::VectorXd>&,
+                                         const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &CostModelImpulseCoM::calcDiff, bp::args("self", "data", "x"),
           "Compute the derivatives of the CoM position cost for impulse dynamics.\n\n"
           ":param data: action data\n"
           ":param x: time-discrete state vector\n")
+      .def<void (CostModelImpulseCoM::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                         const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &CostModelAbstract::calcDiff, bp::args("self", "data", "x"))
       .def("createData", &CostModelImpulseCoM::createData, bp::with_custodian_and_ward_postcall<0, 2>(),
            bp::args("self", "data"),
            "Create the CoM position cost data.\n\n"

--- a/bindings/python/crocoddyl/multibody/costs/state.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/state.cpp
@@ -70,21 +70,27 @@ void exposeCostState() {
           "For this case the default xref is the zeros state, i.e. state.zero(), the default activation\n"
           "model is quadratic, i.e. crocoddyl.ActivationModelQuad(state.ndx), and nu is equals to model.nv.\n"
           ":param state: state of the multibody system"))
-      .def("calc", &CostModelState::calc_wrap,
-           CostModel_calc_wraps(bp::args("self", "data", "x", "u"),
-                                "Compute the state cost.\n\n"
-                                ":param data: cost data\n"
-                                ":param x: time-discrete state vector\n"
-                                ":param u: time-discrete control input"))
-      .def<void (CostModelState::*)(const boost::shared_ptr<CostDataAbstract>&, const Eigen::VectorXd&,
-                                    const Eigen::VectorXd&)>("calcDiff", &CostModelState::calcDiff_wrap,
-                                                             bp::args("self", "data", "x", "u"),
-                                                             "Compute the derivatives of the state cost.\n\n"
-                                                             ":param data: action data\n"
-                                                             ":param x: time-discrete state vector\n"
-                                                             ":param u: time-discrete control input\n")
-      .def<void (CostModelState::*)(const boost::shared_ptr<CostDataAbstract>&, const Eigen::VectorXd&)>(
-          "calcDiff", &CostModelState::calcDiff_wrap, bp::args("self", "data", "x"))
+      .def<void (CostModelState::*)(
+          const boost::shared_ptr<CostDataAbstract>&, const Eigen::Ref<const Eigen::VectorXd>&,
+          const Eigen::Ref<const Eigen::VectorXd>&)>("calc", &CostModelState::calc, bp::args("self", "data", "x", "u"),
+                                                     "Compute the state cost.\n\n"
+                                                     ":param data: cost data\n"
+                                                     ":param x: time-discrete state vector\n"
+                                                     ":param u: time-discrete control input")
+      .def<void (CostModelState::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                    const Eigen::Ref<const Eigen::VectorXd>&)>("calc", &CostModelAbstract::calc,
+                                                                               bp::args("self", "data", "x"))
+      .def<void (CostModelState::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                    const Eigen::Ref<const Eigen::VectorXd>&,
+                                    const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &CostModelState::calcDiff, bp::args("self", "data", "x", "u"),
+          "Compute the derivatives of the state cost.\n\n"
+          ":param data: action data\n"
+          ":param x: time-discrete state vector\n"
+          ":param u: time-discrete control input\n")
+      .def<void (CostModelState::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                    const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &CostModelAbstract::calcDiff, bp::args("self", "data", "x"))
       .def("createData", &CostModelState::createData, bp::with_custodian_and_ward_postcall<0, 2>(),
            bp::args("self", "data"),
            "Create the state cost data.\n\n"

--- a/bindings/python/crocoddyl/multibody/impulses/impulse-3d.cpp
+++ b/bindings/python/crocoddyl/multibody/impulses/impulse-3d.cpp
@@ -23,13 +23,13 @@ void exposeImpulse3D() {
                                                        "Initialize the 3D impulse model.\n\n"
                                                        ":param state: state of the multibody system\n"
                                                        ":param frame: reference frame id"))
-      .def("calc", &ImpulseModel3D::calc_wrap, bp::args("self", "data", "x"),
+      .def("calc", &ImpulseModel3D::calc, bp::args("self", "data", "x"),
            "Compute the 3D impulse Jacobian and drift.\n\n"
            "The rigid impulse model throught acceleration-base holonomic constraint\n"
            "of the impulse frame placement.\n"
            ":param data: impulse data\n"
            ":param x: state vector")
-      .def("calcDiff", &ImpulseModel3D::calcDiff_wrap, bp::args("self", "data", "x"),
+      .def("calcDiff", &ImpulseModel3D::calcDiff, bp::args("self", "data", "x"),
            "Compute the derivatives of the 3D impulse holonomic constraint.\n\n"
            "The rigid impulse model throught acceleration-base holonomic constraint\n"
            "of the impulse frame placement.\n"

--- a/bindings/python/crocoddyl/multibody/impulses/impulse-6d.cpp
+++ b/bindings/python/crocoddyl/multibody/impulses/impulse-6d.cpp
@@ -23,13 +23,13 @@ void exposeImpulse6D() {
                                                        "Initialize the impulse model.\n\n"
                                                        ":param state: state of the multibody system\n"
                                                        ":param frame: reference frame id"))
-      .def("calc", &ImpulseModel6D::calc_wrap, bp::args("self", "data", "x"),
+      .def("calc", &ImpulseModel6D::calc, bp::args("self", "data", "x"),
            "Compute the 6D impulse Jacobian and drift.\n\n"
            "The rigid impulse model throught acceleration-base holonomic constraint\n"
            "of the impulse frame placement.\n"
            ":param data: impulse data\n"
            ":param x: state vector")
-      .def("calcDiff", &ImpulseModel6D::calcDiff_wrap, bp::args("self", "data", "x"),
+      .def("calcDiff", &ImpulseModel6D::calcDiff, bp::args("self", "data", "x"),
            "Compute the derivatives of the 6D impulse holonomic constraint.\n\n"
            "The rigid impulse model throught acceleration-base holonomic constraint\n"
            "of the impulse frame placement.\n"

--- a/bindings/python/crocoddyl/multibody/impulses/multiple-impulses.cpp
+++ b/bindings/python/crocoddyl/multibody/impulses/multiple-impulses.cpp
@@ -67,13 +67,13 @@ void exposeImpulseMultiple() {
            "Change the impulse status.\n\n"
            ":param name: impulse name\n"
            ":param active: impulse status (true for active and false for inactive)")
-      .def("calc", &ImpulseModelMultiple::calc_wrap, bp::args("self", "data", "x"),
+      .def("calc", &ImpulseModelMultiple::calc, bp::args("self", "data", "x"),
            "Compute the total impulse Jacobian and drift.\n\n"
            "The rigid impulse model throught acceleration-base holonomic constraint\n"
            "of the impulse frame placement.\n"
            ":param data: impulse data\n"
            ":param x: state vector")
-      .def("calcDiff", &ImpulseModelMultiple::calcDiff_wrap, bp::args("self", "data", "x"),
+      .def("calcDiff", &ImpulseModelMultiple::calcDiff, bp::args("self", "data", "x"),
            "Compute the derivatives of the total impulse holonomic constraint.\n\n"
            "The rigid impulse model throught acceleration-base holonomic constraint\n"
            "of the impulse frame placement.\n"

--- a/bindings/python/crocoddyl/multibody/states/multibody.cpp
+++ b/bindings/python/crocoddyl/multibody/states/multibody.cpp
@@ -34,14 +34,14 @@ void exposeStateMultibody() {
       .def("rand", &StateMultibody::rand, bp::args("self"),
            "Return a random reference state.\n\n"
            ":return random reference state")
-      .def("diff", &StateMultibody::diff_wrap, bp::args("self", "x0", "x1"),
+      .def("diff", &StateMultibody::diff_dx, bp::args("self", "x0", "x1"),
            "Operator that differentiates the two robot states.\n\n"
            "It returns the value of x1 [-] x0 operation. This operator uses the Lie\n"
            "algebra since the robot's root could lie in the SE(3) manifold.\n"
            ":param x0: current state (dim state.nx()).\n"
            ":param x1: next state (dim state.nx()).\n"
            ":return x1 - x0 value (dim state.nx()).")
-      .def("integrate", &StateMultibody::integrate_wrap, bp::args("self", "x", "dx"),
+      .def("integrate", &StateMultibody::integrate_x, bp::args("self", "x", "dx"),
            "Operator that integrates the current robot state.\n\n"
            "It returns the value of x [+] dx operation. This operator uses the Lie\n"
            "algebra since the robot's root could lie in the SE(3) manifold.\n"
@@ -50,7 +50,7 @@ void exposeStateMultibody() {
            ":param x: current state (dim state.nx()).\n"
            ":param dx: displacement of the state (dim state.ndx()).\n"
            ":return x + dx value (dim state.nx()).")
-      .def("Jdiff", &StateMultibody::Jdiff_wrap,
+      .def("Jdiff", &StateMultibody::Jdiff_Js,
            Jdiffs(bp::args("self", "x0", "x1", "firstsecond"),
                   "Compute the partial derivatives of the diff operator.\n\n"
                   "Both Jacobian matrices are represented throught an identity matrix, with the exception\n"
@@ -62,7 +62,7 @@ void exposeStateMultibody() {
                   ":param x1: next state (dim state.nx()).\n"
                   ":param firstsecond: desired partial derivative\n"
                   ":return the partial derivative(s) of the diff(x0, x1) function"))
-      .def("Jintegrate", &StateMultibody::Jintegrate_wrap,
+      .def("Jintegrate", &StateMultibody::Jintegrate_Js,
            Jintegrates(bp::args("self", "x", "dx", "firstsecond"),
                        "Compute the partial derivatives of arithmetic addition.\n\n"
                        "Both Jacobian matrices are represented throught an identity matrix. with the exception\n"

--- a/include/crocoddyl/core/action-base.hpp
+++ b/include/crocoddyl/core/action-base.hpp
@@ -47,12 +47,7 @@ class ActionModelAbstractTpl {
   void quasiStatic(const boost::shared_ptr<ActionDataAbstract>& data, Eigen::Ref<VectorXs> u,
                    const Eigen::Ref<const VectorXs>& x, const std::size_t& maxiter = 100, const Scalar& tol = 1e-9);
   VectorXs quasiStatic_x(const boost::shared_ptr<ActionDataAbstract>& data, const VectorXs& x,
-                         const std::size_t& maxiter = 100, const Scalar& tol = 1e-9) {
-    VectorXs u(nu_);
-    u.setZero();
-    quasiStatic(data, u, x, maxiter, tol);
-    return u;
-  }
+                         const std::size_t& maxiter = 100, const Scalar& tol = 1e-9);
 
   const std::size_t& get_nu() const;
   const std::size_t& get_nr() const;

--- a/include/crocoddyl/core/action-base.hpp
+++ b/include/crocoddyl/core/action-base.hpp
@@ -46,6 +46,13 @@ class ActionModelAbstractTpl {
 
   void quasiStatic(const boost::shared_ptr<ActionDataAbstract>& data, Eigen::Ref<VectorXs> u,
                    const Eigen::Ref<const VectorXs>& x, const std::size_t& maxiter = 100, const Scalar& tol = 1e-9);
+  VectorXs quasiStatic_x(const boost::shared_ptr<ActionDataAbstract>& data, const VectorXs& x,
+                         const std::size_t& maxiter = 100, const Scalar& tol = 1e-9) {
+    VectorXs u(nu_);
+    u.setZero();
+    quasiStatic(data, u, x, maxiter, tol);
+    return u;
+  }
 
   const std::size_t& get_nu() const;
   const std::size_t& get_nr() const;
@@ -68,35 +75,6 @@ class ActionModelAbstractTpl {
   bool has_control_limits_;                             //!< Indicates whether any of the control limits is finite
 
   void update_has_control_limits();
-
-#ifdef PYTHON_BINDINGS
-
- public:
-  void calc_wrap(const boost::shared_ptr<ActionDataAbstract>& data, const VectorXs& x,
-                 const VectorXs& u = VectorXs()) {
-    if (u.size() == 0) {
-      calc(data, x);
-    } else {
-      calc(data, x, u);
-    }
-  }
-
-  void calcDiff_wrap(const boost::shared_ptr<ActionDataAbstract>& data, const VectorXs& x, const VectorXs& u) {
-    calcDiff(data, x, u);
-  }
-  void calcDiff_wrap(const boost::shared_ptr<ActionDataAbstract>& data, const VectorXs& x) {
-    calcDiff(data, x, unone_);
-  }
-
-  VectorXs quasiStatic_wrap(const boost::shared_ptr<ActionDataAbstract>& data, const VectorXs& x,
-                            const std::size_t& maxiter = 100, const Scalar& tol = 1e-9) {
-    VectorXs u(nu_);
-    u.setZero();
-    quasiStatic(data, u, x, maxiter, tol);
-    return u;
-  }
-
-#endif
 };
 
 template <typename _Scalar>

--- a/include/crocoddyl/core/action-base.hxx
+++ b/include/crocoddyl/core/action-base.hxx
@@ -69,6 +69,16 @@ void ActionModelAbstractTpl<Scalar>::quasiStatic(const boost::shared_ptr<ActionD
 }
 
 template <typename Scalar>
+typename MathBaseTpl<Scalar>::VectorXs ActionModelAbstractTpl<Scalar>::quasiStatic_x(
+    const boost::shared_ptr<ActionDataAbstract>& data, const VectorXs& x, const std::size_t& maxiter,
+    const Scalar& tol) {
+  VectorXs u(nu_);
+  u.setZero();
+  quasiStatic(data, u, x, maxiter, tol);
+  return u;
+}
+
+template <typename Scalar>
 boost::shared_ptr<ActionDataAbstractTpl<Scalar> > ActionModelAbstractTpl<Scalar>::createData() {
   return boost::make_shared<ActionDataAbstractTpl<Scalar> >(this);
 }

--- a/include/crocoddyl/core/activation-base.hpp
+++ b/include/crocoddyl/core/activation-base.hpp
@@ -44,19 +44,6 @@ class ActivationModelAbstractTpl {
 
  protected:
   std::size_t nr_;
-
-#ifdef PYTHON_BINDINGS
-
- public:
-  void calc_wrap(const boost::shared_ptr<ActivationDataAbstractTpl<Scalar> >& data, const VectorXs& r) {
-    calc(data, r);
-  }
-
-  void calcDiff_wrap(const boost::shared_ptr<ActivationDataAbstractTpl<Scalar> >& data, const VectorXs& r) {
-    calcDiff(data, r);
-  }
-
-#endif
 };
 
 template <typename _Scalar>

--- a/include/crocoddyl/core/actuation-base.hpp
+++ b/include/crocoddyl/core/actuation-base.hpp
@@ -55,19 +55,6 @@ class ActuationModelAbstractTpl {
  protected:
   std::size_t nu_;
   boost::shared_ptr<StateAbstract> state_;
-
-#ifdef PYTHON_BINDINGS
-
- public:
-  void calc_wrap(const boost::shared_ptr<ActuationDataAbstract>& data, const VectorXs& x, const VectorXs& u) {
-    calc(data, x, u);
-  }
-
-  void calcDiff_wrap(const boost::shared_ptr<ActuationDataAbstract>& data, const VectorXs& x, const VectorXs& u) {
-    calcDiff(data, x, u);
-  }
-
-#endif
 };
 
 template <typename _Scalar>

--- a/include/crocoddyl/core/actuation/squashing-base.hpp
+++ b/include/crocoddyl/core/actuation/squashing-base.hpp
@@ -56,15 +56,6 @@ class SquashingModelAbstractTpl {
   VectorXs u_lb_;  // Squashing function lower bound
   VectorXs s_ub_;  // Bound for the s variable (to apply using the Quadratic barrier)
   VectorXs s_lb_;  // Bound for the s variable (to apply using the Quadratic barrier)
-
-#ifdef PYTHON_BINDINGS
-
- public:
-  void calc_wrap(const boost::shared_ptr<SquashingDataAbstract>& data, const VectorXs& s) { calc(data, s); }
-
-  void calcDiff_wrap(const boost::shared_ptr<SquashingDataAbstract>& data, const VectorXs& s) { calcDiff(data, s); }
-
-#endif
 };
 
 template <typename _Scalar>

--- a/include/crocoddyl/core/diff-action-base.hpp
+++ b/include/crocoddyl/core/diff-action-base.hpp
@@ -85,28 +85,6 @@ class DifferentialActionModelAbstractTpl {
   bool has_control_limits_;                 //!< Indicates whether any of the control limits is finite
 
   void update_has_control_limits();
-
-#ifdef PYTHON_BINDINGS
-
- public:
-  void calc_wrap(const boost::shared_ptr<DifferentialActionDataAbstract>& data, const VectorXs& x,
-                 const VectorXs& u = VectorXs()) {
-    if (u.size() == 0) {
-      calc(data, x);
-    } else {
-      calc(data, x, u);
-    }
-  }
-
-  void calcDiff_wrap(const boost::shared_ptr<DifferentialActionDataAbstract>& data, const VectorXs& x,
-                     const VectorXs& u) {
-    calcDiff(data, x, u);
-  }
-  void calcDiff_wrap(const boost::shared_ptr<DifferentialActionDataAbstract>& data, const VectorXs& x) {
-    calcDiff(data, x, unone_);
-  }
-
-#endif
 };
 
 template <typename _Scalar>

--- a/include/crocoddyl/core/state-base.hpp
+++ b/include/crocoddyl/core/state-base.hpp
@@ -88,43 +88,47 @@ class StateAbstractTpl {
     integrate(x, dx, xout);
     return xout;
   }
-  std::vector<MatrixXs> Jdiff_wrap(const VectorXs& x0, const VectorXs& x1, std::string firstsecond = "both") {
+  std::vector<MatrixXs> Jdiff_wrap(const VectorXs& x0, const VectorXs& x1, Jcomponent firstsecond = both) {
     MatrixXs Jfirst(ndx_, ndx_), Jsecond(ndx_, ndx_);
     std::vector<MatrixXs> Jacs;
-    if (firstsecond == "both") {
-      Jdiff(x0, x1, Jfirst, Jsecond, both);
-      Jacs.push_back(Jfirst);
-      Jacs.push_back(Jsecond);
-    } else if (firstsecond == "first") {
-      Jdiff(x0, x1, Jfirst, Jsecond, first);
-      Jacs.push_back(Jfirst);
-    } else if (firstsecond == "second") {
-      Jdiff(x0, x1, Jfirst, Jsecond, second);
-      Jacs.push_back(Jsecond);
-    } else {
-      Jdiff(x0, x1, Jfirst, Jsecond, both);
-      Jacs.push_back(Jfirst);
-      Jacs.push_back(Jsecond);
+    Jdiff(x0, x1, Jfirst, Jsecond, firstsecond);
+    switch (firstsecond) {
+      case both:
+        Jacs.push_back(Jfirst);
+        Jacs.push_back(Jsecond);
+        break;
+      case first:
+        Jacs.push_back(Jfirst);
+        break;
+      case second:
+        Jacs.push_back(Jsecond);
+        break;
+      default:
+        Jacs.push_back(Jfirst);
+        Jacs.push_back(Jsecond);
+        break;
     }
     return Jacs;
   }
-  std::vector<MatrixXs> Jintegrate_wrap(const VectorXs& x, const VectorXs& dx, std::string firstsecond = "both") {
+  std::vector<MatrixXs> Jintegrate_wrap(const VectorXs& x, const VectorXs& dx, Jcomponent firstsecond = both) {
     MatrixXs Jfirst(ndx_, ndx_), Jsecond(ndx_, ndx_);
     std::vector<MatrixXs> Jacs;
-    if (firstsecond == "both") {
-      Jintegrate(x, dx, Jfirst, Jsecond, both);
-      Jacs.push_back(Jfirst);
-      Jacs.push_back(Jsecond);
-    } else if (firstsecond == "first") {
-      Jintegrate(x, dx, Jfirst, Jsecond, first);
-      Jacs.push_back(Jfirst);
-    } else if (firstsecond == "second") {
-      Jintegrate(x, dx, Jfirst, Jsecond, second);
-      Jacs.push_back(Jsecond);
-    } else {
-      Jintegrate(x, dx, Jfirst, Jsecond, both);
-      Jacs.push_back(Jfirst);
-      Jacs.push_back(Jsecond);
+    Jintegrate(x, dx, Jfirst, Jsecond, firstsecond);
+    switch (firstsecond) {
+      case both:
+        Jacs.push_back(Jfirst);
+        Jacs.push_back(Jsecond);
+        break;
+      case first:
+        Jacs.push_back(Jfirst);
+        break;
+      case second:
+        Jacs.push_back(Jsecond);
+        break;
+      default:
+        Jacs.push_back(Jfirst);
+        Jacs.push_back(Jsecond);
+        break;
     }
     return Jacs;
   }

--- a/include/crocoddyl/core/state-base.hpp
+++ b/include/crocoddyl/core/state-base.hpp
@@ -51,6 +51,12 @@ class StateAbstractTpl {
   virtual void Jintegrate(const Eigen::Ref<const VectorXs>& x, const Eigen::Ref<const VectorXs>& dx,
                           Eigen::Ref<MatrixXs> Jfirst, Eigen::Ref<MatrixXs> Jsecond,
                           Jcomponent firstsecond = both) const = 0;
+  VectorXs diff_dx(const Eigen::Ref<const VectorXs>& x0, const Eigen::Ref<const VectorXs>& x1);
+  VectorXs integrate_x(const Eigen::Ref<const VectorXs>& x, const Eigen::Ref<const VectorXs>& dx);
+  std::vector<MatrixXs> Jdiff_Js(const Eigen::Ref<const VectorXs>& x0, const Eigen::Ref<const VectorXs>& x1,
+                                 Jcomponent firstsecond = both);
+  std::vector<MatrixXs> Jintegrate_Js(const Eigen::Ref<const VectorXs>& x, const Eigen::Ref<const VectorXs>& dx,
+                                      Jcomponent firstsecond = both);
 
   const std::size_t& get_nx() const;
   const std::size_t& get_ndx() const;
@@ -74,65 +80,6 @@ class StateAbstractTpl {
   VectorXs lb_;      //!< Lower state limits
   VectorXs ub_;      //!< Upper state limits
   bool has_limits_;  //!< Indicates whether any of the state limits is finite
-
-#ifdef PYTHON_BINDINGS
-
- public:
-  VectorXs diff_wrap(const VectorXs& x0, const VectorXs& x1) {
-    VectorXs dxout = VectorXs::Zero(ndx_);
-    diff(x0, x1, dxout);
-    return dxout;
-  }
-  VectorXs integrate_wrap(const VectorXs& x, const VectorXs& dx) {
-    VectorXs xout = VectorXs::Zero(nx_);
-    integrate(x, dx, xout);
-    return xout;
-  }
-  std::vector<MatrixXs> Jdiff_wrap(const VectorXs& x0, const VectorXs& x1, Jcomponent firstsecond = both) {
-    MatrixXs Jfirst(ndx_, ndx_), Jsecond(ndx_, ndx_);
-    std::vector<MatrixXs> Jacs;
-    Jdiff(x0, x1, Jfirst, Jsecond, firstsecond);
-    switch (firstsecond) {
-      case both:
-        Jacs.push_back(Jfirst);
-        Jacs.push_back(Jsecond);
-        break;
-      case first:
-        Jacs.push_back(Jfirst);
-        break;
-      case second:
-        Jacs.push_back(Jsecond);
-        break;
-      default:
-        Jacs.push_back(Jfirst);
-        Jacs.push_back(Jsecond);
-        break;
-    }
-    return Jacs;
-  }
-  std::vector<MatrixXs> Jintegrate_wrap(const VectorXs& x, const VectorXs& dx, Jcomponent firstsecond = both) {
-    MatrixXs Jfirst(ndx_, ndx_), Jsecond(ndx_, ndx_);
-    std::vector<MatrixXs> Jacs;
-    Jintegrate(x, dx, Jfirst, Jsecond, firstsecond);
-    switch (firstsecond) {
-      case both:
-        Jacs.push_back(Jfirst);
-        Jacs.push_back(Jsecond);
-        break;
-      case first:
-        Jacs.push_back(Jfirst);
-        break;
-      case second:
-        Jacs.push_back(Jsecond);
-        break;
-      default:
-        Jacs.push_back(Jfirst);
-        Jacs.push_back(Jsecond);
-        break;
-    }
-    return Jacs;
-  }
-#endif
 };
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/core/state-base.hpp
+++ b/include/crocoddyl/core/state-base.hpp
@@ -32,70 +32,65 @@ class StateAbstractTpl {
 
   typedef _Scalar Scalar;
   typedef MathBaseTpl<Scalar> MathBase;
+  typedef typename MathBase::VectorXs VectorXs;
+  typedef typename MathBase::MatrixXs MatrixXs;
 
   StateAbstractTpl(const std::size_t& nx, const std::size_t& ndx);
   StateAbstractTpl();
   virtual ~StateAbstractTpl();
 
-  virtual typename MathBase::VectorXs zero() const = 0;
-  virtual typename MathBase::VectorXs rand() const = 0;
-  virtual void diff(const Eigen::Ref<const typename MathBase::VectorXs>& x0,
-                    const Eigen::Ref<const typename MathBase::VectorXs>& x1,
-                    Eigen::Ref<typename MathBase::VectorXs> dxout) const = 0;
-  virtual void integrate(const Eigen::Ref<const typename MathBase::VectorXs>& x,
-                         const Eigen::Ref<const typename MathBase::VectorXs>& dx,
-                         Eigen::Ref<typename MathBase::VectorXs> xout) const = 0;
-  virtual void Jdiff(const Eigen::Ref<const typename MathBase::VectorXs>& x0,
-                     const Eigen::Ref<const typename MathBase::VectorXs>& x1,
-                     Eigen::Ref<typename MathBase::MatrixXs> Jfirst, Eigen::Ref<typename MathBase::MatrixXs> Jsecond,
+  virtual VectorXs zero() const = 0;
+  virtual VectorXs rand() const = 0;
+  virtual void diff(const Eigen::Ref<const VectorXs>& x0, const Eigen::Ref<const VectorXs>& x1,
+                    Eigen::Ref<VectorXs> dxout) const = 0;
+  virtual void integrate(const Eigen::Ref<const VectorXs>& x, const Eigen::Ref<const VectorXs>& dx,
+                         Eigen::Ref<VectorXs> xout) const = 0;
+  virtual void Jdiff(const Eigen::Ref<const VectorXs>& x0, const Eigen::Ref<const VectorXs>& x1,
+                     Eigen::Ref<MatrixXs> Jfirst, Eigen::Ref<MatrixXs> Jsecond,
                      Jcomponent firstsecond = both) const = 0;
-  virtual void Jintegrate(const Eigen::Ref<const typename MathBase::VectorXs>& x,
-                          const Eigen::Ref<const typename MathBase::VectorXs>& dx,
-                          Eigen::Ref<typename MathBase::MatrixXs> Jfirst,
-                          Eigen::Ref<typename MathBase::MatrixXs> Jsecond, Jcomponent firstsecond = both) const = 0;
+  virtual void Jintegrate(const Eigen::Ref<const VectorXs>& x, const Eigen::Ref<const VectorXs>& dx,
+                          Eigen::Ref<MatrixXs> Jfirst, Eigen::Ref<MatrixXs> Jsecond,
+                          Jcomponent firstsecond = both) const = 0;
 
   const std::size_t& get_nx() const;
   const std::size_t& get_ndx() const;
   const std::size_t& get_nq() const;
   const std::size_t& get_nv() const;
 
-  const typename MathBase::VectorXs& get_lb() const;
-  const typename MathBase::VectorXs& get_ub() const;
+  const VectorXs& get_lb() const;
+  const VectorXs& get_ub() const;
   bool const& get_has_limits() const;
 
-  void set_lb(const typename MathBase::VectorXs& lb);
-  void set_ub(const typename MathBase::VectorXs& ub);
+  void set_lb(const VectorXs& lb);
+  void set_ub(const VectorXs& ub);
 
   void update_has_limits();
 
  protected:
-  std::size_t nx_;                  //!< State dimension
-  std::size_t ndx_;                 //!< State rate dimension
-  std::size_t nq_;                  //!< Configuration dimension
-  std::size_t nv_;                  //!< Velocity dimension
-  typename MathBase::VectorXs lb_;  //!< Lower state limits
-  typename MathBase::VectorXs ub_;  //!< Upper state limits
-  bool has_limits_;                 //!< Indicates whether any of the state limits is finite
+  std::size_t nx_;   //!< State dimension
+  std::size_t ndx_;  //!< State rate dimension
+  std::size_t nq_;   //!< Configuration dimension
+  std::size_t nv_;   //!< Velocity dimension
+  VectorXs lb_;      //!< Lower state limits
+  VectorXs ub_;      //!< Upper state limits
+  bool has_limits_;  //!< Indicates whether any of the state limits is finite
 
 #ifdef PYTHON_BINDINGS
 
  public:
-  typename MathBase::VectorXs diff_wrap(const typename MathBase::VectorXs& x0, const typename MathBase::VectorXs& x1) {
-    typename MathBase::VectorXs dxout = MathBase::VectorXs::Zero(ndx_);
+  VectorXs diff_wrap(const VectorXs& x0, const VectorXs& x1) {
+    VectorXs dxout = VectorXs::Zero(ndx_);
     diff(x0, x1, dxout);
     return dxout;
   }
-  typename MathBase::VectorXs integrate_wrap(const typename MathBase::VectorXs& x,
-                                             const typename MathBase::VectorXs& dx) {
-    typename MathBase::VectorXs xout = MathBase::VectorXs::Zero(nx_);
+  VectorXs integrate_wrap(const VectorXs& x, const VectorXs& dx) {
+    VectorXs xout = VectorXs::Zero(nx_);
     integrate(x, dx, xout);
     return xout;
   }
-  std::vector<typename MathBase::MatrixXs> Jdiff_wrap(const typename MathBase::VectorXs& x0,
-                                                      const typename MathBase::VectorXs& x1,
-                                                      std::string firstsecond = "both") {
-    typename MathBase::MatrixXs Jfirst(ndx_, ndx_), Jsecond(ndx_, ndx_);
-    std::vector<typename MathBase::MatrixXs> Jacs;
+  std::vector<MatrixXs> Jdiff_wrap(const VectorXs& x0, const VectorXs& x1, std::string firstsecond = "both") {
+    MatrixXs Jfirst(ndx_, ndx_), Jsecond(ndx_, ndx_);
+    std::vector<MatrixXs> Jacs;
     if (firstsecond == "both") {
       Jdiff(x0, x1, Jfirst, Jsecond, both);
       Jacs.push_back(Jfirst);
@@ -113,11 +108,9 @@ class StateAbstractTpl {
     }
     return Jacs;
   }
-  std::vector<typename MathBase::MatrixXs> Jintegrate_wrap(const typename MathBase::VectorXs& x,
-                                                           const typename MathBase::VectorXs& dx,
-                                                           std::string firstsecond = "both") {
-    typename MathBase::MatrixXs Jfirst(ndx_, ndx_), Jsecond(ndx_, ndx_);
-    std::vector<typename MathBase::MatrixXs> Jacs;
+  std::vector<MatrixXs> Jintegrate_wrap(const VectorXs& x, const VectorXs& dx, std::string firstsecond = "both") {
+    MatrixXs Jfirst(ndx_, ndx_), Jsecond(ndx_, ndx_);
+    std::vector<MatrixXs> Jacs;
     if (firstsecond == "both") {
       Jintegrate(x, dx, Jfirst, Jsecond, both);
       Jacs.push_back(Jfirst);

--- a/include/crocoddyl/core/state-base.hxx
+++ b/include/crocoddyl/core/state-base.hxx
@@ -31,6 +31,72 @@ template <typename Scalar>
 StateAbstractTpl<Scalar>::~StateAbstractTpl() {}
 
 template <typename Scalar>
+typename MathBaseTpl<Scalar>::VectorXs StateAbstractTpl<Scalar>::diff_dx(const Eigen::Ref<const VectorXs>& x0,
+                                                                         const Eigen::Ref<const VectorXs>& x1) {
+  VectorXs dxout = VectorXs::Zero(ndx_);
+  diff(x0, x1, dxout);
+  return dxout;
+}
+
+template <typename Scalar>
+typename MathBaseTpl<Scalar>::VectorXs StateAbstractTpl<Scalar>::integrate_x(const Eigen::Ref<const VectorXs>& x,
+                                                                             const Eigen::Ref<const VectorXs>& dx) {
+  VectorXs xout = VectorXs::Zero(nx_);
+  integrate(x, dx, xout);
+  return xout;
+}
+
+template <typename Scalar>
+std::vector<typename MathBaseTpl<Scalar>::MatrixXs> StateAbstractTpl<Scalar>::Jdiff_Js(
+    const Eigen::Ref<const VectorXs>& x0, const Eigen::Ref<const VectorXs>& x1, Jcomponent firstsecond) {
+  MatrixXs Jfirst(ndx_, ndx_), Jsecond(ndx_, ndx_);
+  std::vector<MatrixXs> Jacs;
+  Jdiff(x0, x1, Jfirst, Jsecond, firstsecond);
+  switch (firstsecond) {
+    case both:
+      Jacs.push_back(Jfirst);
+      Jacs.push_back(Jsecond);
+      break;
+    case first:
+      Jacs.push_back(Jfirst);
+      break;
+    case second:
+      Jacs.push_back(Jsecond);
+      break;
+    default:
+      Jacs.push_back(Jfirst);
+      Jacs.push_back(Jsecond);
+      break;
+  }
+  return Jacs;
+}
+
+template <typename Scalar>
+std::vector<typename MathBaseTpl<Scalar>::MatrixXs> StateAbstractTpl<Scalar>::Jintegrate_Js(
+    const Eigen::Ref<const VectorXs>& x, const Eigen::Ref<const VectorXs>& dx, Jcomponent firstsecond) {
+  MatrixXs Jfirst(ndx_, ndx_), Jsecond(ndx_, ndx_);
+  std::vector<MatrixXs> Jacs;
+  Jintegrate(x, dx, Jfirst, Jsecond, firstsecond);
+  switch (firstsecond) {
+    case both:
+      Jacs.push_back(Jfirst);
+      Jacs.push_back(Jsecond);
+      break;
+    case first:
+      Jacs.push_back(Jfirst);
+      break;
+    case second:
+      Jacs.push_back(Jsecond);
+      break;
+    default:
+      Jacs.push_back(Jfirst);
+      Jacs.push_back(Jsecond);
+      break;
+  }
+  return Jacs;
+}
+
+template <typename Scalar>
 const std::size_t& StateAbstractTpl<Scalar>::get_nx() const {
   return nx_;
 }

--- a/include/crocoddyl/core/state-base.hxx
+++ b/include/crocoddyl/core/state-base.hxx
@@ -12,8 +12,8 @@ template <typename Scalar>
 StateAbstractTpl<Scalar>::StateAbstractTpl(const std::size_t& nx, const std::size_t& ndx)
     : nx_(nx),
       ndx_(ndx),
-      lb_(MathBase::VectorXs::Constant(nx_, -std::numeric_limits<Scalar>::infinity())),
-      ub_(MathBase::VectorXs::Constant(nx_, std::numeric_limits<Scalar>::infinity())),
+      lb_(VectorXs::Constant(nx_, -std::numeric_limits<Scalar>::infinity())),
+      ub_(VectorXs::Constant(nx_, std::numeric_limits<Scalar>::infinity())),
       has_limits_(false) {
   nv_ = ndx / 2;
   nq_ = nx_ - nv_;
@@ -66,7 +66,7 @@ bool const& StateAbstractTpl<Scalar>::get_has_limits() const {
 }
 
 template <typename Scalar>
-void StateAbstractTpl<Scalar>::set_lb(const typename MathBase::VectorXs& lb) {
+void StateAbstractTpl<Scalar>::set_lb(const VectorXs& lb) {
   if (static_cast<std::size_t>(lb.size()) != nx_) {
     throw_pretty("Invalid argument: "
                  << "lower bound has wrong dimension (it should be " + std::to_string(nx_) + ")");
@@ -76,7 +76,7 @@ void StateAbstractTpl<Scalar>::set_lb(const typename MathBase::VectorXs& lb) {
 }
 
 template <typename Scalar>
-void StateAbstractTpl<Scalar>::set_ub(const typename MathBase::VectorXs& ub) {
+void StateAbstractTpl<Scalar>::set_ub(const VectorXs& ub) {
   if (static_cast<std::size_t>(ub.size()) != nx_) {
     throw_pretty("Invalid argument: "
                  << "upper bound has wrong dimension (it should be " + std::to_string(nx_) + ")");

--- a/include/crocoddyl/multibody/contact-base.hpp
+++ b/include/crocoddyl/multibody/contact-base.hpp
@@ -51,15 +51,6 @@ class ContactModelAbstractTpl {
   boost::shared_ptr<StateMultibody> state_;
   std::size_t nc_;
   std::size_t nu_;
-
-#ifdef PYTHON_BINDINGS
-
- public:
-  void calc_wrap(const boost::shared_ptr<ContactDataAbstract>& data, const VectorXs& x) { calc(data, x); }
-
-  void calcDiff_wrap(const boost::shared_ptr<ContactDataAbstract>& data, const VectorXs& x) { calcDiff(data, x); }
-
-#endif
 };
 
 template <typename _Scalar>

--- a/include/crocoddyl/multibody/contacts/multiple-contacts.hpp
+++ b/include/crocoddyl/multibody/contacts/multiple-contacts.hpp
@@ -88,15 +88,6 @@ class ContactModelMultipleTpl {
   std::size_t nc_;
   std::size_t nc_total_;
   std::size_t nu_;
-
-#ifdef PYTHON_BINDINGS
-
- public:
-  void calc_wrap(const boost::shared_ptr<ContactDataMultiple>& data, const VectorXs& x) { calc(data, x); }
-
-  void calcDiff_wrap(const boost::shared_ptr<ContactDataMultiple>& data, const VectorXs& x) { calcDiff(data, x); }
-
-#endif
 };
 
 template <typename _Scalar>

--- a/include/crocoddyl/multibody/cost-base.hpp
+++ b/include/crocoddyl/multibody/cost-base.hpp
@@ -70,24 +70,6 @@ class CostModelAbstractTpl {
   boost::shared_ptr<ActivationModelAbstract> activation_;
   std::size_t nu_;
   VectorXs unone_;
-
-#ifdef PYTHON_BINDINGS
-
- public:
-  void calc_wrap(const boost::shared_ptr<CostDataAbstract>& data, const VectorXs& x, const VectorXs& u = VectorXs()) {
-    if (u.size() == 0) {
-      calc(data, x);
-    } else {
-      calc(data, x, u);
-    }
-  }
-
-  void calcDiff_wrap(const boost::shared_ptr<CostDataAbstract>& data, const VectorXs& x, const VectorXs& u) {
-    calcDiff(data, x, u);
-  }
-  void calcDiff_wrap(const boost::shared_ptr<CostDataAbstract>& data, const VectorXs& x) { calcDiff(data, x, unone_); }
-
-#endif
 };
 
 template <typename _Scalar>

--- a/include/crocoddyl/multibody/costs/cost-sum.hpp
+++ b/include/crocoddyl/multibody/costs/cost-sum.hpp
@@ -86,27 +86,6 @@ class CostModelSumTpl {
   std::size_t nr_;
   std::size_t nr_total_;
   VectorXs unone_;
-
-#ifdef PYTHON_BINDINGS
-
- public:
-  void calc_wrap(const boost::shared_ptr<CostDataSumTpl<Scalar> >& data, const VectorXs& x,
-                 const VectorXs& u = VectorXs()) {
-    if (u.size() == 0) {
-      calc(data, x);
-    } else {
-      calc(data, x, u);
-    }
-  }
-
-  void calcDiff_wrap(const boost::shared_ptr<CostDataSumTpl<Scalar> >& data, const VectorXs& x, const VectorXs& u) {
-    calcDiff(data, x, u);
-  }
-  void calcDiff_wrap(const boost::shared_ptr<CostDataSumTpl<Scalar> >& data, const VectorXs& x) {
-    calcDiff(data, x, unone_);
-  }
-
-#endif
 };
 
 template <typename _Scalar>

--- a/include/crocoddyl/multibody/impulse-base.hpp
+++ b/include/crocoddyl/multibody/impulse-base.hpp
@@ -47,15 +47,6 @@ class ImpulseModelAbstractTpl {
  protected:
   boost::shared_ptr<StateMultibody> state_;
   std::size_t ni_;
-
-#ifdef PYTHON_BINDINGS
-
- public:
-  void calc_wrap(const boost::shared_ptr<ImpulseDataAbstract>& data, const VectorXs& x) { calc(data, x); }
-
-  void calcDiff_wrap(const boost::shared_ptr<ImpulseDataAbstract>& data, const VectorXs& x) { calcDiff(data, x); }
-
-#endif
 };
 
 template <typename _Scalar>

--- a/include/crocoddyl/multibody/impulses/multiple-impulses.hpp
+++ b/include/crocoddyl/multibody/impulses/multiple-impulses.hpp
@@ -84,15 +84,6 @@ class ImpulseModelMultipleTpl {
   ImpulseModelContainer impulses_;
   std::size_t ni_;
   std::size_t ni_total_;
-
-#ifdef PYTHON_BINDINGS
-
- public:
-  void calc_wrap(const boost::shared_ptr<ImpulseDataMultiple>& data, const VectorXs& x) { calc(data, x); }
-
-  void calcDiff_wrap(const boost::shared_ptr<ImpulseDataMultiple>& data, const VectorXs& x) { calcDiff(data, x); }
-
-#endif
 };
 
 template <typename _Scalar>

--- a/unittest/bindings/test_states.py
+++ b/unittest/bindings/test_states.py
@@ -51,8 +51,8 @@ class StateAbstractTestCase(unittest.TestCase):
         x1 = self.STATE.rand()
 
         # Checking that both Jdiff functions agree
-        J1, J2 = self.STATE.Jdiff(x0, x1, "both")
-        J1d, J2d = self.STATE_DER.Jdiff(x0, x1, "both")
+        J1, J2 = self.STATE.Jdiff(x0, x1)
+        J1d, J2d = self.STATE_DER.Jdiff(x0, x1)
         if self.STATE.__class__ == crocoddyl.libcrocoddyl_pywrap.StateMultibody:
             nv = self.STATE.nv
             self.assertTrue(np.allclose(J1[nv:, nv:], J1d[nv:, nv:], atol=1e-9),
@@ -70,8 +70,8 @@ class StateAbstractTestCase(unittest.TestCase):
         dx = self.STATE.rand()[:self.STATE.ndx]
 
         # Checking that both Jintegrate functions agree
-        J1, J2 = self.STATE.Jintegrate(x, dx, "both")
-        J1d, J2d = self.STATE_DER.Jintegrate(x, dx, "both")
+        J1, J2 = self.STATE.Jintegrate(x, dx)
+        J1d, J2d = self.STATE_DER.Jintegrate(x, dx)
         if self.STATE.__class__ == crocoddyl.libcrocoddyl_pywrap.StateMultibody:
             nv = self.STATE.nv
             self.assertTrue(np.allclose(J1[nv:, nv:], J1d[nv:, nv:], atol=1e-9),


### PR DESCRIPTION
The latest release of EigenPy allows us to bind functions with `Eigen::Ref`. This PR removes the unnecessary code defined by the `PYTHON_BINDINGS` and allows us to wrap functions with `Eigen::Ref`.