### PR TITLE
Improved the warning messages in cost-sum, contact and impulse

### DIFF
--- a/bindings/python/crocoddyl/multibody/contacts/multiple-contacts.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/multiple-contacts.cpp
@@ -114,7 +114,14 @@ void exposeContactMultiple() {
           "dimension of the total contact vector")
       .add_property("nu",
                     bp::make_function(&ContactModelMultiple::get_nu, bp::return_value_policy<bp::return_by_value>()),
-                    "dimension of control vector");
+                    "dimension of control vector")
+      .add_property(
+          "active",
+          bp::make_function(&ContactModelMultiple::get_active, bp::return_value_policy<bp::return_by_value>()),
+          "name of active contact items")
+      .def("getContactStatus", &ContactModelMultiple::getContactStatus, bp::args("self", "name"),
+           "Return the contact status of a given contact name.\n\n"
+           ":param name: contact name");
 
   bp::register_ptr_to_python<boost::shared_ptr<ContactDataMultiple> >();
 

--- a/bindings/python/crocoddyl/multibody/costs/cost-sum.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/cost-sum.cpp
@@ -119,7 +119,13 @@ void exposeCostSum() {
                     "dimension of the residual vector of active cost")
       .add_property("nr_total",
                     bp::make_function(&CostModelSum::get_nr_total, bp::return_value_policy<bp::return_by_value>()),
-                    "dimension of the total residual vector");
+                    "dimension of the total residual vector")
+      .add_property("active",
+                    bp::make_function(&CostModelSum::get_active, bp::return_value_policy<bp::return_by_value>()),
+                    "name of active cost items")
+      .def("getCostStatus", &CostModelSum::getCostStatus, bp::args("self", "name"),
+           "Return the cost status of a given cost name.\n\n"
+           ":param name: cost name");
 
   bp::register_ptr_to_python<boost::shared_ptr<CostDataSum> >();
 

--- a/bindings/python/crocoddyl/multibody/impulses/multiple-impulses.cpp
+++ b/bindings/python/crocoddyl/multibody/impulses/multiple-impulses.cpp
@@ -114,7 +114,14 @@ void exposeImpulseMultiple() {
       .add_property(
           "ni_total",
           bp::make_function(&ImpulseModelMultiple::get_ni_total, bp::return_value_policy<bp::return_by_value>()),
-          "dimension of the total impulse vector");
+          "dimension of the total impulse vector")
+      .add_property(
+          "active",
+          bp::make_function(&ImpulseModelMultiple::get_active, bp::return_value_policy<bp::return_by_value>()),
+          "name of active impulse items")
+      .def("getImpulseStatus", &ImpulseModelMultiple::getImpulseStatus, bp::args("self", "name"),
+           "Return the impulse status of a given impulse name.\n\n"
+           ":param name: impulse name");
 
   bp::register_ptr_to_python<boost::shared_ptr<ImpulseDataMultiple> >();
 

