### PR TITLE
Clean forward declaration mistake + define derived destructors as virtuals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,5 @@ install:
   - export CMAKE_PREFIX_PATH=/opt/openrobots:$CMAKE_PREFIX_PATH
 
 script:
-  - travis_wait 60 /bin/bash .travis/build-and-test.sh
+  - travis_wait 90 /bin/bash .travis/build-and-test.sh
   - travis_wait 60 /bin/bash .travis/check-formatting.sh

--- a/bindings/python/crocoddyl/utils/__init__.py
+++ b/bindings/python/crocoddyl/utils/__init__.py
@@ -3,8 +3,6 @@ import pinocchio
 import numpy as np
 import scipy.linalg as scl
 
-crocoddyl.switchToNumpyMatrix()
-
 
 def a2m(a):
     return np.matrix(a).T

--- a/include/crocoddyl/core/actions/diff-lqr.hpp
+++ b/include/crocoddyl/core/actions/diff-lqr.hpp
@@ -30,7 +30,7 @@ class DifferentialActionModelLQRTpl : public DifferentialActionModelAbstractTpl<
   typedef typename MathBase::MatrixXs MatrixXs;
 
   DifferentialActionModelLQRTpl(const std::size_t& nq, const std::size_t& nu, bool drift_free = true);
-  ~DifferentialActionModelLQRTpl();
+  virtual ~DifferentialActionModelLQRTpl();
 
   virtual void calc(const boost::shared_ptr<DifferentialActionDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,
                     const Eigen::Ref<const VectorXs>& u);

