### PR TITLE
State bounds: proper enabling of limits + writing internal data of lb / ub

### DIFF
--- a/bindings/python/crocoddyl/core/state-base.cpp
+++ b/bindings/python/crocoddyl/core/state-base.cpp
@@ -94,10 +94,10 @@ void exposeStateAbstract() {
           bp::make_function(&StateAbstract_wrap::get_has_limits, bp::return_value_policy<bp::return_by_value>()),
           "indicates whether problem has finite state limits")
       .add_property("lb",
-                    bp::make_function(&StateAbstract_wrap::get_lb, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&StateAbstract_wrap::lb_, bp::return_internal_reference<>()),
                     &StateAbstract_wrap::set_lb, "lower state limits")
       .add_property("ub",
-                    bp::make_function(&StateAbstract_wrap::get_ub, bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_getter(&StateAbstract_wrap::ub_, bp::return_internal_reference<>()),
                     &StateAbstract_wrap::set_ub, "upper state limits");
 }
 

--- a/bindings/python/crocoddyl/core/state-base.cpp
+++ b/bindings/python/crocoddyl/core/state-base.cpp
@@ -93,11 +93,9 @@ void exposeStateAbstract() {
           "has_limits",
           bp::make_function(&StateAbstract_wrap::get_has_limits, bp::return_value_policy<bp::return_by_value>()),
           "indicates whether problem has finite state limits")
-      .add_property("lb",
-                    bp::make_getter(&StateAbstract_wrap::lb_, bp::return_internal_reference<>()),
+      .add_property("lb", bp::make_getter(&StateAbstract_wrap::lb_, bp::return_internal_reference<>()),
                     &StateAbstract_wrap::set_lb, "lower state limits")
-      .add_property("ub",
-                    bp::make_getter(&StateAbstract_wrap::ub_, bp::return_internal_reference<>()),
+      .add_property("ub", bp::make_getter(&StateAbstract_wrap::ub_, bp::return_internal_reference<>()),
                     &StateAbstract_wrap::set_ub, "upper state limits");
 }
 

--- a/bindings/python/crocoddyl/core/state-base.hpp
+++ b/bindings/python/crocoddyl/core/state-base.hpp
@@ -20,6 +20,9 @@ namespace python {
 
 class StateAbstract_wrap : public StateAbstract, public bp::wrapper<StateAbstract> {
  public:
+  using StateAbstract::lb_;
+  using StateAbstract::ub_;
+
   StateAbstract_wrap(int nx, int ndx) : StateAbstract(nx, ndx), bp::wrapper<StateAbstract>() {}
 
   Eigen::VectorXd zero() const { return bp::call<Eigen::VectorXd>(this->get_override("zero").ptr()); }

--- a/include/crocoddyl/core/state-base.hxx
+++ b/include/crocoddyl/core/state-base.hxx
@@ -153,7 +153,7 @@ void StateAbstractTpl<Scalar>::set_ub(const VectorXs& ub) {
 
 template <typename Scalar>
 void StateAbstractTpl<Scalar>::update_has_limits() {
-  has_limits_ = isfinite(lb_.array()).any() && isfinite(ub_.array()).any();
+  has_limits_ = isfinite(lb_.array()).any() || isfinite(ub_.array()).any();
 }
 
 }  // namespace crocoddyl


### PR DESCRIPTION
This PR enables the limits `has_limits` whenever it has been defined at least one upper / lower bounds. Additionally, it allows us to write internal data for Python code.