--- a/include/crocoddyl/multibody/contacts/multiple-contacts.hpp
+++ b/include/crocoddyl/multibody/contacts/multiple-contacts.hpp
@@ -81,6 +81,8 @@ class ContactModelMultipleTpl {
   const std::size_t& get_nc() const;
   const std::size_t& get_nc_total() const;
   const std::size_t& get_nu() const;
+  const std::vector<std::string>& get_active() const;
+  bool getContactStatus(const std::string& name) const;
 
  private:
   boost::shared_ptr<StateMultibody> state_;
@@ -88,6 +90,7 @@ class ContactModelMultipleTpl {
   std::size_t nc_;
   std::size_t nc_total_;
   std::size_t nu_;
+  std::vector<std::string> active_;
 };
 
 template <typename _Scalar>

--- a/include/crocoddyl/multibody/contacts/multiple-contacts.hxx
+++ b/include/crocoddyl/multibody/contacts/multiple-contacts.hxx
@@ -24,13 +24,14 @@ template <typename Scalar>
 void ContactModelMultipleTpl<Scalar>::addContact(const std::string& name,
                                                  boost::shared_ptr<ContactModelAbstract> contact, bool active) {
   if (contact->get_nu() != nu_) {
-    throw_pretty("Invalid argument: "
-                 << "contact item doesn't have the same control dimension (" + std::to_string(nu_) + ")");
+    throw_pretty("Invalid argument: " << name
+                                      << " contact item doesn't have the same control dimension (" +
+                                             std::to_string(nu_) + ")");
   }
   std::pair<typename ContactModelContainer::iterator, bool> ret =
       contacts_.insert(std::make_pair(name, boost::make_shared<ContactItem>(name, contact, active)));
   if (ret.second == false) {
-    std::cout << "Warning: this contact item already existed, we cannot add it" << std::endl;
+    std::cout << "Warning: we couldn't add the " << name << " contact item, it already existed." << std::endl;
   } else if (active) {
     nc_ += contact->get_nc();
     nc_total_ += contact->get_nc();
@@ -47,7 +48,7 @@ void ContactModelMultipleTpl<Scalar>::removeContact(const std::string& name) {
     nc_total_ -= it->second->contact->get_nc();
     contacts_.erase(it);
   } else {
-    std::cout << "Warning: this contact item doesn't exist, we cannot remove it" << std::endl;
+    std::cout << "Warning: we couldn't remove the " << name << " contact item, it doesn't exist." << std::endl;
   }
 }
 
@@ -62,7 +63,8 @@ void ContactModelMultipleTpl<Scalar>::changeContactStatus(const std::string& nam
     }
     it->second->active = active;
   } else {
-    std::cout << "Warning: this contact item doesn't exist, we cannot change its status" << std::endl;
+    std::cout << "Warning: we couldn't change the status of the " << name << " contact item, it doesn't exist."
+              << std::endl;
   }
 }
 