--- a/include/crocoddyl/core/actions/lqr.hpp
+++ b/include/crocoddyl/core/actions/lqr.hpp
@@ -29,7 +29,7 @@ class ActionModelLQRTpl : public ActionModelAbstractTpl<_Scalar> {
   typedef typename MathBase::MatrixXs MatrixXs;
 
   ActionModelLQRTpl(const std::size_t& nx, const std::size_t& nu, bool drift_free = true);
-  ~ActionModelLQRTpl();
+  virtual ~ActionModelLQRTpl();
 
   virtual void calc(const boost::shared_ptr<ActionDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,
                     const Eigen::Ref<const VectorXs>& u);

--- a/include/crocoddyl/core/actions/unicycle.hpp
+++ b/include/crocoddyl/core/actions/unicycle.hpp
@@ -25,7 +25,7 @@ class ActionModelUnicycleTpl : public ActionModelAbstractTpl<_Scalar> {
   typedef MathBaseTpl<Scalar> MathBase;
 
   ActionModelUnicycleTpl();
-  ~ActionModelUnicycleTpl();
+  virtual ~ActionModelUnicycleTpl();
 
   virtual void calc(const boost::shared_ptr<ActionDataAbstract>& data,
                     const Eigen::Ref<const typename MathBase::VectorXs>& x,

--- a/include/crocoddyl/core/activations/quadratic-barrier.hpp
+++ b/include/crocoddyl/core/activations/quadratic-barrier.hpp
@@ -76,7 +76,7 @@ class ActivationModelQuadraticBarrierTpl : public ActivationModelAbstractTpl<_Sc
 
   explicit ActivationModelQuadraticBarrierTpl(const ActivationBounds& bounds)
       : Base(bounds.lb.size()), bounds_(bounds){};
-  ~ActivationModelQuadraticBarrierTpl(){};
+  virtual ~ActivationModelQuadraticBarrierTpl(){};
 
   virtual void calc(const boost::shared_ptr<ActivationDataAbstract>& data, const Eigen::Ref<const VectorXs>& r) {
     if (static_cast<std::size_t>(r.size()) != nr_) {

--- a/include/crocoddyl/core/activations/quadratic.hpp
+++ b/include/crocoddyl/core/activations/quadratic.hpp
@@ -27,7 +27,7 @@ class ActivationModelQuadTpl : public ActivationModelAbstractTpl<_Scalar> {
   typedef typename MathBase::MatrixXs MatrixXs;
 
   explicit ActivationModelQuadTpl(const std::size_t& nr) : Base(nr){};
-  ~ActivationModelQuadTpl(){};
+  virtual ~ActivationModelQuadTpl(){};
 
   virtual void calc(const boost::shared_ptr<ActivationDataAbstract>& data, const Eigen::Ref<const VectorXs>& r) {
     if (static_cast<std::size_t>(r.size()) != nr_) {

--- a/include/crocoddyl/core/activations/smooth-abs.hpp
+++ b/include/crocoddyl/core/activations/smooth-abs.hpp
@@ -29,7 +29,7 @@ class ActivationModelSmoothAbsTpl : public ActivationModelAbstractTpl<_Scalar> {
   typedef typename MathBase::MatrixXs MatrixXs;
 
   explicit ActivationModelSmoothAbsTpl(const std::size_t& nr) : Base(nr){};
-  ~ActivationModelSmoothAbsTpl(){};
+  virtual ~ActivationModelSmoothAbsTpl(){};
 
   virtual void calc(const boost::shared_ptr<ActivationDataAbstract>& data, const Eigen::Ref<const VectorXs>& r) {
     if (static_cast<std::size_t>(r.size()) != nr_) {

--- a/include/crocoddyl/core/activations/weighted-quadratic-barrier.hpp
+++ b/include/crocoddyl/core/activations/weighted-quadratic-barrier.hpp
@@ -29,7 +29,7 @@ class ActivationModelWeightedQuadraticBarrierTpl : public ActivationModelAbstrac
 
   explicit ActivationModelWeightedQuadraticBarrierTpl(const ActivationBounds& bounds, const VectorXs& weights)
       : Base(bounds.lb.size()), bounds_(bounds), weights_(weights){};
-  ~ActivationModelWeightedQuadraticBarrierTpl(){};
+  virtual ~ActivationModelWeightedQuadraticBarrierTpl(){};
 
   virtual void calc(const boost::shared_ptr<ActivationDataAbstract>& data, const Eigen::Ref<const VectorXs>& r) {
     if (static_cast<std::size_t>(r.size()) != nr_) {

--- a/include/crocoddyl/core/activations/weighted-quadratic.hpp
+++ b/include/crocoddyl/core/activations/weighted-quadratic.hpp
@@ -29,7 +29,7 @@ class ActivationModelWeightedQuadTpl : public ActivationModelAbstractTpl<_Scalar
   typedef typename MathBase::MatrixXs MatrixXs;
 
   explicit ActivationModelWeightedQuadTpl(const VectorXs& weights) : Base(weights.size()), weights_(weights){};
-  ~ActivationModelWeightedQuadTpl(){};
+  virtual ~ActivationModelWeightedQuadTpl(){};
 
   virtual void calc(const boost::shared_ptr<ActivationDataAbstract>& data, const Eigen::Ref<const VectorXs>& r) {
     if (static_cast<std::size_t>(r.size()) != nr_) {

--- a/include/crocoddyl/core/actuation/actuation-squashing.hpp
+++ b/include/crocoddyl/core/actuation/actuation-squashing.hpp
@@ -34,7 +34,7 @@ class ActuationSquashingModelTpl : public ActuationModelAbstractTpl<_Scalar> {
                              boost::shared_ptr<SquashingModelAbstract> squashing, const std::size_t& nu)
       : Base(actuation->get_state(), nu), squashing_(squashing), actuation_(actuation){};
 
-  ~ActuationSquashingModelTpl(){};
+  virtual ~ActuationSquashingModelTpl(){};
 
   virtual void calc(const boost::shared_ptr<ActuationDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,
                     const Eigen::Ref<const VectorXs>& u) {

--- a/include/crocoddyl/core/actuation/squashing/smooth-sat.hpp
+++ b/include/crocoddyl/core/actuation/squashing/smooth-sat.hpp
@@ -42,7 +42,7 @@ class SquashingModelSmoothSatTpl : public SquashingModelAbstractTpl<_Scalar> {
     a_ = d_.array() * d_.array();
   }
 
-  ~SquashingModelSmoothSatTpl(){};
+  virtual ~SquashingModelSmoothSatTpl(){};
 
   virtual void calc(const boost::shared_ptr<SquashingDataAbstract>& data, const Eigen::Ref<const VectorXs>& s) {
     // Squashing function used: "Smooth abs":

--- a/include/crocoddyl/core/fwd.hpp
+++ b/include/crocoddyl/core/fwd.hpp
@@ -11,45 +11,39 @@
 
 namespace crocoddyl {
 
-// DiffAction
+// differential action
 template <typename Scalar>
 class DifferentialActionModelAbstractTpl;
-
 template <typename Scalar>
-class DifferentialActionDataAbstractTpl;
+struct DifferentialActionDataAbstractTpl;
 
 template <typename Scalar>
 class DifferentialActionModelLQRTpl;
-
 template <typename Scalar>
-class DifferentialActionDataLQRTpl;
+struct DifferentialActionDataLQRTpl;
 
-// Actions
+// action
 template <typename Scalar>
 class ActionModelUnicycleTpl;
-
 template <typename Scalar>
-class ActionDataUnicycleTpl;
+struct ActionDataUnicycleTpl;
 
 template <typename Scalar>
 class ActionModelLQRTpl;
-
 template <typename Scalar>
-class ActionDataLQRTpl;
+struct ActionDataLQRTpl;
 
-// DataCollector
+// data collector
 template <typename Scalar>
-class DataCollectorAbstractTpl;
+struct DataCollectorAbstractTpl;
 
-// Activations
+// activation
 template <typename Scalar>
-class ActivationDataQuadraticBarrierTpl;
-
+struct ActivationBoundsTpl;
 template <typename Scalar>
 class ActivationModelQuadraticBarrierTpl;
-
 template <typename Scalar>
-class ActivationBoundsTpl;
+struct ActivationDataQuadraticBarrierTpl;
 
 template <typename Scalar>
 class ActivationModelWeightedQuadraticBarrierTpl;
@@ -59,45 +53,39 @@ class ActivationModelQuadTpl;
 
 template <typename Scalar>
 class ActivationModelWeightedQuadTpl;
-
 template <typename Scalar>
-class ActivationDataWeightedQuadTpl;
+struct ActivationDataWeightedQuadTpl;
 
 template <typename Scalar>
 class ActivationModelSmoothAbsTpl;
-
 template <typename Scalar>
-class ActivationDataSmoothAbsTpl;
+struct ActivationDataSmoothAbsTpl;
 
 template <typename Scalar>
 class ActivationModelAbstractTpl;
-
 template <typename Scalar>
-class ActivationDataAbstractTpl;
+struct ActivationDataAbstractTpl;
 
-// State
+// state
 template <typename Scalar>
 class StateAbstractTpl;
 
-// Actuations
-template <typename Scalar>
-class ActuationDataAbstractTpl;
-
+// actuation
 template <typename Scalar>
 class ActuationModelAbstractTpl;
-
 template <typename Scalar>
-class ActuationSquashingDataTpl;
+struct ActuationDataAbstractTpl;
 
 template <typename Scalar>
 class ActuationSquashingModelTpl;
-
-// Squashing
 template <typename Scalar>
-class SquashingDataAbstractTpl;
+struct ActuationSquashingDataTpl;
 
+// squashing
 template <typename Scalar>
 class SquashingModelAbstractTpl;
+template <typename Scalar>
+struct SquashingDataAbstractTpl;
 
 template <typename Scalar>
 class SquashingModelSmoothSatTpl;
@@ -106,24 +94,23 @@ class SquashingModelSmoothSatTpl;
 template <typename Scalar>
 class ShootingProblemTpl;
 
-// IAMs
+// integrated action
 template <typename Scalar>
 class IntegratedActionModelEulerTpl;
-
 template <typename Scalar>
-class IntegratedActionDataEulerTpl;
+struct IntegratedActionDataEulerTpl;
 
-// State
+// state
 template <typename Scalar>
 class StateVectorTpl;
 
-// Datacollect
+// data collector
 template <typename Scalar>
-class DataCollectorActuationTpl;
+struct DataCollectorActuationTpl;
 
 // ActionData
 template <typename Scalar>
-class ActionDataAbstractTpl;
+struct ActionDataAbstractTpl;
 
 template <typename Scalar>
 class ActionModelAbstractTpl;
@@ -131,21 +118,18 @@ class ActionModelAbstractTpl;
 // Numdiff
 template <typename Scalar>
 class ActionModelNumDiffTpl;
-
 template <typename Scalar>
-class ActionDataNumDiffTpl;
+struct ActionDataNumDiffTpl;
 
 template <typename Scalar>
 class DifferentialActionModelNumDiffTpl;
-
 template <typename Scalar>
-class DifferentialActionDataNumDiffTpl;
+struct DifferentialActionDataNumDiffTpl;
 
 template <typename Scalar>
 class ActivationModelNumDiffTpl;
-
 template <typename Scalar>
-class ActivationDataNumDiffTpl;
+struct ActivationDataNumDiffTpl;
 
 template <typename Scalar>
 class StateNumDiffTpl;

--- a/include/crocoddyl/core/integrator/euler.hpp
+++ b/include/crocoddyl/core/integrator/euler.hpp
@@ -31,7 +31,7 @@ class IntegratedActionModelEulerTpl : public ActionModelAbstractTpl<_Scalar> {
 
   IntegratedActionModelEulerTpl(boost::shared_ptr<DifferentialActionModelAbstract> model,
                                 const Scalar& time_step = 1e-3, const bool& with_cost_residual = true);
-  ~IntegratedActionModelEulerTpl();
+  virtual ~IntegratedActionModelEulerTpl();
 
   virtual void calc(const boost::shared_ptr<ActionDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,
                     const Eigen::Ref<const VectorXs>& u);

--- a/include/crocoddyl/core/numdiff/action.hpp
+++ b/include/crocoddyl/core/numdiff/action.hpp
@@ -70,7 +70,7 @@ class ActionModelNumDiffTpl : public ActionModelAbstractTpl<_Scalar> {
   /**
    * @brief Destroy the ActionModelNumDiff object
    */
-  ~ActionModelNumDiffTpl();
+  virtual ~ActionModelNumDiffTpl();
 
   /**
    * @brief @copydoc Base::calc()

--- a/include/crocoddyl/core/numdiff/activation.hpp
+++ b/include/crocoddyl/core/numdiff/activation.hpp
@@ -40,7 +40,7 @@ class ActivationModelNumDiffTpl : public ActivationModelAbstractTpl<_Scalar> {
   /**
    * @brief Destroy the ActivationModelNumDiff object
    */
-  ~ActivationModelNumDiffTpl();
+  virtual ~ActivationModelNumDiffTpl();
 
   /**
    * @brief @copydoc Base::calc()

--- a/include/crocoddyl/core/numdiff/actuation.hpp
+++ b/include/crocoddyl/core/numdiff/actuation.hpp
@@ -37,7 +37,7 @@ class ActuationModelNumDiffTpl : public ActuationModelAbstractTpl<_Scalar> {
   /**
    * @brief Destroy the ActuationModelNumDiff object
    */
-  ~ActuationModelNumDiffTpl();
+  virtual ~ActuationModelNumDiffTpl();
 
   /**
    * @brief @copydoc Base::calc()

--- a/include/crocoddyl/core/numdiff/diff-action.hpp
+++ b/include/crocoddyl/core/numdiff/diff-action.hpp
@@ -31,7 +31,7 @@ class DifferentialActionModelNumDiffTpl : public DifferentialActionModelAbstract
   typedef typename MathBase::MatrixXs MatrixXs;
 
   explicit DifferentialActionModelNumDiffTpl(boost::shared_ptr<Base> model, bool with_gauss_approx = false);
-  ~DifferentialActionModelNumDiffTpl();
+  virtual ~DifferentialActionModelNumDiffTpl();
 
   virtual void calc(const boost::shared_ptr<DifferentialActionDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,
                     const Eigen::Ref<const VectorXs>& u);

--- a/include/crocoddyl/core/numdiff/state.hpp
+++ b/include/crocoddyl/core/numdiff/state.hpp
@@ -30,7 +30,7 @@ class StateNumDiffTpl : public StateAbstractTpl<_Scalar> {
   typedef typename MathBase::MatrixXs MatrixXs;
 
   explicit StateNumDiffTpl(boost::shared_ptr<Base> state);
-  ~StateNumDiffTpl();
+  virtual ~StateNumDiffTpl();
 
   virtual VectorXs zero() const;
   virtual VectorXs rand() const;

--- a/include/crocoddyl/core/solvers/box-ddp.hpp
+++ b/include/crocoddyl/core/solvers/box-ddp.hpp
@@ -22,7 +22,7 @@ class SolverBoxDDP : public SolverDDP {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   explicit SolverBoxDDP(boost::shared_ptr<ShootingProblem> problem);
-  ~SolverBoxDDP();
+  virtual ~SolverBoxDDP();
 
   virtual void allocateData();
   virtual void computeGains(const std::size_t& t);

--- a/include/crocoddyl/core/solvers/box-fddp.hpp
+++ b/include/crocoddyl/core/solvers/box-fddp.hpp
@@ -22,7 +22,7 @@ class SolverBoxFDDP : public SolverFDDP {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   explicit SolverBoxFDDP(boost::shared_ptr<ShootingProblem> problem);
-  ~SolverBoxFDDP();
+  virtual ~SolverBoxFDDP();
 
   virtual void allocateData();
   virtual void computeGains(const std::size_t& t);

--- a/include/crocoddyl/core/solvers/ddp.hpp
+++ b/include/crocoddyl/core/solvers/ddp.hpp
@@ -21,7 +21,7 @@ class SolverDDP : public SolverAbstract {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   explicit SolverDDP(boost::shared_ptr<ShootingProblem> problem);
-  ~SolverDDP();
+  virtual ~SolverDDP();
 
   virtual bool solve(const std::vector<Eigen::VectorXd>& init_xs = DEFAULT_VECTOR,
                      const std::vector<Eigen::VectorXd>& init_us = DEFAULT_VECTOR, const std::size_t& maxiter = 100,

--- a/include/crocoddyl/core/solvers/fddp.hpp
+++ b/include/crocoddyl/core/solvers/fddp.hpp
@@ -21,7 +21,7 @@ class SolverFDDP : public SolverDDP {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   explicit SolverFDDP(boost::shared_ptr<ShootingProblem> problem);
-  ~SolverFDDP();
+  virtual ~SolverFDDP();
 
   virtual bool solve(const std::vector<Eigen::VectorXd>& init_xs = DEFAULT_VECTOR,
                      const std::vector<Eigen::VectorXd>& init_us = DEFAULT_VECTOR, const std::size_t& maxiter = 100,

--- a/include/crocoddyl/core/solvers/kkt.hpp
+++ b/include/crocoddyl/core/solvers/kkt.hpp
@@ -22,7 +22,7 @@ class SolverKKT : public SolverAbstract {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   explicit SolverKKT(boost::shared_ptr<ShootingProblem> problem);
-  ~SolverKKT();
+  virtual ~SolverKKT();
 
   virtual bool solve(const std::vector<Eigen::VectorXd>& init_xs = DEFAULT_VECTOR,
                      const std::vector<Eigen::VectorXd>& init_us = DEFAULT_VECTOR, const std::size_t& maxiter = 100,

--- a/include/crocoddyl/core/solvers/kkt.hpp
+++ b/include/crocoddyl/core/solvers/kkt.hpp
@@ -70,7 +70,6 @@ class SolverKKT : public SolverAbstract {
   Eigen::VectorXd dual_;
   std::vector<double> alphas_;
   double th_grad_;
-  double th_step_;
   bool was_feasible_;
   Eigen::VectorXd kkt_primal_;
   Eigen::VectorXd dF;

--- a/include/crocoddyl/core/states/euclidean.hpp
+++ b/include/crocoddyl/core/states/euclidean.hpp
@@ -20,12 +20,13 @@ class StateVectorTpl : public StateAbstractTpl<_Scalar> {
  public:
   typedef _Scalar Scalar;
   typedef MathBaseTpl<Scalar> MathBase;
+  typedef typename MathBase::VectorXs VectorXs;
 
   explicit StateVectorTpl(const std::size_t& nx);
   ~StateVectorTpl();
 
-  typename MathBase::VectorXs zero() const;
-  typename MathBase::VectorXs rand() const;
+  virtual VectorXs zero() const;
+  virtual VectorXs rand() const;
   virtual void diff(const Eigen::Ref<const typename MathBase::VectorXs>& x0,
                     const Eigen::Ref<const typename MathBase::VectorXs>& x1,
                     Eigen::Ref<typename MathBase::VectorXs> dxout) const;

--- a/include/crocoddyl/core/states/euclidean.hpp
+++ b/include/crocoddyl/core/states/euclidean.hpp
@@ -23,7 +23,7 @@ class StateVectorTpl : public StateAbstractTpl<_Scalar> {
   typedef typename MathBase::VectorXs VectorXs;
 
   explicit StateVectorTpl(const std::size_t& nx);
-  ~StateVectorTpl();
+  virtual ~StateVectorTpl();
 
   virtual VectorXs zero() const;
   virtual VectorXs rand() const;

--- a/include/crocoddyl/multibody/actions/contact-fwddyn.hpp
+++ b/include/crocoddyl/multibody/actions/contact-fwddyn.hpp
@@ -42,7 +42,7 @@ class DifferentialActionModelContactFwdDynamicsTpl : public DifferentialActionMo
                                                boost::shared_ptr<ContactModelMultiple> contacts,
                                                boost::shared_ptr<CostModelSum> costs,
                                                const Scalar& JMinvJt_damping = 0., const bool& enable_force = false);
-  ~DifferentialActionModelContactFwdDynamicsTpl();
+  virtual ~DifferentialActionModelContactFwdDynamicsTpl();
 
   virtual void calc(const boost::shared_ptr<DifferentialActionDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,
                     const Eigen::Ref<const VectorXs>& u);

--- a/include/crocoddyl/multibody/actions/free-fwddyn.hpp
+++ b/include/crocoddyl/multibody/actions/free-fwddyn.hpp
@@ -38,7 +38,7 @@ class DifferentialActionModelFreeFwdDynamicsTpl : public DifferentialActionModel
   DifferentialActionModelFreeFwdDynamicsTpl(boost::shared_ptr<StateMultibody> state,
                                             boost::shared_ptr<ActuationModelAbstract> actuation,
                                             boost::shared_ptr<CostModelSum> costs);
-  ~DifferentialActionModelFreeFwdDynamicsTpl();
+  virtual ~DifferentialActionModelFreeFwdDynamicsTpl();
 
   virtual void calc(const boost::shared_ptr<DifferentialActionDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,
                     const Eigen::Ref<const VectorXs>& u);

--- a/include/crocoddyl/multibody/actions/impulse-fwddyn.hpp
+++ b/include/crocoddyl/multibody/actions/impulse-fwddyn.hpp
@@ -49,7 +49,7 @@ class ActionModelImpulseFwdDynamicsTpl : public ActionModelAbstractTpl<_Scalar> 
                                    boost::shared_ptr<ImpulseModelMultiple> impulses,
                                    boost::shared_ptr<CostModelSum> costs, const Scalar& r_coeff = 0.,
                                    const Scalar& JMinvJt_damping = 0., const bool& enable_force = false);
-  ~ActionModelImpulseFwdDynamicsTpl();
+  virtual ~ActionModelImpulseFwdDynamicsTpl();
 
   virtual void calc(const boost::shared_ptr<ActionDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,
                     const Eigen::Ref<const VectorXs>& u);

--- a/include/crocoddyl/multibody/actuations/floating-base.hpp
+++ b/include/crocoddyl/multibody/actuations/floating-base.hpp
@@ -33,7 +33,7 @@ class ActuationModelFloatingBaseTpl : public ActuationModelAbstractTpl<_Scalar> 
                    << "the first joint has to be free-flyer");
     }
   };
-  ~ActuationModelFloatingBaseTpl(){};
+  virtual ~ActuationModelFloatingBaseTpl(){};
 
   virtual void calc(const boost::shared_ptr<ActuationDataAbstract>& data, const Eigen::Ref<const VectorXs>& /*x*/,
                     const Eigen::Ref<const VectorXs>& u) {

--- a/include/crocoddyl/multibody/actuations/full.hpp
+++ b/include/crocoddyl/multibody/actuations/full.hpp
@@ -33,7 +33,7 @@ class ActuationModelFullTpl : public ActuationModelAbstractTpl<_Scalar> {
     }
   };
 
-  ~ActuationModelFullTpl(){};
+  virtual ~ActuationModelFullTpl(){};
 
   virtual void calc(const boost::shared_ptr<ActuationDataAbstract>& data, const Eigen::Ref<const VectorXs>& /*x*/,
                     const Eigen::Ref<const VectorXs>& u) {

--- a/include/crocoddyl/multibody/actuations/multicopter-base.hpp
+++ b/include/crocoddyl/multibody/actuations/multicopter-base.hpp
@@ -52,7 +52,7 @@ class ActuationModelMultiCopterBaseTpl : public ActuationModelAbstractTpl<_Scala
           MatrixXs::Identity(nu_ - n_rotors_, nu_ - n_rotors_);
     }
   };
-  ~ActuationModelMultiCopterBaseTpl(){};
+  virtual ~ActuationModelMultiCopterBaseTpl(){};
 
   virtual void calc(const boost::shared_ptr<ActuationDataAbstract>& data, const Eigen::Ref<const VectorXs>& /*x*/,
                     const Eigen::Ref<const VectorXs>& u) {

--- a/include/crocoddyl/multibody/contacts/contact-3d.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-3d.hpp
@@ -42,7 +42,7 @@ class ContactModel3DTpl : public ContactModelAbstractTpl<_Scalar> {
                     const Vector2s& gains = Vector2s::Zero());
   ContactModel3DTpl(boost::shared_ptr<StateMultibody> state, const FrameTranslation& xref,
                     const Vector2s& gains = Vector2s::Zero());
-  ~ContactModel3DTpl();
+  virtual ~ContactModel3DTpl();
 
   virtual void calc(const boost::shared_ptr<ContactDataAbstract>& data, const Eigen::Ref<const VectorXs>& x);
   virtual void calcDiff(const boost::shared_ptr<ContactDataAbstract>& data, const Eigen::Ref<const VectorXs>& x);

--- a/include/crocoddyl/multibody/contacts/contact-6d.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-6d.hpp
@@ -39,7 +39,7 @@ class ContactModel6DTpl : public ContactModelAbstractTpl<_Scalar> {
                     const Vector2s& gains = Vector2s::Zero());
   ContactModel6DTpl(boost::shared_ptr<StateMultibody> state, const FramePlacement& xref,
                     const Vector2s& gains = Vector2s::Zero());
-  ~ContactModel6DTpl();
+  virtual ~ContactModel6DTpl();
 
   virtual void calc(const boost::shared_ptr<ContactDataAbstract>& data, const Eigen::Ref<const VectorXs>& x);
   virtual void calcDiff(const boost::shared_ptr<ContactDataAbstract>& data, const Eigen::Ref<const VectorXs>& x);

--- a/include/crocoddyl/multibody/costs/centroidal-momentum.hpp
+++ b/include/crocoddyl/multibody/costs/centroidal-momentum.hpp
@@ -41,7 +41,7 @@ class CostModelCentroidalMomentumTpl : public CostModelAbstractTpl<_Scalar> {
                                  boost::shared_ptr<ActivationModelAbstract> activation, const Vector6s& mref);
   CostModelCentroidalMomentumTpl(boost::shared_ptr<StateMultibody> state, const Vector6s& mref, const std::size_t& nu);
   CostModelCentroidalMomentumTpl(boost::shared_ptr<StateMultibody> state, const Vector6s& mref);
-  ~CostModelCentroidalMomentumTpl();
+  virtual ~CostModelCentroidalMomentumTpl();
 
   virtual void calc(const boost::shared_ptr<CostDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,
                     const Eigen::Ref<const VectorXs>& u);

--- a/include/crocoddyl/multibody/costs/com-position.hpp
+++ b/include/crocoddyl/multibody/costs/com-position.hpp
@@ -40,7 +40,7 @@ class CostModelCoMPositionTpl : public CostModelAbstractTpl<_Scalar> {
                           boost::shared_ptr<ActivationModelAbstract> activation, const Vector3s& cref);
   CostModelCoMPositionTpl(boost::shared_ptr<StateMultibody> state, const Vector3s& cref, const std::size_t& nu);
   CostModelCoMPositionTpl(boost::shared_ptr<StateMultibody> state, const Vector3s& cref);
-  ~CostModelCoMPositionTpl();
+  virtual ~CostModelCoMPositionTpl();
 
   virtual void calc(const boost::shared_ptr<CostDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,
                     const Eigen::Ref<const VectorXs>& u);

--- a/include/crocoddyl/multibody/costs/contact-force.hpp
+++ b/include/crocoddyl/multibody/costs/contact-force.hpp
@@ -43,7 +43,7 @@ class CostModelContactForceTpl : public CostModelAbstractTpl<_Scalar> {
                            boost::shared_ptr<ActivationModelAbstract> activation, const FrameForce& fref);
   CostModelContactForceTpl(boost::shared_ptr<StateMultibody> state, const FrameForce& fref, const std::size_t& nu);
   CostModelContactForceTpl(boost::shared_ptr<StateMultibody> state, const FrameForce& fref);
-  ~CostModelContactForceTpl();
+  virtual ~CostModelContactForceTpl();
 
   virtual void calc(const boost::shared_ptr<CostDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,
                     const Eigen::Ref<const VectorXs>& u);

--- a/include/crocoddyl/multibody/costs/contact-friction-cone.hpp
+++ b/include/crocoddyl/multibody/costs/contact-friction-cone.hpp
@@ -51,7 +51,7 @@ class CostModelContactFrictionConeTpl : public CostModelAbstractTpl<_Scalar> {
   CostModelContactFrictionConeTpl(boost::shared_ptr<StateMultibody> state, const FrameFrictionCone& fref,
                                   const std::size_t& nu);
   CostModelContactFrictionConeTpl(boost::shared_ptr<StateMultibody> state, const FrameFrictionCone& fref);
-  ~CostModelContactFrictionConeTpl();
+  virtual ~CostModelContactFrictionConeTpl();
 
   virtual void calc(const boost::shared_ptr<CostDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,
                     const Eigen::Ref<const VectorXs>& u);

--- a/include/crocoddyl/multibody/costs/control.hpp
+++ b/include/crocoddyl/multibody/costs/control.hpp
@@ -38,7 +38,7 @@ class CostModelControlTpl : public CostModelAbstractTpl<_Scalar> {
   CostModelControlTpl(boost::shared_ptr<StateMultibody> state, const VectorXs& uref);
   explicit CostModelControlTpl(boost::shared_ptr<StateMultibody> state);
   CostModelControlTpl(boost::shared_ptr<StateMultibody> state, const std::size_t& nu);
-  ~CostModelControlTpl();
+  virtual ~CostModelControlTpl();
 
   virtual void calc(const boost::shared_ptr<CostDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,
                     const Eigen::Ref<const VectorXs>& u);

--- a/include/crocoddyl/multibody/costs/frame-placement.hpp
+++ b/include/crocoddyl/multibody/costs/frame-placement.hpp
@@ -42,7 +42,7 @@ class CostModelFramePlacementTpl : public CostModelAbstractTpl<_Scalar> {
   CostModelFramePlacementTpl(boost::shared_ptr<StateMultibody> state, const FramePlacement& Fref,
                              const std::size_t& nu);
   CostModelFramePlacementTpl(boost::shared_ptr<StateMultibody> state, const FramePlacement& Fref);
-  ~CostModelFramePlacementTpl();
+  virtual ~CostModelFramePlacementTpl();
 
   virtual void calc(const boost::shared_ptr<CostDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,
                     const Eigen::Ref<const VectorXs>& u);

--- a/include/crocoddyl/multibody/costs/frame-rotation.hpp
+++ b/include/crocoddyl/multibody/costs/frame-rotation.hpp
@@ -41,7 +41,7 @@ class CostModelFrameRotationTpl : public CostModelAbstractTpl<_Scalar> {
                             boost::shared_ptr<ActivationModelAbstract> activation, const FrameRotation& Fref);
   CostModelFrameRotationTpl(boost::shared_ptr<StateMultibody> state, const FrameRotation& Fref, const std::size_t& nu);
   CostModelFrameRotationTpl(boost::shared_ptr<StateMultibody> state, const FrameRotation& Fref);
-  ~CostModelFrameRotationTpl();
+  virtual ~CostModelFrameRotationTpl();
 
   virtual void calc(const boost::shared_ptr<CostDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,
                     const Eigen::Ref<const VectorXs>& u);

--- a/include/crocoddyl/multibody/costs/frame-translation.hpp
+++ b/include/crocoddyl/multibody/costs/frame-translation.hpp
@@ -43,7 +43,7 @@ class CostModelFrameTranslationTpl : public CostModelAbstractTpl<_Scalar> {
   CostModelFrameTranslationTpl(boost::shared_ptr<StateMultibody> state, const FrameTranslation& xref,
                                const std::size_t& nu);
   CostModelFrameTranslationTpl(boost::shared_ptr<StateMultibody> state, const FrameTranslation& xref);
-  ~CostModelFrameTranslationTpl();
+  virtual ~CostModelFrameTranslationTpl();
 
   virtual void calc(const boost::shared_ptr<CostDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,
                     const Eigen::Ref<const VectorXs>& u);

--- a/include/crocoddyl/multibody/costs/frame-velocity.hpp
+++ b/include/crocoddyl/multibody/costs/frame-velocity.hpp
@@ -41,7 +41,7 @@ class CostModelFrameVelocityTpl : public CostModelAbstractTpl<_Scalar> {
                             boost::shared_ptr<ActivationModelAbstract> activation, const FrameMotion& Fref);
   CostModelFrameVelocityTpl(boost::shared_ptr<StateMultibody> state, const FrameMotion& vref, const std::size_t& nu);
   CostModelFrameVelocityTpl(boost::shared_ptr<StateMultibody> state, const FrameMotion& vref);
-  ~CostModelFrameVelocityTpl();
+  virtual ~CostModelFrameVelocityTpl();
 
   virtual void calc(const boost::shared_ptr<CostDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,
                     const Eigen::Ref<const VectorXs>& u);

--- a/include/crocoddyl/multibody/costs/state.hpp
+++ b/include/crocoddyl/multibody/costs/state.hpp
@@ -42,8 +42,7 @@ class CostModelStateTpl : public CostModelAbstractTpl<_Scalar> {
   CostModelStateTpl(boost::shared_ptr<StateMultibody> state, const std::size_t& nu);
   CostModelStateTpl(boost::shared_ptr<StateMultibody> state, boost::shared_ptr<ActivationModelAbstract> activation);
   explicit CostModelStateTpl(boost::shared_ptr<StateMultibody> state);
-
-  ~CostModelStateTpl();
+  virtual ~CostModelStateTpl();
 
   virtual void calc(const boost::shared_ptr<CostDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,
                     const Eigen::Ref<const VectorXs>& u);

--- a/include/crocoddyl/multibody/fwd.hpp
+++ b/include/crocoddyl/multibody/fwd.hpp
@@ -10,7 +10,8 @@
 #define CROCODDYL_MULTIBODY_FWD_HPP_
 
 namespace crocoddyl {
-// Actuation
+
+// actuation
 template <typename Scalar>
 class ActuationModelFloatingBaseTpl;
 
@@ -20,224 +21,196 @@ class ActuationModelFullTpl;
 template <typename Scalar>
 class ActuationModelMultiCopterBaseTpl;
 
-// Contacts
+// contact
 template <typename Scalar>
 class ContactModelAbstractTpl;
-
 template <typename Scalar>
-class ContactDataAbstractTpl;
+struct ContactDataAbstractTpl;
 
-// Actions
+// action
 template <typename Scalar>
 class ActionModelImpulseFwdDynamicsTpl;
-
 template <typename Scalar>
-class ActionDataImpulseFwdDynamicsTpl;
+struct ActionDataImpulseFwdDynamicsTpl;
 
-// Diffs
+// differential action
 template <typename Scalar>
 class DifferentialActionModelFreeFwdDynamicsTpl;
-
 template <typename Scalar>
-class DifferentialActionDataFreeFwdDynamicsTpl;
+struct DifferentialActionDataFreeFwdDynamicsTpl;
 
 template <typename Scalar>
 class DifferentialActionModelContactFwdDynamicsTpl;
-
 template <typename Scalar>
-class DifferentialActionDataContactFwdDynamicsTpl;
+struct DifferentialActionDataContactFwdDynamicsTpl;
 
-// Numdiff
+// numdiff
 template <typename Scalar>
 class CostModelNumDiffTpl;
-
 template <typename Scalar>
-class CostDataNumDiffTpl;
+struct CostDataNumDiffTpl;
 
 template <typename Scalar>
 class ContactModelNumDiffTpl;
+template <typename Scalar>
+struct ContactDataNumDiffTpl;
+
+// frame
+template <typename Scalar>
+struct FrameTranslationTpl;
 
 template <typename Scalar>
-class ContactDataNumDiffTpl;
-
-// Frames
-template <typename Scalar>
-class FrameTranslationTpl;
+struct FrameRotationTpl;
 
 template <typename Scalar>
-class FrameRotationTpl;
+struct FramePlacementTpl;
 
 template <typename Scalar>
-class FramePlacementTpl;
+struct FrameMotionTpl;
 
 template <typename Scalar>
-class FrameMotionTpl;
+struct FrameForceTpl;
 
 template <typename Scalar>
-class FrameForceTpl;
+struct FrameFrictionConeTpl;
 
-template <typename Scalar>
-class FrameFrictionConeTpl;
-
-// Costs
+// cost
 template <typename Scalar>
 class CostModelAbstractTpl;
-
 template <typename Scalar>
-class CostDataAbstractTpl;
+struct CostDataAbstractTpl;
 
 template <typename Scalar>
 class CostModelFrameTranslationTpl;
+template <typename Scalar>
+struct CostDataFrameTranslationTpl;
 
 template <typename Scalar>
-class CostDataFrameTranslationTpl;
-
-template <typename Scalar>
-class CostItemTpl;
-
+struct CostItemTpl;
 template <typename Scalar>
 class CostModelSumTpl;
-
 template <typename Scalar>
-class CostDataSumTpl;
+struct CostDataSumTpl;
 
 template <typename Scalar>
 class CostModelCentroidalMomentumTpl;
-
 template <typename Scalar>
-class CostDataCentroidalMomentumTpl;
+struct CostDataCentroidalMomentumTpl;
 
 template <typename Scalar>
 class CostModelCoMPositionTpl;
-
 template <typename Scalar>
-class CostDataCoMPositionTpl;
+struct CostDataCoMPositionTpl;
 
 template <typename Scalar>
 class CostModelFramePlacementTpl;
-
 template <typename Scalar>
-class CostDataFramePlacementTpl;
+struct CostDataFramePlacementTpl;
 
 template <typename Scalar>
 class CostModelImpulseCoMTpl;
-
 template <typename Scalar>
-class CostDataImpulseCoMTpl;
+struct CostDataImpulseCoMTpl;
 
 template <typename Scalar>
 class CostModelStateTpl;
-
 template <typename Scalar>
-class CostDataStateTpl;
+struct CostDataStateTpl;
 
 template <typename Scalar>
 class CostModelFrameVelocityTpl;
-
 template <typename Scalar>
-class CostDataFrameVelocityTpl;
+struct CostDataFrameVelocityTpl;
 
 template <typename Scalar>
 class CostModelContactFrictionConeTpl;
-
 template <typename Scalar>
-class CostDataContactFrictionConeTpl;
+struct CostDataContactFrictionConeTpl;
 
 template <typename Scalar>
 class CostModelContactForceTpl;
-
 template <typename Scalar>
-class CostDataContactForceTpl;
+struct CostDataContactForceTpl;
 
 template <typename Scalar>
 class CostModelControlTpl;
 
 template <typename Scalar>
 class CostModelFrameRotationTpl;
-
 template <typename Scalar>
-class CostDataFrameRotationTpl;
+struct CostDataFrameRotationTpl;
 
-// Impulses
+// impulse
 template <typename Scalar>
 class ImpulseModelAbstractTpl;
-
 template <typename Scalar>
-class ImpulseDataAbstractTpl;
+struct ImpulseDataAbstractTpl;
 
-// Contacts
+// contact
 template <typename Scalar>
-class ContactItemTpl;
-
+struct ContactItemTpl;
 template <typename Scalar>
 class ContactModelMultipleTpl;
-
 template <typename Scalar>
-class ContactDataMultipleTpl;
+struct ContactDataMultipleTpl;
 
 template <typename Scalar>
 class ContactModel3DTpl;
-
 template <typename Scalar>
-class ContactData3DTpl;
+struct ContactData3DTpl;
 
 template <typename Scalar>
 class ContactModel6DTpl;
-
 template <typename Scalar>
-class ContactData6DTpl;
+struct ContactData6DTpl;
 
-// Friction
+// friction
 template <typename Scalar>
 class FrictionConeTpl;
 
-// States
+// state
 template <typename Scalar>
 class StateMultibodyTpl;
 
-// DataCollector
+// data collector
 template <typename Scalar>
-class DataCollectorMultibodyTpl;
+struct DataCollectorMultibodyTpl;
 
 template <typename Scalar>
-class DataCollectorActMultibodyTpl;
+struct DataCollectorActMultibodyTpl;
 
 template <typename Scalar>
-class DataCollectorContactTpl;
+struct DataCollectorContactTpl;
 
 template <typename Scalar>
-class DataCollectorMultibodyInContactTpl;
+struct DataCollectorMultibodyInContactTpl;
 
 template <typename Scalar>
-class DataCollectorActMultibodyInContactTpl;
+struct DataCollectorActMultibodyInContactTpl;
 
 template <typename Scalar>
-class DataCollectorImpulseTpl;
+struct DataCollectorImpulseTpl;
 
 template <typename Scalar>
-class DataCollectorMultibodyInImpulseTpl;
+struct DataCollectorMultibodyInImpulseTpl;
 
-// Impulses
+// impulse
 template <typename Scalar>
 class ImpulseModel6DTpl;
-
 template <typename Scalar>
-class ImpulseData6DTpl;
+struct ImpulseData6DTpl;
 
 template <typename Scalar>
 class ImpulseModel3DTpl;
+template <typename Scalar>
+struct ImpulseData3DTpl;
 
 template <typename Scalar>
-class ImpulseData3DTpl;
-
-template <typename Scalar>
-class ImpulseItemTpl;
-
+struct ImpulseItemTpl;
 template <typename Scalar>
 class ImpulseModelMultipleTpl;
-
 template <typename Scalar>
-class ImpulseDataMultipleTpl;
+struct ImpulseDataMultipleTpl;
 
 /*******************************Template Instantiation**************************/
 

--- a/include/crocoddyl/multibody/impulses/impulse-3d.hpp
+++ b/include/crocoddyl/multibody/impulses/impulse-3d.hpp
@@ -34,7 +34,7 @@ class ImpulseModel3DTpl : public ImpulseModelAbstractTpl<_Scalar> {
   typedef typename MathBase::MatrixXs MatrixXs;
 
   ImpulseModel3DTpl(boost::shared_ptr<StateMultibody> state, const std::size_t& frame);
-  ~ImpulseModel3DTpl();
+  virtual ~ImpulseModel3DTpl();
 
   virtual void calc(const boost::shared_ptr<ImpulseDataAbstract>& data, const Eigen::Ref<const VectorXs>& x);
   virtual void calcDiff(const boost::shared_ptr<ImpulseDataAbstract>& data, const Eigen::Ref<const VectorXs>& x);

--- a/include/crocoddyl/multibody/impulses/impulse-6d.hpp
+++ b/include/crocoddyl/multibody/impulses/impulse-6d.hpp
@@ -34,7 +34,7 @@ class ImpulseModel6DTpl : public ImpulseModelAbstractTpl<_Scalar> {
   typedef typename MathBase::MatrixXs MatrixXs;
 
   ImpulseModel6DTpl(boost::shared_ptr<StateMultibody> state, const std::size_t& frame);
-  ~ImpulseModel6DTpl();
+  virtual ~ImpulseModel6DTpl();
 
   virtual void calc(const boost::shared_ptr<ImpulseDataAbstract>& data, const Eigen::Ref<const VectorXs>& x);
   virtual void calcDiff(const boost::shared_ptr<ImpulseDataAbstract>& data, const Eigen::Ref<const VectorXs>& x);

--- a/include/crocoddyl/multibody/states/multibody.hpp
+++ b/include/crocoddyl/multibody/states/multibody.hpp
@@ -30,8 +30,8 @@ class StateMultibodyTpl : public StateAbstractTpl<_Scalar> {
   explicit StateMultibodyTpl(boost::shared_ptr<pinocchio::ModelTpl<Scalar> > model);
   ~StateMultibodyTpl();
 
-  VectorXs zero() const;
-  VectorXs rand() const;
+  virtual VectorXs zero() const;
+  virtual VectorXs rand() const;
   virtual void diff(const Eigen::Ref<const VectorXs>& x0, const Eigen::Ref<const VectorXs>& x1,
                     Eigen::Ref<VectorXs> dxout) const;
   virtual void integrate(const Eigen::Ref<const VectorXs>& x, const Eigen::Ref<const VectorXs>& dx,

--- a/include/crocoddyl/multibody/states/multibody.hpp
+++ b/include/crocoddyl/multibody/states/multibody.hpp
@@ -28,7 +28,7 @@ class StateMultibodyTpl : public StateAbstractTpl<_Scalar> {
   enum JointType { FreeFlyer = 0, Spherical, Simple };
 
   explicit StateMultibodyTpl(boost::shared_ptr<pinocchio::ModelTpl<Scalar> > model);
-  ~StateMultibodyTpl();
+  virtual ~StateMultibodyTpl();
 
   virtual VectorXs zero() const;
   virtual VectorXs rand() const;

--- a/src/core/solvers/kkt.cpp
+++ b/src/core/solvers/kkt.cpp
@@ -18,7 +18,6 @@ SolverKKT::SolverKKT(boost::shared_ptr<ShootingProblem> problem)
       regmax_(1e9),
       cost_try_(0.),
       th_grad_(1e-12),
-      th_step_(0.5),
       was_feasible_(false) {
   allocateData();
   const unsigned int& n_alphas = 10;

--- a/unittest/factory/activation.cpp
+++ b/unittest/factory/activation.cpp
@@ -53,7 +53,7 @@ boost::shared_ptr<crocoddyl::ActivationModelAbstract> ActivationModelFactory::cr
   boost::shared_ptr<crocoddyl::ActivationModelAbstract> activation;
   Eigen::VectorXd lb = Eigen::VectorXd::Random(nr);
   Eigen::VectorXd ub = lb + Eigen::VectorXd::Ones(nr) + Eigen::VectorXd::Random(nr);
-  Eigen::VectorXd weights = Eigen::VectorXd::Random(nr);
+  Eigen::VectorXd weights = 0.1 * Eigen::VectorXd::Random(nr);
 
   switch (activation_type) {
     case ActivationModelTypes::ActivationModelQuad:

--- a/unittest/test_actions.cpp
+++ b/unittest/test_actions.cpp
@@ -18,15 +18,6 @@ using namespace crocoddyl::unittest;
 
 //----------------------------------------------------------------------------//
 
-void test_construct_data(ActionModelTypes::Type action_model_type) {
-  // create the model
-  ActionModelFactory factory;
-  const boost::shared_ptr<crocoddyl::ActionModelAbstract>& model = factory.create(action_model_type);
-
-  // create the corresponding data object
-  const boost::shared_ptr<crocoddyl::ActionDataAbstract>& data = model->createData();
-}
-
 void test_calc_returns_state(ActionModelTypes::Type action_model_type) {
   // create the model
   ActionModelFactory factory;
@@ -109,7 +100,6 @@ void register_action_model_unit_tests(ActionModelTypes::Type action_model_type) 
   test_name << "test_" << action_model_type;
   std::cout << "Running " << test_name.str() << std::endl;
   test_suite* ts = BOOST_TEST_SUITE(test_name.str());
-  ts->add(BOOST_TEST_CASE(boost::bind(&test_construct_data, action_model_type)));
   ts->add(BOOST_TEST_CASE(boost::bind(&test_calc_returns_state, action_model_type)));
   ts->add(BOOST_TEST_CASE(boost::bind(&test_calc_returns_a_cost, action_model_type)));
   ts->add(BOOST_TEST_CASE(boost::bind(&test_partial_derivatives_against_numdiff, action_model_type)));

--- a/unittest/test_costs.cpp
+++ b/unittest/test_costs.cpp
@@ -147,7 +147,6 @@ void test_dimensions_in_cost_sum(CostModelTypes::Type cost_type, StateModelTypes
   pinocchio::Model& pinocchio_model = *state->get_pinocchio().get();
   pinocchio::Data pinocchio_data(pinocchio_model);
   crocoddyl::DataCollectorMultibody shared_data(&pinocchio_data);
-  const boost::shared_ptr<crocoddyl::CostDataAbstract>& data = model->createData(&shared_data);
 
   // create the cost sum model
   crocoddyl::CostModelSum cost_sum(state, model->get_nu());

--- a/unittest/test_costs.cpp
+++ b/unittest/test_costs.cpp
@@ -20,19 +20,6 @@ using namespace crocoddyl::unittest;
 
 //----------------------------------------------------------------------------//
 
-void test_construct_data(CostModelTypes::Type cost_type, StateModelTypes::Type state_type,
-                         ActivationModelTypes::Type activation_type) {
-  // create the model
-  CostModelFactory factory;
-  const boost::shared_ptr<crocoddyl::CostModelAbstract>& model =
-      factory.create(cost_type, state_type, activation_type);
-
-  // create the corresponding data object
-  pinocchio::Data pinocchio_data(*model->get_state()->get_pinocchio().get());
-  crocoddyl::DataCollectorMultibody shared_data(&pinocchio_data);
-  const boost::shared_ptr<crocoddyl::CostDataAbstract>& data = model->createData(&shared_data);
-}
-
 void test_calc_returns_a_cost(CostModelTypes::Type cost_type, StateModelTypes::Type state_type,
                               ActivationModelTypes::Type activation_type) {
   // create the model
@@ -168,7 +155,6 @@ void test_dimensions_in_cost_sum(CostModelTypes::Type cost_type, StateModelTypes
 
   // Generating random values for the state and control
   const Eigen::VectorXd& x = state->rand();
-  const Eigen::VectorXd& u = Eigen::VectorXd::Random(model->get_nu());
 
   // Compute all the pinocchio function needed for the models.
   crocoddyl::unittest::updateAllPinocchio(&pinocchio_model, &pinocchio_data, x);
@@ -230,7 +216,6 @@ void register_cost_model_unit_tests(CostModelTypes::Type cost_type, StateModelTy
   test_name << "test_" << cost_type << "_" << activation_type << "_" << state_type;
   std::cout << "Running " << test_name.str() << std::endl;
   test_suite* ts = BOOST_TEST_SUITE(test_name.str());
-  ts->add(BOOST_TEST_CASE(boost::bind(&test_construct_data, cost_type, state_type, activation_type)));
   ts->add(BOOST_TEST_CASE(boost::bind(&test_calc_returns_a_cost, cost_type, state_type, activation_type)));
   ts->add(BOOST_TEST_CASE(boost::bind(&test_calc_against_numdiff, cost_type, state_type, activation_type)));
   ts->add(

--- a/unittest/test_diff_actions.cpp
+++ b/unittest/test_diff_actions.cpp
@@ -17,15 +17,6 @@ using namespace crocoddyl::unittest;
 
 //----------------------------------------------------------------------------//
 
-void test_construct_data(DifferentialActionModelTypes::Type action_type) {
-  // create the model
-  DifferentialActionModelFactory factory;
-  const boost::shared_ptr<crocoddyl::DifferentialActionModelAbstract>& model = factory.create(action_type);
-
-  // create the corresponding data object
-  const boost::shared_ptr<crocoddyl::DifferentialActionDataAbstract>& data = model->createData();
-}
-
 void test_calc_returns_state(DifferentialActionModelTypes::Type action_type) {
   // create the model
   DifferentialActionModelFactory factory;
@@ -108,7 +99,6 @@ void register_action_model_unit_tests(DifferentialActionModelTypes::Type action_
   test_name << "test_" << action_type;
   std::cout << "Running " << test_name.str() << std::endl;
   test_suite* ts = BOOST_TEST_SUITE(test_name.str());
-  ts->add(BOOST_TEST_CASE(boost::bind(&test_construct_data, action_type)));
   ts->add(BOOST_TEST_CASE(boost::bind(&test_calc_returns_state, action_type)));
   ts->add(BOOST_TEST_CASE(boost::bind(&test_calc_returns_a_cost, action_type)));
   ts->add(BOOST_TEST_CASE(boost::bind(&test_partial_derivatives_against_numdiff, action_type)));


### PR DESCRIPTION
This PR cleans the code in different ways:
 1. Use proper forward declaration of structures
 2. Define the derived destrutors as virtuals (alternatively, in future, we could use `final` if we agree to move into c++11)
 3. Define `rand` and `zero` in derived states as virtuals
 4. Remove dependency of `switchNumPyMatrix` to Python bindings unittest
 5. Improve the unittest by using clang compiler