@@ -83,7 +85,8 @@ void ContactModelMultipleTpl<Scalar>::calc(const boost::shared_ptr<ContactDataMu
     const boost::shared_ptr<ContactItem>& m_i = it_m->second;
     if (m_i->active) {
       const boost::shared_ptr<ContactDataAbstract>& d_i = it_d->second;
-      assert_pretty(it_m->first == it_d->first, "it doesn't match the contact name between data and model");
+      assert_pretty(it_m->first == it_d->first, "it doesn't match the contact name between model and data ("
+                                                    << it_m->first << " != " << it_d->first << ")");
 
       m_i->contact->calc(d_i, x);
       const std::size_t& nc_i = m_i->contact->get_nc();
@@ -111,7 +114,8 @@ void ContactModelMultipleTpl<Scalar>::calcDiff(const boost::shared_ptr<ContactDa
     const boost::shared_ptr<ContactItem>& m_i = it_m->second;
     if (m_i->active) {
       const boost::shared_ptr<ContactDataAbstract>& d_i = it_d->second;
-      assert_pretty(it_m->first == it_d->first, "it doesn't match the contact name between data and model");
+      assert_pretty(it_m->first == it_d->first, "it doesn't match the contact name between model and data ("
+                                                    << it_m->first << " != " << it_d->first << ")");
 
       m_i->contact->calcDiff(d_i, x);
       const std::size_t& nc_i = m_i->contact->get_nc();

--- a/include/crocoddyl/multibody/contacts/multiple-contacts.hxx
+++ b/include/crocoddyl/multibody/contacts/multiple-contacts.hxx
@@ -35,6 +35,7 @@ void ContactModelMultipleTpl<Scalar>::addContact(const std::string& name,
   } else if (active) {
     nc_ += contact->get_nc();
     nc_total_ += contact->get_nc();
+    active_.push_back(name);
   } else if (!active) {
     nc_total_ += contact->get_nc();
   }
@@ -47,6 +48,7 @@ void ContactModelMultipleTpl<Scalar>::removeContact(const std::string& name) {
     nc_ -= it->second->contact->get_nc();
     nc_total_ -= it->second->contact->get_nc();
     contacts_.erase(it);
+    active_.erase(std::remove(active_.begin(), active_.end(), name), active_.end());
   } else {
     std::cout << "Warning: we couldn't remove the " << name << " contact item, it doesn't exist." << std::endl;
   }
@@ -58,8 +60,10 @@ void ContactModelMultipleTpl<Scalar>::changeContactStatus(const std::string& nam
   if (it != contacts_.end()) {
     if (active && !it->second->active) {
       nc_ += it->second->contact->get_nc();
+      active_.push_back(name);
     } else if (!active && it->second->active) {
       nc_ -= it->second->contact->get_nc();
+      active_.erase(std::remove(active_.begin(), active_.end(), name), active_.end());
     }
     it->second->active = active;
   } else {
@@ -250,6 +254,23 @@ const std::size_t& ContactModelMultipleTpl<Scalar>::get_nc_total() const {
 template <typename Scalar>
 const std::size_t& ContactModelMultipleTpl<Scalar>::get_nu() const {
   return nu_;
+}
+
+template <typename Scalar>
+const std::vector<std::string>& ContactModelMultipleTpl<Scalar>::get_active() const {
+  return active_;
+}
+
+template <typename Scalar>
+bool ContactModelMultipleTpl<Scalar>::getContactStatus(const std::string& name) const {
+  typename ContactModelContainer::const_iterator it = contacts_.find(name);
+  if (it != contacts_.end()) {
+    return it->second->active;
+  } else {
+    std::cout << "Warning: we couldn't get the status of the " << name << " contact item, it doesn't exist."
+              << std::endl;
+    return false;
+  }
 }
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/multibody/costs/cost-sum.hpp
+++ b/include/crocoddyl/multibody/costs/cost-sum.hpp
@@ -78,6 +78,8 @@ class CostModelSumTpl {
   const std::size_t& get_nu() const;
   const std::size_t& get_nr() const;
   const std::size_t& get_nr_total() const;
+  const std::vector<std::string>& get_active() const;
+  bool getCostStatus(const std::string& name) const;
 
  private:
   boost::shared_ptr<StateMultibody> state_;
@@ -85,6 +87,7 @@ class CostModelSumTpl {
   std::size_t nu_;
   std::size_t nr_;
   std::size_t nr_total_;
+  std::vector<std::string> active_;
   VectorXs unone_;
 };
 

--- a/include/crocoddyl/multibody/costs/cost-sum.hxx
+++ b/include/crocoddyl/multibody/costs/cost-sum.hxx
@@ -36,6 +36,7 @@ void CostModelSumTpl<Scalar>::addCost(const std::string& name, boost::shared_ptr
   } else if (active) {
     nr_ += cost->get_activation()->get_nr();
     nr_total_ += cost->get_activation()->get_nr();
+    active_.push_back(name);
   } else if (!active) {
     nr_total_ += cost->get_activation()->get_nr();
   }
@@ -48,6 +49,7 @@ void CostModelSumTpl<Scalar>::removeCost(const std::string& name) {
     nr_ -= it->second->cost->get_activation()->get_nr();
     nr_total_ -= it->second->cost->get_activation()->get_nr();
     costs_.erase(it);
+    active_.erase(std::remove(active_.begin(), active_.end(), name), active_.end());
   } else {
     std::cout << "Warning: we couldn't remove the " << name << " cost item, it doesn't exist." << std::endl;
   }
@@ -59,8 +61,10 @@ void CostModelSumTpl<Scalar>::changeCostStatus(const std::string& name, bool act
   if (it != costs_.end()) {
     if (active && !it->second->active) {
       nr_ += it->second->cost->get_activation()->get_nr();
+      active_.push_back(name);
     } else if (!active && it->second->active) {
       nr_ -= it->second->cost->get_activation()->get_nr();
+      active_.erase(std::remove(active_.begin(), active_.end(), name), active_.end());
     }
     it->second->active = active;
   } else {
@@ -183,6 +187,22 @@ const std::size_t& CostModelSumTpl<Scalar>::get_nr() const {
 template <typename Scalar>
 const std::size_t& CostModelSumTpl<Scalar>::get_nr_total() const {
   return nr_total_;
+}
+
+template <typename Scalar>
+const std::vector<std::string>& CostModelSumTpl<Scalar>::get_active() const {
+  return active_;
+}
+
+template <typename Scalar>
+bool CostModelSumTpl<Scalar>::getCostStatus(const std::string& name) const {
+  typename CostModelContainer::const_iterator it = costs_.find(name);
+  if (it != costs_.end()) {
+    return it->second->active;
+  } else {
+    std::cout << "Warning: we couldn't get the status of the " << name << " cost item, it doesn't exist." << std::endl;
+    return false;
+  }
 }
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/multibody/costs/cost-sum.hxx
+++ b/include/crocoddyl/multibody/costs/cost-sum.hxx
@@ -26,12 +26,13 @@ template <typename Scalar>
 void CostModelSumTpl<Scalar>::addCost(const std::string& name, boost::shared_ptr<CostModelAbstract> cost,
                                       const Scalar& weight, bool active) {
   if (cost->get_nu() != nu_) {
-    throw_pretty("Cost item doesn't have the same control dimension (it should be " + std::to_string(nu_) + ")");
+    throw_pretty(name << " cost item doesn't have the same control dimension (it should be " + std::to_string(nu_) +
+                             ")");
   }
   std::pair<typename CostModelContainer::iterator, bool> ret =
       costs_.insert(std::make_pair(name, boost::make_shared<CostItem>(name, cost, weight, active)));
   if (ret.second == false) {
-    std::cout << "Warning: this cost item already existed, we cannot add it" << std::endl;
+    std::cout << "Warning: we couldn't add the " << name << " cost item, it already existed." << std::endl;
   } else if (active) {
     nr_ += cost->get_activation()->get_nr();
     nr_total_ += cost->get_activation()->get_nr();
@@ -48,7 +49,7 @@ void CostModelSumTpl<Scalar>::removeCost(const std::string& name) {
     nr_total_ -= it->second->cost->get_activation()->get_nr();
     costs_.erase(it);
   } else {
-    std::cout << "Warning: this cost item doesn't exist, we cannot remove it" << std::endl;
+    std::cout << "Warning: we couldn't remove the " << name << " cost item, it doesn't exist." << std::endl;
   }
 }
 
@@ -63,7 +64,8 @@ void CostModelSumTpl<Scalar>::changeCostStatus(const std::string& name, bool act
     }
     it->second->active = active;
   } else {
-    std::cout << "Warning: this cost item doesn't exist, we cannot change its status" << std::endl;
+    std::cout << "Warning: we couldn't change the status of the " << name << " cost item, it doesn't exist."
+              << std::endl;
   }
 }
 
@@ -91,7 +93,8 @@ void CostModelSumTpl<Scalar>::calc(const boost::shared_ptr<CostDataSumTpl<Scalar
     const boost::shared_ptr<CostItem>& m_i = it_m->second;
     if (m_i->active) {
       const boost::shared_ptr<CostDataAbstract>& d_i = it_d->second;
-      assert_pretty(it_m->first == it_d->first, "it doesn't match the cost name between data and model");
+      assert_pretty(it_m->first == it_d->first, "it doesn't match the cost name between model and data ("
+                                                    << it_m->first << " != " << it_d->first << ")");
 
       m_i->cost->calc(d_i, x, u);
       data->cost += m_i->weight * d_i->cost;
@@ -127,7 +130,8 @@ void CostModelSumTpl<Scalar>::calcDiff(const boost::shared_ptr<CostDataSumTpl<Sc
     const boost::shared_ptr<CostItem>& m_i = it_m->second;
     if (m_i->active) {
       const boost::shared_ptr<CostDataAbstract>& d_i = it_d->second;
-      assert_pretty(it_m->first == it_d->first, "it doesn't match the cost name between data and model");
+      assert_pretty(it_m->first == it_d->first, "it doesn't match the cost name between model and data ("
+                                                    << it_m->first << " != " << it_d->first << ")");
 
       m_i->cost->calcDiff(d_i, x, u);
       data->Lx += m_i->weight * d_i->Lx;

--- a/include/crocoddyl/multibody/impulses/multiple-impulses.hpp
+++ b/include/crocoddyl/multibody/impulses/multiple-impulses.hpp
@@ -78,12 +78,15 @@ class ImpulseModelMultipleTpl {
   const ImpulseModelContainer& get_impulses() const;
   const std::size_t& get_ni() const;
   const std::size_t& get_ni_total() const;
+  const std::vector<std::string>& get_active() const;
+  bool getImpulseStatus(const std::string& name) const;
 
  private:
   boost::shared_ptr<StateMultibody> state_;
   ImpulseModelContainer impulses_;
   std::size_t ni_;
   std::size_t ni_total_;
+  std::vector<std::string> active_;
 };
 
 template <typename _Scalar>

--- a/include/crocoddyl/multibody/impulses/multiple-impulses.hxx
+++ b/include/crocoddyl/multibody/impulses/multiple-impulses.hxx
@@ -24,7 +24,7 @@ void ImpulseModelMultipleTpl<Scalar>::addImpulse(const std::string& name,
   std::pair<typename ImpulseModelContainer::iterator, bool> ret =
       impulses_.insert(std::make_pair(name, boost::make_shared<ImpulseItem>(name, impulse, active)));
   if (ret.second == false) {
-    std::cout << "Warning: this impulse item already existed, we cannot add it" << std::endl;
+    std::cout << "Warning: we couldn't add the " << name << " impulse item, it already existed." << std::endl;
   } else if (active) {
     ni_ += impulse->get_ni();
     ni_total_ += impulse->get_ni();
@@ -41,7 +41,7 @@ void ImpulseModelMultipleTpl<Scalar>::removeImpulse(const std::string& name) {
     ni_total_ -= it->second->impulse->get_ni();
     impulses_.erase(it);
   } else {
-    std::cout << "Warning: this impulse item doesn't exist, we cannot remove it" << std::endl;
+    std::cout << "Warning: we couldn't remove the " << name << " impulse item, it doesn't exist." << std::endl;
   }
 }
 
@@ -56,7 +56,8 @@ void ImpulseModelMultipleTpl<Scalar>::changeImpulseStatus(const std::string& nam
     }
     it->second->active = active;
   } else {
-    std::cout << "Warning: this impulse item doesn't exist, we cannot change its status" << std::endl;
+    std::cout << "Warning: we couldn't change the status of the " << name << " impulse item, it doesn't exist."
+              << std::endl;
   }
 }
 
@@ -77,7 +78,8 @@ void ImpulseModelMultipleTpl<Scalar>::calc(const boost::shared_ptr<ImpulseDataMu
     const boost::shared_ptr<ImpulseItem>& m_i = it_m->second;
     if (m_i->active) {
       const boost::shared_ptr<ImpulseDataAbstract>& d_i = it_d->second;
-      assert_pretty(it_m->first == it_d->first, "it doesn't match the impulse name between data and model");
+      assert_pretty(it_m->first == it_d->first, "it doesn't match the impulse name between model and data ("
+                                                    << it_m->first << " != " << it_d->first << ")");
 
       m_i->impulse->calc(d_i, x);
       const std::size_t& ni_i = m_i->impulse->get_ni();
@@ -104,7 +106,8 @@ void ImpulseModelMultipleTpl<Scalar>::calcDiff(const boost::shared_ptr<ImpulseDa
     const boost::shared_ptr<ImpulseItem>& m_i = it_m->second;
     if (m_i->active) {
       const boost::shared_ptr<ImpulseDataAbstract>& d_i = it_d->second;
-      assert_pretty(it_m->first == it_d->first, "it doesn't match the impulse name between data and model");
+      assert_pretty(it_m->first == it_d->first, "it doesn't match the impulse name between model and data ("
+                                                    << it_m->first << " != " << it_d->first << ")");
 
       m_i->impulse->calcDiff(d_i, x);
       const std::size_t& ni_i = m_i->impulse->get_ni();

--- a/include/crocoddyl/multibody/impulses/multiple-impulses.hxx
+++ b/include/crocoddyl/multibody/impulses/multiple-impulses.hxx
@@ -28,6 +28,7 @@ void ImpulseModelMultipleTpl<Scalar>::addImpulse(const std::string& name,
   } else if (active) {
     ni_ += impulse->get_ni();
     ni_total_ += impulse->get_ni();
+    active_.push_back(name);
   } else if (!active) {
     ni_total_ += impulse->get_ni();
   }
@@ -40,6 +41,7 @@ void ImpulseModelMultipleTpl<Scalar>::removeImpulse(const std::string& name) {
     ni_ -= it->second->impulse->get_ni();
     ni_total_ -= it->second->impulse->get_ni();
     impulses_.erase(it);
+    active_.erase(std::remove(active_.begin(), active_.end(), name), active_.end());
   } else {
     std::cout << "Warning: we couldn't remove the " << name << " impulse item, it doesn't exist." << std::endl;
   }
@@ -51,8 +53,10 @@ void ImpulseModelMultipleTpl<Scalar>::changeImpulseStatus(const std::string& nam
   if (it != impulses_.end()) {
     if (active && !it->second->active) {
       ni_ += it->second->impulse->get_ni();
+      active_.push_back(name);
     } else if (!active && it->second->active) {
       ni_ -= it->second->impulse->get_ni();
+      active_.erase(std::remove(active_.begin(), active_.end(), name), active_.end());
     }
     it->second->active = active;
   } else {
@@ -230,6 +234,23 @@ const std::size_t& ImpulseModelMultipleTpl<Scalar>::get_ni() const {
 template <typename Scalar>
 const std::size_t& ImpulseModelMultipleTpl<Scalar>::get_ni_total() const {
   return ni_total_;
+}
+
+template <typename Scalar>
+const std::vector<std::string>& ImpulseModelMultipleTpl<Scalar>::get_active() const {
+  return active_;
+}
+
+template <typename Scalar>
+bool ImpulseModelMultipleTpl<Scalar>::getImpulseStatus(const std::string& name) const {
+  typename ImpulseModelContainer::const_iterator it = impulses_.find(name);
+  if (it != impulses_.end()) {
+    return it->second->active;
+  } else {
+    std::cout << "Warning: we couldn't get the status of the " << name << " impulse item, it doesn't exist."
+              << std::endl;
+    return false;
+  }
 }
 
 }  // namespace crocoddyl

--- a/unittest/test_cost_sum.cpp
+++ b/unittest/test_cost_sum.cpp
@@ -76,7 +76,7 @@ void test_addCost_error_message(StateModelTypes::Type state_type) {
   model.addCost("random_cost", rand_cost, 1.);
   capture_ios.endCapture();
   std::stringstream expected_buffer;
-  expected_buffer << "Warning: this cost item already existed, we cannot add it" << std::endl;
+  expected_buffer << "Warning: we couldn't add the random_cost cost item, it already existed." << std::endl;
   BOOST_CHECK(capture_ios.str() == expected_buffer.str());
 
   // test error message when we change the cost status of an inexistent cost
@@ -84,7 +84,8 @@ void test_addCost_error_message(StateModelTypes::Type state_type) {
   model.changeCostStatus("no_exist_cost", true);
   capture_ios.endCapture();
   expected_buffer.clear();
-  expected_buffer << "Warning: this cost item doesn't exist, we cannot change its status" << std::endl;
+  expected_buffer << "Warning: we couldn't change the status of the no_exist_cost cost item, it doesn't exist."
+                  << std::endl;
   BOOST_CHECK(capture_ios.str() == expected_buffer.str());
 }
 
@@ -119,7 +120,7 @@ void test_removeCost_error_message(StateModelTypes::Type state_type) {
 
   // Test that the error message is sent.
   std::stringstream expected_buffer;
-  expected_buffer << "Warning: this cost item doesn't exist, we cannot remove it" << std::endl;
+  expected_buffer << "Warning: we couldn't remove the random_cost cost item, it doesn't exist." << std::endl;
   BOOST_CHECK(capture_ios.str() == expected_buffer.str());
 }
 

--- a/unittest/test_multiple_contacts.cpp
+++ b/unittest/test_multiple_contacts.cpp
@@ -111,7 +111,7 @@ void test_addContact_error_message() {
   model.addContact("random_contact", rand_contact);
   capture_ios.endCapture();
   std::stringstream expected_buffer;
-  expected_buffer << "Warning: this contact item already existed, we cannot add it" << std::endl;
+  expected_buffer << "Warning: we couldn't add the random_contact contact item, it already existed." << std::endl;
   BOOST_CHECK(capture_ios.str() == expected_buffer.str());
 
   // test error message when we change the contact status of an inexistent contact
@@ -119,7 +119,8 @@ void test_addContact_error_message() {
   model.changeContactStatus("no_exist_contact", true);
   capture_ios.endCapture();
   expected_buffer.clear();
-  expected_buffer << "Warning: this contact item doesn't exist, we cannot change its status" << std::endl;
+  expected_buffer << "Warning: we couldn't change the status of the no_exist_contact contact item, it doesn't exist."
+                  << std::endl;
   BOOST_CHECK(capture_ios.str() == expected_buffer.str());
 }
 
@@ -155,7 +156,7 @@ void test_removeContact_error_message() {
 
   // Test that the error message is sent.
   std::stringstream expected_buffer;
-  expected_buffer << "Warning: this contact item doesn't exist, we cannot remove it" << std::endl;
+  expected_buffer << "Warning: we couldn't remove the random_contact contact item, it doesn't exist." << std::endl;
   BOOST_CHECK(capture_ios.str() == expected_buffer.str());
 }
 

--- a/unittest/test_multiple_impulses.cpp
+++ b/unittest/test_multiple_impulses.cpp
@@ -112,7 +112,7 @@ void test_addImpulse_error_message() {
   model.addImpulse("random_impulse", rand_impulse);
   capture_ios.endCapture();
   std::stringstream expected_buffer;
-  expected_buffer << "Warning: this impulse item already existed, we cannot add it" << std::endl;
+  expected_buffer << "Warning: we couldn't add the random_impulse impulse item, it already existed." << std::endl;
   BOOST_CHECK(capture_ios.str() == expected_buffer.str());
 
   // test error message when we change the impulse status of an inexistent impulse
@@ -120,7 +120,8 @@ void test_addImpulse_error_message() {
   model.changeImpulseStatus("no_exist_impulse", true);
   capture_ios.endCapture();
   expected_buffer.clear();
-  expected_buffer << "Warning: this impulse item doesn't exist, we cannot change its status" << std::endl;
+  expected_buffer << "Warning: we couldn't change the status of the no_exist_impulse impulse item, it doesn't exist."
+                  << std::endl;
   BOOST_CHECK(capture_ios.str() == expected_buffer.str());
 }
 
@@ -154,7 +155,7 @@ void test_removeImpulse_error_message() {
 
   // Test that the error message is sent.
   std::stringstream expected_buffer;
-  expected_buffer << "Warning: this impulse item doesn't exist, we cannot remove it" << std::endl;
+  expected_buffer << "Warning: we couldn't remove the random_impulse impulse item, it doesn't exist." << std::endl;
   BOOST_CHECK(capture_ios.str() == expected_buffer.str());
 }
 


### PR DESCRIPTION
The warning messages includes the name of the cost, contact or impulse items. This helps the users to debug their own code.

Additionally, the PR updates the expected warning messages in the unittest code.