### PR TITLE
Using active contact and impulses in actions + other minor improvements

### DIFF
--- a/bindings/python/crocoddyl/__init__.py
+++ b/bindings/python/crocoddyl/__init__.py
@@ -310,11 +310,11 @@ class GepettoDisplay(DisplayAbstract):
 
 
 class MeshcatDisplay(DisplayAbstract):
-    def __init__(self, robot, rate=-1, freq=1):
+    def __init__(self, robot, rate=-1, freq=1, openWindow=True):
         DisplayAbstract.__init__(self, rate, freq)
         self.robot = robot
         robot.setVisualizer(pinocchio.visualize.MeshcatVisualizer())
-        self._addRobot()
+        self._addRobot(openWindow)
 
     def display(self, xs, fs=[], ps=[], dts=[], factor=1.):
         if not dts:
@@ -326,9 +326,9 @@ class MeshcatDisplay(DisplayAbstract):
                 self.robot.display(x[:self.robot.nq])
                 time.sleep(dts[i] * factor)
 
-    def _addRobot(self):
+    def _addRobot(self, openWindow):
         # Spawn robot model
-        self.robot.initViewer(open=True)
+        self.robot.initViewer(open=openWindow)
         self.robot.loadViewerModel(rootNodeName="robot")
 
 

--- a/bindings/python/crocoddyl/__init__.py
+++ b/bindings/python/crocoddyl/__init__.py
@@ -309,6 +309,29 @@ class GepettoDisplay(DisplayAbstract):
             self.createCone(coneName, self.frictionConeScale, mu)
 
 
+class MeshcatDisplay(DisplayAbstract):
+    def __init__(self, robot, rate=-1, freq=1):
+        DisplayAbstract.__init__(self, rate, freq)
+        self.robot = robot
+        robot.setVisualizer(pinocchio.visualize.MeshcatVisualizer())
+        self._addRobot()
+
+    def display(self, xs, fs=[], ps=[], dts=[], factor=1.):
+        if not dts:
+            dts = [0.] * len(xs)
+
+        S = 1 if self.rate <= 0 else max(len(xs) / self.rate, 1)
+        for i, x in enumerate(xs):
+            if not i % S:
+                self.robot.display(x[:self.robot.nq])
+                time.sleep(dts[i] * factor)
+
+    def _addRobot(self):
+        # Spawn robot model
+        self.robot.initViewer(open=True)
+        self.robot.loadViewerModel(rootNodeName="robot")
+
+
 class CallbackDisplay(libcrocoddyl_pywrap.CallbackAbstract):
     def __init__(self, display):
         libcrocoddyl_pywrap.CallbackAbstract.__init__(self)

--- a/bindings/python/crocoddyl/__init__.py
+++ b/bindings/python/crocoddyl/__init__.py
@@ -162,6 +162,8 @@ class GepettoDisplay(DisplayAbstract):
             libcrocoddyl_pywrap.switchToNumpyMatrix()
 
     def getForceTrajectoryFromSolver(self, solver):
+        if len(self.frameTrajNames) == 0:
+            return None
         fs = []
         models = solver.problem.runningModels + [solver.problem.terminalModel]
         datas = solver.problem.runningDatas + [solver.problem.terminalData]
@@ -201,6 +203,8 @@ class GepettoDisplay(DisplayAbstract):
         return fs
 
     def getFrameTrajectoryFromSolver(self, solver):
+        if len(self.frameTrajNames) == 0:
+            return None
         ps = {fr: [] for fr in self.frameTrajNames}
         models = solver.problem.runningModels + [solver.problem.terminalModel]
         datas = solver.problem.runningDatas + [solver.problem.terminalData]
@@ -306,7 +310,7 @@ class GepettoDisplay(DisplayAbstract):
             self.robot.viewer.gui.deleteNode(coneGroup + "/lines", "")
             self.robot.viewer.gui.deleteNode(coneGroup + "/cone", "")
             self.robot.viewer.gui.deleteNode(coneGroup, "")
-            self.createCone(coneName, self.frictionConeScale, mu)
+            self._createCone(coneName, self.frictionConeScale, mu)
 
 
 class MeshcatDisplay(DisplayAbstract):

--- a/bindings/python/crocoddyl/utils/pendulum.py
+++ b/bindings/python/crocoddyl/utils/pendulum.py
@@ -9,15 +9,15 @@ class CostModelDoublePendulum(crocoddyl.CostModelAbstract):
         crocoddyl.CostModelAbstract.__init__(self, state, activation, nu=nu)
 
     def calc(self, data, x, u):
-        c1, c2 = np.cos(x[0, 0]), np.cos(x[1, 0])
-        s1, s2 = np.sin(x[0, 0]), np.sin(x[1, 0])
-        data.r = np.matrix([s1, s2, 1 - c1, 1 - c2, x[2, 0], x[3, 0]]).T
+        c1, c2 = np.cos(x[0]), np.cos(x[1])
+        s1, s2 = np.sin(x[0]), np.sin(x[1])
+        data.r = np.array([s1, s2, 1 - c1, 1 - c2, x[2], x[3]])
         self.activation.calc(data.activation, data.r)
         data.cost = data.activation.a
 
     def calcDiff(self, data, x, u):
-        c1, c2 = np.cos(x[0, 0]), np.cos(x[1, 0])
-        s1, s2 = np.sin(x[0, 0]), np.sin(x[1, 0])
+        c1, c2 = np.cos(x[0]), np.cos(x[1])
+        s1, s2 = np.sin(x[0]), np.sin(x[1])
 
         self.activation.calcDiff(data.activation, data.r)
 
@@ -25,14 +25,14 @@ class CostModelDoublePendulum(crocoddyl.CostModelAbstract):
         J[:2, :2] = np.diag([c1, c2])
         J[2:4, :2] = np.diag([s1, s2])
         J[4:6, 2:4] = np.diag([1, 1])
-        data.Lx = J.T * data.activation.Ar
+        data.Lx = np.dot(J.T, data.activation.Ar)
 
         H = pinocchio.utils.zero((6, 4))
         H[:2, :2] = np.diag([c1**2 - s1**2, c2**2 - s2**2])
         H[2:4, :2] = np.diag([s1**2 + (1 - c1) * c1, s2**2 + (1 - c2) * c2])
         H[4:6, 2:4] = np.diag([1, 1])
-        Lxx = H.T * np.matrix(np.diag(data.activation.Arr)).T
-        data.Lxx = np.matrix(np.diag([Lxx[0, 0], Lxx[1, 0], Lxx[2, 0], Lxx[3, 0]]))
+        Lxx = np.dot(H.T, np.diag(data.activation.Arr))
+        data.Lxx = np.diag(Lxx)
 
 
 class ActuationModelDoublePendulum(crocoddyl.ActuationModelAbstract):
@@ -50,8 +50,7 @@ class ActuationModelDoublePendulum(crocoddyl.ActuationModelAbstract):
         data.tau = S * u
 
     def calcDiff(self, data, x, u):
-
-        S = pinocchio.utils.zero((self.nv, self.nu))
+        S = np.zeros((self.nv, self.nu))
         if self.actLink == 1:
             S[0] = 1
         else:

--- a/examples/arm_manipulation.py
+++ b/examples/arm_manipulation.py
@@ -9,8 +9,6 @@ import example_robot_data
 WITHDISPLAY = 'display' in sys.argv or 'CROCODDYL_DISPLAY' in os.environ
 WITHPLOT = 'plot' in sys.argv or 'CROCODDYL_PLOT' in os.environ
 
-crocoddyl.switchToNumpyMatrix()
-
 # In this example test, we will solve the reaching-goal task with the Talos arm.
 # For that, we use the forward dynamics (with its analytical derivatives)
 # developed inside crocoddyl; it describes inside DifferentialActionModelFullyActuated class.
@@ -31,7 +29,7 @@ terminalCostModel = crocoddyl.CostModelSum(state)
 # goal-tracking cost, state and control regularization; and one terminal-cost:
 # goal cost. First, let's create the common cost functions.
 Mref = crocoddyl.FramePlacement(robot_model.getFrameId("gripper_left_joint"),
-                                pinocchio.SE3(np.eye(3), np.matrix([[.0], [.0], [.4]])))
+                                pinocchio.SE3(np.eye(3), np.array([.0, .0, .4])))
 goalTrackingCost = crocoddyl.CostModelFramePlacement(state, Mref)
 xRegCost = crocoddyl.CostModelState(state)
 uRegCost = crocoddyl.CostModelControl(state)
@@ -49,15 +47,15 @@ actuationModel = crocoddyl.ActuationModelFull(state)
 dt = 1e-3
 runningModel = crocoddyl.IntegratedActionModelEuler(
     crocoddyl.DifferentialActionModelFreeFwdDynamics(state, actuationModel, runningCostModel), dt)
-runningModel.differential.armature = np.matrix([0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.]).T
+runningModel.differential.armature = np.array([0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.])
 terminalModel = crocoddyl.IntegratedActionModelEuler(
     crocoddyl.DifferentialActionModelFreeFwdDynamics(state, actuationModel, terminalCostModel), 0.)
-terminalModel.differential.armature = np.matrix([0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.]).T
+terminalModel.differential.armature = np.array([0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.])
 
 # For this optimal control problem, we define 250 knots (or running action
 # models) plus a terminal knot
 T = 250
-q0 = np.matrix([0.173046, 1., -0.52366, 0., 0., 0.1, -0.005]).T
+q0 = np.array([0.173046, 1., -0.52366, 0., 0., 0.1, -0.005])
 x0 = np.concatenate([q0, pinocchio.utils.zero(robot_model.nv)])
 problem = crocoddyl.ShootingProblem(x0, [runningModel] * T, terminalModel)
 

--- a/examples/bipedal_walk.py
+++ b/examples/bipedal_walk.py
@@ -11,8 +11,6 @@ from crocoddyl.utils.biped import SimpleBipedGaitProblem, plotSolution
 WITHDISPLAY = 'display' in sys.argv or 'CROCODDYL_DISPLAY' in os.environ
 WITHPLOT = 'plot' in sys.argv or 'CROCODDYL_PLOT' in os.environ
 
-crocoddyl.switchToNumpyMatrix()
-
 # Creating the lower-body part of Talos
 talos_legs = example_robot_data.loadTalosLegs()
 

--- a/examples/bipedal_walk_ubound.py
+++ b/examples/bipedal_walk_ubound.py
@@ -11,8 +11,6 @@ from crocoddyl.utils.biped import SimpleBipedGaitProblem, plotSolution
 WITHDISPLAY = 'display' in sys.argv or 'CROCODDYL_DISPLAY' in os.environ
 WITHPLOT = 'plot' in sys.argv or 'CROCODDYL_PLOT' in os.environ
 
-crocoddyl.switchToNumpyMatrix()
-
 # Creating the lower-body part of Talos
 talos_legs = example_robot_data.loadTalosLegs()
 lims = talos_legs.model.effortLimit

--- a/examples/boxfddp_vs_boxddp.py
+++ b/examples/boxfddp_vs_boxddp.py
@@ -11,8 +11,6 @@ from crocoddyl.utils.quadruped import SimpleQuadrupedalGaitProblem, plotSolution
 WITHDISPLAY = 'display' in sys.argv or 'CROCODDYL_DISPLAY' in os.environ
 WITHPLOT = 'plot' in sys.argv or 'CROCODDYL_PLOT' in os.environ
 
-crocoddyl.switchToNumpyMatrix()
-
 # Loading the anymal model
 anymal = example_robot_data.loadANYmal()
 lims = anymal.model.effortLimit

--- a/examples/double_pendulum.py
+++ b/examples/double_pendulum.py
@@ -9,8 +9,6 @@ from crocoddyl.utils.pendulum import CostModelDoublePendulum, ActuationModelDoub
 WITHDISPLAY = 'display' in sys.argv or 'CROCODDYL_DISPLAY' in os.environ
 WITHPLOT = 'plot' in sys.argv or 'CROCODDYL_PLOT' in os.environ
 
-crocoddyl.switchToNumpyMatrix()
-
 # Loading the double pendulum model
 robot = example_robot_data.loadDoublePendulum()
 robot_model = robot.model
@@ -23,7 +21,7 @@ runningCostModel = crocoddyl.CostModelSum(state, actModel.nu)
 terminalCostModel = crocoddyl.CostModelSum(state, actModel.nu)
 xRegCost = crocoddyl.CostModelState(state, crocoddyl.ActivationModelQuad(state.ndx), state.zero(), actModel.nu)
 uRegCost = crocoddyl.CostModelControl(state, crocoddyl.ActivationModelQuad(1), actModel.nu)
-xPendCost = CostModelDoublePendulum(state, crocoddyl.ActivationModelWeightedQuad(np.matrix(weights).T), actModel.nu)
+xPendCost = CostModelDoublePendulum(state, crocoddyl.ActivationModelWeightedQuad(weights), actModel.nu)
 
 dt = 1e-2
 
@@ -38,8 +36,8 @@ terminalModel = crocoddyl.IntegratedActionModelEuler(
 
 # Creating the shooting problem and the FDDP solver
 T = 100
-x0 = [3.14, 0, 0., 0.]
-problem = crocoddyl.ShootingProblem(np.matrix(x0).T, [runningModel] * T, terminalModel)
+x0 = np.array([3.14, 0, 0., 0.])
+problem = crocoddyl.ShootingProblem(x0, [runningModel] * T, terminalModel)
 fddp = crocoddyl.SolverFDDP(problem)
 
 cameraTF = [1.4, 0., 0.2, 0.5, 0.5, 0.5, 0.5]

--- a/examples/humanoid_manipulation_ubound.py
+++ b/examples/humanoid_manipulation_ubound.py
@@ -10,8 +10,6 @@ import pinocchio
 WITHDISPLAY = 'display' in sys.argv or 'CROCODDYL_DISPLAY' in os.environ
 WITHPLOT = 'plot' in sys.argv or 'CROCODDYL_PLOT' in os.environ
 
-crocoddyl.switchToNumpyMatrix()
-
 # Load robot
 robot = example_robot_data.loadTalos()
 rmodel = robot.model
@@ -37,7 +35,7 @@ endEffectorId = rmodel.getFrameId(endEffector)
 rightFootId = rmodel.getFrameId(rightFoot)
 leftFootId = rmodel.getFrameId(leftFoot)
 q0 = rmodel.referenceConfigurations["half_sitting"]
-rmodel.defaultState = np.concatenate([q0, np.zeros((rmodel.nv, 1))])
+rmodel.defaultState = np.concatenate([q0, np.zeros(rmodel.nv)])
 pinocchio.forwardKinematics(rmodel, rdata, q0)
 pinocchio.updateFramePlacements(rmodel, rdata)
 rfPos0 = rdata.oMf[rightFootId].translation
@@ -55,24 +53,24 @@ if WITHDISPLAY:
 # Add contact to the model
 contactModel = crocoddyl.ContactModelMultiple(state, actuation.nu)
 framePlacementLeft = crocoddyl.FramePlacement(leftFootId, pinocchio.SE3.Identity())
-supportContactModelLeft = crocoddyl.ContactModel6D(state, framePlacementLeft, actuation.nu, np.matrix([0, 0]).T)
+supportContactModelLeft = crocoddyl.ContactModel6D(state, framePlacementLeft, actuation.nu, np.array([0, 0]))
 contactModel.addContact(leftFoot + "_contact", supportContactModelLeft)
 framePlacementRight = crocoddyl.FramePlacement(rightFootId, pinocchio.SE3.Identity())
-supportContactModelRight = crocoddyl.ContactModel6D(state, framePlacementRight, actuation.nu, np.matrix([0, 0]).T)
+supportContactModelRight = crocoddyl.ContactModel6D(state, framePlacementRight, actuation.nu, np.array([0, 0]))
 contactModel.addContact(rightFoot + "_contact", supportContactModelRight)
 contactData = contactModel.createData(rdata)
 
 # Cost for self-collision
 maxfloat = sys.float_info.max
-xlb = np.vstack([
-    -maxfloat * np.matrix(np.ones((6, 1))),  # dimension of the SE(3) manifold
+xlb = np.concatenate([
+    -maxfloat * np.ones(6),  # dimension of the SE(3) manifold
     rmodel.lowerPositionLimit[7:],
-    -maxfloat * np.matrix(np.ones((state.nv, 1)))
+    -maxfloat * np.ones(state.nv)
 ])
-xub = np.vstack([
-    maxfloat * np.matrix(np.ones((6, 1))),  # dimension of the SE(3) manifold
+xub = np.concatenate([
+    maxfloat * np.ones(6),  # dimension of the SE(3) manifold
     rmodel.upperPositionLimit[7:],
-    maxfloat * np.matrix(np.ones((state.nv, 1)))
+    maxfloat * np.ones(state.nv)
 ])
 bounds = crocoddyl.ActivationBounds(xlb, xub, 1.)
 limitCost = crocoddyl.CostModelState(state, crocoddyl.ActivationModelQuadraticBarrier(bounds), rmodel.defaultState,
@@ -81,19 +79,20 @@ limitCost = crocoddyl.CostModelState(state, crocoddyl.ActivationModelQuadraticBa
 # Cost for state and control
 stateWeights = np.array([0] * 3 + [10.] * 3 + [0.01] * (state.nv - 6) + [10] * state.nv)
 stateWeightsTerm = np.array([0] * 3 + [10.] * 3 + [0.01] * (state.nv - 6) + [100] * state.nv)
-xRegCost = crocoddyl.CostModelState(state, crocoddyl.ActivationModelWeightedQuad(np.matrix(stateWeights**2).T),
-                                    rmodel.defaultState, actuation.nu)
+xRegCost = crocoddyl.CostModelState(state, crocoddyl.ActivationModelWeightedQuad(stateWeights**2), rmodel.defaultState,
+                                    actuation.nu)
 uRegCost = crocoddyl.CostModelControl(state, actuation.nu)
-xRegTermCost = crocoddyl.CostModelState(state, crocoddyl.ActivationModelWeightedQuad(np.matrix(stateWeightsTerm**2).T),
+xRegTermCost = crocoddyl.CostModelState(state, crocoddyl.ActivationModelWeightedQuad(stateWeightsTerm**2),
                                         rmodel.defaultState, actuation.nu)
 
 # Cost for target reaching
 goaltrackingWeights = np.array([1] * 3 + [0.0001] * 3)
 framePoseEff = pinocchio.SE3.Identity()
-framePoseEff.translation = np.matrix(target).T
+framePoseEff.translation = target
 Pref = crocoddyl.FramePlacement(endEffectorId, framePoseEff)
-goalTrackingCost = crocoddyl.CostModelFramePlacement(
-    state, crocoddyl.ActivationModelWeightedQuad(np.matrix(goaltrackingWeights**2).T), Pref, actuation.nu)
+goalTrackingCost = crocoddyl.CostModelFramePlacement(state,
+                                                     crocoddyl.ActivationModelWeightedQuad(goaltrackingWeights**2),
+                                                     Pref, actuation.nu)
 
 # Cost for CoM reference
 comTrack = crocoddyl.CostModelCoMPosition(state, comRef, actuation.nu)

--- a/examples/humanoid_taichi.py
+++ b/examples/humanoid_taichi.py
@@ -10,8 +10,6 @@ import pinocchio
 WITHDISPLAY = 'display' in sys.argv or 'CROCODDYL_DISPLAY' in os.environ
 WITHPLOT = 'plot' in sys.argv or 'CROCODDYL_PLOT' in os.environ
 
-crocoddyl.switchToNumpyMatrix()
-
 # Load robot
 robot = example_robot_data.loadTalos()
 rmodel = robot.model
@@ -37,7 +35,7 @@ endEffectorId = rmodel.getFrameId(endEffector)
 rightFootId = rmodel.getFrameId(rightFoot)
 leftFootId = rmodel.getFrameId(leftFoot)
 q0 = rmodel.referenceConfigurations["half_sitting"]
-rmodel.defaultState = np.concatenate([q0, np.zeros((rmodel.nv, 1))])
+rmodel.defaultState = np.concatenate([q0, np.zeros(rmodel.nv)])
 pinocchio.forwardKinematics(rmodel, rdata, q0)
 pinocchio.updateFramePlacements(rmodel, rdata)
 rfPos0 = rdata.oMf[rightFootId].translation
@@ -57,23 +55,23 @@ contactModel1Foot = crocoddyl.ContactModelMultiple(state, actuation.nu)
 contactModel2Feet = crocoddyl.ContactModelMultiple(state, actuation.nu)
 framePlacementLeft = crocoddyl.FramePlacement(leftFootId, pinocchio.SE3.Identity())
 framePlacementRight = crocoddyl.FramePlacement(rightFootId, pinocchio.SE3.Identity())
-supportContactModelLeft = crocoddyl.ContactModel6D(state, framePlacementLeft, actuation.nu, np.matrix([0, 40]).T)
-supportContactModelRight = crocoddyl.ContactModel6D(state, framePlacementRight, actuation.nu, np.matrix([0, 40]).T)
+supportContactModelLeft = crocoddyl.ContactModel6D(state, framePlacementLeft, actuation.nu, np.array([0, 40]))
+supportContactModelRight = crocoddyl.ContactModel6D(state, framePlacementRight, actuation.nu, np.array([0, 40]))
 contactModel1Foot.addContact(rightFoot + "_contact", supportContactModelRight)
 contactModel2Feet.addContact(leftFoot + "_contact", supportContactModelLeft)
 contactModel2Feet.addContact(rightFoot + "_contact", supportContactModelRight)
 
 # Cost for self-collision
 maxfloat = sys.float_info.max
-xlb = np.vstack([
-    -maxfloat * np.matrix(np.ones((6, 1))),  # dimension of the SE(3) manifold
+xlb = np.concatenate([
+    -maxfloat * np.ones(6),  # dimension of the SE(3) manifold
     rmodel.lowerPositionLimit[7:],
-    -maxfloat * np.matrix(np.ones((state.nv, 1)))
+    -maxfloat * np.ones(state.nv)
 ])
-xub = np.vstack([
-    maxfloat * np.matrix(np.ones((6, 1))),  # dimension of the SE(3) manifold
+xub = np.concatenate([
+    maxfloat * np.ones(6),  # dimension of the SE(3) manifold
     rmodel.upperPositionLimit[7:],
-    maxfloat * np.matrix(np.ones((state.nv, 1)))
+    maxfloat * np.ones(state.nv)
 ])
 bounds = crocoddyl.ActivationBounds(xlb, xub, 1.)
 limitCost = crocoddyl.CostModelState(state, crocoddyl.ActivationModelQuadraticBarrier(bounds), rmodel.defaultState,
@@ -82,25 +80,28 @@ limitCost = crocoddyl.CostModelState(state, crocoddyl.ActivationModelQuadraticBa
 # Cost for state and control
 stateWeights = np.array([0] * 3 + [10.] * 3 + [0.01] * (state.nv - 6) + [10] * state.nv)
 stateWeightsTerm = np.array([0] * 3 + [10.] * 3 + [0.01] * (state.nv - 6) + [100] * state.nv)
-xRegCost = crocoddyl.CostModelState(state, crocoddyl.ActivationModelWeightedQuad(np.matrix(stateWeights**2).T),
-                                    rmodel.defaultState, actuation.nu)
+xRegCost = crocoddyl.CostModelState(state, crocoddyl.ActivationModelWeightedQuad(stateWeights**2), rmodel.defaultState,
+                                    actuation.nu)
 uRegCost = crocoddyl.CostModelControl(state, actuation.nu)
-xRegTermCost = crocoddyl.CostModelState(state, crocoddyl.ActivationModelWeightedQuad(np.matrix(stateWeightsTerm**2).T),
+xRegTermCost = crocoddyl.CostModelState(state, crocoddyl.ActivationModelWeightedQuad(stateWeightsTerm**2),
                                         rmodel.defaultState, actuation.nu)
 
 # Cost for target reaching: hand and foot
 handTrackingWeights = np.array([1] * 3 + [0.0001] * 3)
-Pref = crocoddyl.FramePlacement(endEffectorId, pinocchio.SE3(np.eye(3), np.matrix(target).T))
-handTrackingCost = crocoddyl.CostModelFramePlacement(
-    state, crocoddyl.ActivationModelWeightedQuad(np.matrix(handTrackingWeights**2).T), Pref, actuation.nu)
+Pref = crocoddyl.FramePlacement(endEffectorId, pinocchio.SE3(np.eye(3), target))
+handTrackingCost = crocoddyl.CostModelFramePlacement(state,
+                                                     crocoddyl.ActivationModelWeightedQuad(handTrackingWeights**2),
+                                                     Pref, actuation.nu)
 
 footTrackingWeights = np.array([1, 1, 0.1] + [1.] * 3)
-Pref = crocoddyl.FramePlacement(leftFootId, pinocchio.SE3(np.eye(3), np.matrix([0., 0.4, 0.]).T))
-footTrackingCost1 = crocoddyl.CostModelFramePlacement(
-    state, crocoddyl.ActivationModelWeightedQuad(np.matrix(footTrackingWeights**2).T), Pref, actuation.nu)
-Pref = crocoddyl.FramePlacement(leftFootId, pinocchio.SE3(np.eye(3), np.matrix([0.3, 0.15, 0.35]).T))
-footTrackingCost2 = crocoddyl.CostModelFramePlacement(
-    state, crocoddyl.ActivationModelWeightedQuad(np.matrix(footTrackingWeights**2).T), Pref, actuation.nu)
+Pref = crocoddyl.FramePlacement(leftFootId, pinocchio.SE3(np.eye(3), np.array([0., 0.4, 0.])))
+footTrackingCost1 = crocoddyl.CostModelFramePlacement(state,
+                                                      crocoddyl.ActivationModelWeightedQuad(footTrackingWeights**2),
+                                                      Pref, actuation.nu)
+Pref = crocoddyl.FramePlacement(leftFootId, pinocchio.SE3(np.eye(3), np.array([0.3, 0.15, 0.35])))
+footTrackingCost2 = crocoddyl.CostModelFramePlacement(state,
+                                                      crocoddyl.ActivationModelWeightedQuad(footTrackingWeights**2),
+                                                      Pref, actuation.nu)
 
 # Cost for CoM reference
 comTrack = crocoddyl.CostModelCoMPosition(state, comRef, actuation.nu)

--- a/examples/notebooks/arm_manipulation.ipynb
+++ b/examples/notebooks/arm_manipulation.ipynb
@@ -22,8 +22,6 @@
     "import numpy as np\n",
     "import example_robot_data\n",
     "\n",
-    "crocoddyl.switchToNumpyMatrix()\n",
-    "\n",
     "robot = example_robot_data.loadTalosArm()\n",
     "robot_model = robot.model\n",
     "\n",
@@ -37,7 +35,7 @@
     "display.robot.viewer.gui.refresh()\n",
     "\n",
     "# Create the cost functions\n",
-    "Mref = crocoddyl.FrameTranslation(robot_model.getFrameId(\"gripper_left_joint\"), np.matrix(target).T)\n",
+    "Mref = crocoddyl.FrameTranslation(robot_model.getFrameId(\"gripper_left_joint\"), target)\n",
     "state = crocoddyl.StateMultibody(robot.model)\n",
     "goalTrackingCost = crocoddyl.CostModelFrameTranslation(state, Mref)\n",
     "xRegCost = crocoddyl.CostModelState(state)\n",
@@ -63,11 +61,11 @@
     "    crocoddyl.DifferentialActionModelFreeFwdDynamics(state, actuationModel, runningCostModel), DT)\n",
     "terminalModel = crocoddyl.IntegratedActionModelEuler(\n",
     "    crocoddyl.DifferentialActionModelFreeFwdDynamics(state, actuationModel, terminalCostModel))\n",
-    "#runningModel.differential.armature = 0.2 * np.matrix(np.ones(state.nv)).T\n",
-    "#terminalModel.differential.armature = 0.2 * np.matrix(np.ones(state.nv)).T\n",
+    "#runningModel.differential.armature = 0.2 * np.ones(state.nv)\n",
+    "#terminalModel.differential.armature = 0.2 * np.ones(state.nv)\n",
     "\n",
     "# Create the problem\n",
-    "q0 = np.matrix([2., 1.5, -2., 0., 0., 0., 0.]).T\n",
+    "q0 = np.array([2., 1.5, -2., 0., 0., 0., 0.])\n",
     "x0 = np.concatenate([q0, pinocchio.utils.zero(state.nv)])\n",
     "problem = crocoddyl.ShootingProblem(x0, [runningModel] * T, terminalModel)\n",
     "\n",
@@ -117,7 +115,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "trackData = goalTrackingCost.createData(robot.data)"
+    "dataCollector = crocoddyl.DataCollectorMultibody(robot.data)\n",
+    "trackData = goalTrackingCost.createData(dataCollector)"
    ]
   },
   {
@@ -137,7 +136,7 @@
    "source": [
     "pinocchio.updateFramePlacements(robot.model, robot.data)\n",
     "pinocchio.computeJointJacobians(robot.model, robot.data, xT[:state.nq])\n",
-    "goalTrackingCost.calc(trackData, x0)\n",    
+    "goalTrackingCost.calc(trackData, x0)\n",
     "goalTrackingCost.calcDiff(trackData, x0)\n",
     "print(trackData.Lx, trackData.Lu)"
    ]

--- a/examples/notebooks/bipedal_walking.ipynb
+++ b/examples/notebooks/bipedal_walking.ipynb
@@ -99,7 +99,7 @@
     "\n",
     "# Using the meshcat displayer, you could enable gepetto viewer for nicer view\n",
     "# display = crocoddyl.GepettoDisplay(talos_legs, 4, 4, frameNames=[rightFoot, leftFoot])\n",
-    "display = crocoddyl.MeshcatDisplay(talos_legs, 4, 4)\n",
+    "display = crocoddyl.MeshcatDisplay(talos_legs, 4, 4, False)\n",
     "ddp.setCallbacks([crocoddyl.CallbackLogger(),\n",
     "                  crocoddyl.CallbackVerbose(),\n",
     "                  crocoddyl.CallbackDisplay(display)])"

--- a/examples/notebooks/bipedal_walking.ipynb
+++ b/examples/notebooks/bipedal_walking.ipynb
@@ -70,8 +70,6 @@
     "import example_robot_data\n",
     "from crocoddyl.utils.biped import SimpleBipedGaitProblem\n",
     "\n",
-    "crocoddyl.switchToNumpyMatrix()\n",
-    "\n",
     "# Creating the lower-body part of Talos\n",
     "talos_legs = example_robot_data.loadTalosLegs()\n",
     "\n",

--- a/examples/notebooks/bipedal_walking.ipynb
+++ b/examples/notebooks/bipedal_walking.ipynb
@@ -96,11 +96,32 @@
     "\n",
     "# Solving the 3d walking problem using Feasibility-prone DDP\n",
     "ddp = crocoddyl.SolverFDDP(problem)\n",
-    "display = crocoddyl.GepettoDisplay(talos_legs, 4, 4, frameNames=[rightFoot, leftFoot])\n",
-    "cameraTF = [3., 3.68, 0.84, 0.2, 0.62, 0.72, 0.22]\n",
+    "\n",
+    "# Using the meshcat displayer, you could enable gepetto viewer for nicer view\n",
+    "# display = crocoddyl.GepettoDisplay(talos_legs, 4, 4, frameNames=[rightFoot, leftFoot])\n",
+    "display = crocoddyl.MeshcatDisplay(talos_legs, 4, 4)\n",
     "ddp.setCallbacks([crocoddyl.CallbackLogger(),\n",
     "                  crocoddyl.CallbackVerbose(),\n",
-    "                  crocoddyl.CallbackDisplay(display)])\n",
+    "                  crocoddyl.CallbackDisplay(display)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Emdebbed meshcat in this cell\n",
+    "display.robot.viewer.jupyter_cell()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Solve the optimal control problem\n",
     "ddp.th_stop = 1e-9\n",
     "init_xs = [talos_legs.model.defaultState] * (problem.T + 1)\n",
     "init_us = []\n",

--- a/examples/notebooks/introduction_to_crocoddyl.ipynb
+++ b/examples/notebooks/introduction_to_crocoddyl.ipynb
@@ -149,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -184,7 +184,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -303,7 +303,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -345,7 +345,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -369,15 +369,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "You can open the visualizer by visiting the following URL:\n",
+      "http://127.0.0.1:7000/static/\n",
+      "\n",
+      "The reached pose by the wrist is\n",
+      "  R =\n",
+      " 0.0787688   0.193091   0.978014\n",
+      " -0.861896   0.506167 -0.0305164\n",
+      "  -0.50093  -0.840542   0.206294\n",
+      "  p =     0.384402 -0.000716569     0.398766\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "# Creating the DDP solver for this OC problem, defining a logger\n",
     "ddp = crocoddyl.SolverDDP(problem)\n",
-    "cameraTF = [2., 2.68, 0.54, 0.2, 0.62, 0.72, 0.22]\n",
     "log = crocoddyl.CallbackLogger()\n",
-    "display = crocoddyl.GepettoDisplay(talos_arm, 4, 4, cameraTF)\n",
+    "\n",
+    "# Using the meshcat displayer, you could enable gepetto viewer for nicer view\n",
+    "# display = crocoddyl.GepettoDisplay(talos_arm, 4, 4)\n",
+    "display = crocoddyl.MeshcatDisplay(talos_arm, 4, 4)\n",
     "ddp.setCallbacks([log,\n",
     "                  crocoddyl.CallbackVerbose(),\n",
     "                  crocoddyl.CallbackDisplay(display)])\n",

--- a/examples/notebooks/introduction_to_crocoddyl.ipynb
+++ b/examples/notebooks/introduction_to_crocoddyl.ipynb
@@ -157,14 +157,12 @@
     "import numpy as np\n",
     "import example_robot_data\n",
     "\n",
-    "crocoddyl.switchToNumpyMatrix()\n",
-    "\n",
     "talos_arm = example_robot_data.loadTalosArm()\n",
     "robot_model = talos_arm.model # getting the Pinocchio model\n",
     "\n",
     "# Defining a initial state\n",
-    "q0 = np.matrix([0.173046, 1., -0.52366, 0., 0., 0.1, -0.005]).T\n",
-    "x0 = np.vstack([q0, np.matrix(np.zeros(talos_arm.model.nv)).T])"
+    "q0 = np.array([0.173046, 1., -0.52366, 0., 0., 0.1, -0.005])\n",
+    "x0 = np.concatenate([q0, np.zeros(talos_arm.model.nv)])"
    ]
   },
   {
@@ -198,7 +196,7 @@
     "        crocoddyl.DifferentialActionModelAbstract.__init__(self, state, state.nv, costModel.nr)\n",
     "        self.costs = costModel\n",
     "        self.enable_force = True\n",
-    "        self.armature = np.matrix(np.zeros(0))\n",
+    "        self.armature = np.zeros(0)\n",
     "\n",
     "    def calc(self, data, x, u=None):\n",
     "        if u is None:\n",
@@ -311,7 +309,7 @@
    "source": [
     "# Create the cost functions\n",
     "target = np.array([0.4, 0., .4])\n",
-    "Mref = crocoddyl.FrameTranslation(robot_model.getFrameId(\"gripper_left_joint\"), np.matrix(target).T)\n",
+    "Mref = crocoddyl.FrameTranslation(robot_model.getFrameId(\"gripper_left_joint\"), target)\n",
     "state = crocoddyl.StateMultibody(robot_model)\n",
     "goalTrackingCost = crocoddyl.CostModelFrameTranslation(state, Mref)\n",
     "xRegCost = crocoddyl.CostModelState(state)\n",

--- a/examples/notebooks/introduction_to_crocoddyl.ipynb
+++ b/examples/notebooks/introduction_to_crocoddyl.ipynb
@@ -396,7 +396,7 @@
     "\n",
     "# Using the meshcat displayer, you could enable gepetto viewer for nicer view\n",
     "# display = crocoddyl.GepettoDisplay(talos_arm, 4, 4)\n",
-    "display = crocoddyl.MeshcatDisplay(talos_arm, 4, 4)\n",
+    "display = crocoddyl.MeshcatDisplay(talos_arm, 4, 4, False)\n",
     "ddp.setCallbacks([log,\n",
     "                  crocoddyl.CallbackVerbose(),\n",
     "                  crocoddyl.CallbackDisplay(display)])\n",

--- a/examples/quadrotor_ubound.py
+++ b/examples/quadrotor_ubound.py
@@ -9,8 +9,6 @@ import example_robot_data
 WITHDISPLAY = 'display' in sys.argv or 'CROCODDYL_DISPLAY' in os.environ
 WITHPLOT = 'plot' in sys.argv or 'CROCODDYL_PLOT' in os.environ
 
-crocoddyl.switchToNumpyMatrix()
-
 hector = example_robot_data.loadHector()
 robot_model = hector.model
 
@@ -23,8 +21,8 @@ cf = 6.6e-5
 cm = 1e-6
 u_lim = 5
 l_lim = 0.1
-tau_f = np.matrix([[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [1.0, 1.0, 1.0, 1.0], [0.0, d_cog, 0.0, -d_cog],
-                   [-d_cog, 0.0, d_cog, 0.0], [-cm / cf, cm / cf, -cm / cf, cm / cf]])
+tau_f = np.array([[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [1.0, 1.0, 1.0, 1.0], [0.0, d_cog, 0.0, -d_cog],
+                  [-d_cog, 0.0, d_cog, 0.0], [-cm / cf, cm / cf, -cm / cf, cm / cf]])
 
 actModel = crocoddyl.ActuationModelMultiCopterBase(state, 4, tau_f)
 
@@ -32,11 +30,9 @@ runningCostModel = crocoddyl.CostModelSum(state, actModel.nu)
 terminalCostModel = crocoddyl.CostModelSum(state, actModel.nu)
 
 # Needed objects to create the costs
-Mref = crocoddyl.FramePlacement(robot_model.getFrameId("base_link"),
-                                pinocchio.SE3(target_quat.matrix(),
-                                              np.matrix(target_pos).T))
-wBasePos, wBaseOri, wBaseVel, wBaseRate = [0.1], [1000], [1000], [10]
-stateWeights = np.matrix([wBasePos * 3 + wBaseOri * 3 + wBaseVel * robot_model.nv]).T
+Mref = crocoddyl.FramePlacement(robot_model.getFrameId("base_link"), pinocchio.SE3(target_quat.matrix(), target_pos))
+wBasePos, wBaseOri, wBaseVel = 0.1, 1000, 1000
+stateWeights = np.array([wBasePos] * 3 + [wBaseOri] * 3 + [wBaseVel] * robot_model.nv)
 
 # Costs
 goalTrackingCost = crocoddyl.CostModelFramePlacement(state, Mref, actModel.nu)
@@ -53,13 +49,12 @@ runningModel = crocoddyl.IntegratedActionModelEuler(
     crocoddyl.DifferentialActionModelFreeFwdDynamics(state, actModel, runningCostModel), dt)
 terminalModel = crocoddyl.IntegratedActionModelEuler(
     crocoddyl.DifferentialActionModelFreeFwdDynamics(state, actModel, terminalCostModel), dt)
-runningModel.u_lb = np.matrix([l_lim, l_lim, l_lim, l_lim]).T
-runningModel.u_ub = np.matrix([u_lim, u_lim, u_lim, u_lim]).T
+runningModel.u_lb = np.array([l_lim, l_lim, l_lim, l_lim])
+runningModel.u_ub = np.array([u_lim, u_lim, u_lim, u_lim])
 
 # Creating the shooting problem and the boxddp solver
 T = 33
-problem = crocoddyl.ShootingProblem(np.vstack([hector.q0, pinocchio.utils.zero((state.nv))]), [runningModel] * T,
-                                    terminalModel)
+problem = crocoddyl.ShootingProblem(np.concatenate([hector.q0, np.zeros(state.nv)]), [runningModel] * T, terminalModel)
 boxddp = crocoddyl.SolverBoxDDP(problem)
 boxddp.setCallbacks([crocoddyl.CallbackLogger(), crocoddyl.CallbackVerbose()])
 

--- a/examples/quadrupedal_gaits.py
+++ b/examples/quadrupedal_gaits.py
@@ -11,8 +11,6 @@ from crocoddyl.utils.quadruped import SimpleQuadrupedalGaitProblem, plotSolution
 WITHDISPLAY = 'display' in sys.argv or 'CROCODDYL_DISPLAY' in os.environ
 WITHPLOT = 'plot' in sys.argv or 'CROCODDYL_PLOT' in os.environ
 
-crocoddyl.switchToNumpyMatrix()
-
 # Loading the anymal model
 anymal = example_robot_data.loadANYmal()
 

--- a/examples/quadrupedal_walk_ubound.py
+++ b/examples/quadrupedal_walk_ubound.py
@@ -14,8 +14,6 @@ from crocoddyl.utils.quadruped import SimpleQuadrupedalGaitProblem, plotSolution
 WITHDISPLAY = 'display' in sys.argv or 'CROCODDYL_DISPLAY' in os.environ
 WITHPLOT = 'plot' in sys.argv or 'CROCODDYL_PLOT' in os.environ
 
-crocoddyl.switchToNumpyMatrix()
-
 # Loading the anymal model
 anymal = example_robot_data.loadANYmal()
 robot_model = anymal.model

--- a/include/crocoddyl/multibody/actions/contact-fwddyn.hxx
+++ b/include/crocoddyl/multibody/actions/contact-fwddyn.hxx
@@ -66,6 +66,7 @@ void DifferentialActionModelContactFwdDynamicsTpl<Scalar>::calc(
                  << "u has wrong dimension (it should be " + std::to_string(nu_) + ")");
   }
 
+  const std::size_t& nc = contacts_->get_nc();
   DifferentialActionDataContactFwdDynamicsTpl<Scalar>* d =
       static_cast<DifferentialActionDataContactFwdDynamicsTpl<Scalar>*>(data.get());
   const Eigen::VectorBlock<const Eigen::Ref<const VectorXs>, Eigen::Dynamic> q = x.head(state_->get_nq());
@@ -82,15 +83,16 @@ void DifferentialActionModelContactFwdDynamicsTpl<Scalar>::calc(
   contacts_->calc(d->multibody.contacts, x);
 
 #ifndef NDEBUG
-  Eigen::FullPivLU<MatrixXs> Jc_lu(d->multibody.contacts->Jc);
+  Eigen::FullPivLU<MatrixXs> Jc_lu(d->multibody.contacts->Jc.topRows(nc));
 
-  if (Jc_lu.rank() < d->multibody.contacts->Jc.rows()) {
+  if (Jc_lu.rank() < d->multibody.contacts->Jc.topRows(nc).rows()) {
     assert_pretty(JMinvJt_damping_ > 0., "A damping factor is needed as the contact Jacobian is not full-rank");
   }
 #endif
 
-  pinocchio::forwardDynamics(pinocchio_, d->pinocchio, d->multibody.actuation->tau, d->multibody.contacts->Jc,
-                             d->multibody.contacts->a0, JMinvJt_damping_);
+  pinocchio::forwardDynamics(pinocchio_, d->pinocchio, d->multibody.actuation->tau,
+                             d->multibody.contacts->Jc.topRows(nc), d->multibody.contacts->a0.head(nc),
+                             JMinvJt_damping_);
   d->xout = d->pinocchio.ddq;
   contacts_->updateAcceleration(d->multibody.contacts, d->pinocchio.ddq);
   contacts_->updateForce(d->multibody.contacts, d->pinocchio.lambda_c);
@@ -123,7 +125,8 @@ void DifferentialActionModelContactFwdDynamicsTpl<Scalar>::calcDiff(
 
   // Computing the dynamics derivatives
   pinocchio::computeRNEADerivatives(pinocchio_, d->pinocchio, q, v, d->xout, d->multibody.contacts->fext);
-  pinocchio::getKKTContactDynamicMatrixInverse(pinocchio_, d->pinocchio, d->multibody.contacts->Jc, d->Kinv);
+  pinocchio::getKKTContactDynamicMatrixInverse(pinocchio_, d->pinocchio, d->multibody.contacts->Jc.topRows(nc),
+                                               d->Kinv);
 
   actuation_->calcDiff(d->multibody.actuation, x, u);
   contacts_->calcDiff(d->multibody.contacts, x);
@@ -135,7 +138,7 @@ void DifferentialActionModelContactFwdDynamicsTpl<Scalar>::calcDiff(
 
   d->Fx.leftCols(nv).noalias() = -a_partial_dtau * d->pinocchio.dtau_dq;
   d->Fx.rightCols(nv).noalias() = -a_partial_dtau * d->pinocchio.dtau_dv;
-  d->Fx.noalias() -= a_partial_da * d->multibody.contacts->da0_dx;
+  d->Fx.noalias() -= a_partial_da * d->multibody.contacts->da0_dx.topRows(nc);
   d->Fx.noalias() += a_partial_dtau * d->multibody.actuation->dtau_dx;
   d->Fu.noalias() = a_partial_dtau * d->multibody.actuation->dtau_du;
 
@@ -143,7 +146,7 @@ void DifferentialActionModelContactFwdDynamicsTpl<Scalar>::calcDiff(
   if (enable_force_) {
     d->df_dx.leftCols(nv).noalias() = f_partial_dtau * d->pinocchio.dtau_dq;
     d->df_dx.rightCols(nv).noalias() = f_partial_dtau * d->pinocchio.dtau_dv;
-    d->df_dx.noalias() += f_partial_da * d->multibody.contacts->da0_dx;
+    d->df_dx.noalias() += f_partial_da * d->multibody.contacts->da0_dx.topRows(nc);
     d->df_dx.noalias() -= f_partial_dtau * d->multibody.actuation->dtau_dx;
     d->df_du.noalias() = -f_partial_dtau * d->multibody.actuation->dtau_du;
     contacts_->updateAccelerationDiff(d->multibody.contacts, d->Fx.bottomRows(nv));

--- a/include/crocoddyl/multibody/contacts/multiple-contacts.hxx
+++ b/include/crocoddyl/multibody/contacts/multiple-contacts.hxx
@@ -35,7 +35,9 @@ void ContactModelMultipleTpl<Scalar>::addContact(const std::string& name,
   } else if (active) {
     nc_ += contact->get_nc();
     nc_total_ += contact->get_nc();
-    active_.push_back(name);
+    std::vector<std::string>::iterator it =
+        std::lower_bound(active_.begin(), active_.end(), name, std::greater<std::string>());
+    active_.insert(it, name);
   } else if (!active) {
     nc_total_ += contact->get_nc();
   }
@@ -60,7 +62,9 @@ void ContactModelMultipleTpl<Scalar>::changeContactStatus(const std::string& nam
   if (it != contacts_.end()) {
     if (active && !it->second->active) {
       nc_ += it->second->contact->get_nc();
-      active_.push_back(name);
+      std::vector<std::string>::iterator it =
+          std::lower_bound(active_.begin(), active_.end(), name, std::greater<std::string>());
+      active_.insert(it, name);
     } else if (!active && it->second->active) {
       nc_ -= it->second->contact->get_nc();
       active_.erase(std::remove(active_.begin(), active_.end(), name), active_.end());

--- a/include/crocoddyl/multibody/costs/cost-sum.hxx
+++ b/include/crocoddyl/multibody/costs/cost-sum.hxx
@@ -36,7 +36,9 @@ void CostModelSumTpl<Scalar>::addCost(const std::string& name, boost::shared_ptr
   } else if (active) {
     nr_ += cost->get_activation()->get_nr();
     nr_total_ += cost->get_activation()->get_nr();
-    active_.push_back(name);
+    std::vector<std::string>::iterator it =
+        std::lower_bound(active_.begin(), active_.end(), name, std::greater<std::string>());
+    active_.insert(it, name);
   } else if (!active) {
     nr_total_ += cost->get_activation()->get_nr();
   }
@@ -61,7 +63,9 @@ void CostModelSumTpl<Scalar>::changeCostStatus(const std::string& name, bool act
   if (it != costs_.end()) {
     if (active && !it->second->active) {
       nr_ += it->second->cost->get_activation()->get_nr();
-      active_.push_back(name);
+      std::vector<std::string>::iterator it =
+          std::lower_bound(active_.begin(), active_.end(), name, std::greater<std::string>());
+      active_.insert(it, name);
     } else if (!active && it->second->active) {
       nr_ -= it->second->cost->get_activation()->get_nr();
       active_.erase(std::remove(active_.begin(), active_.end(), name), active_.end());

--- a/include/crocoddyl/multibody/impulses/multiple-impulses.hxx
+++ b/include/crocoddyl/multibody/impulses/multiple-impulses.hxx
@@ -28,7 +28,9 @@ void ImpulseModelMultipleTpl<Scalar>::addImpulse(const std::string& name,
   } else if (active) {
     ni_ += impulse->get_ni();
     ni_total_ += impulse->get_ni();
-    active_.push_back(name);
+    std::vector<std::string>::iterator it =
+        std::lower_bound(active_.begin(), active_.end(), name, std::greater<std::string>());
+    active_.insert(it, name);
   } else if (!active) {
     ni_total_ += impulse->get_ni();
   }
@@ -53,7 +55,9 @@ void ImpulseModelMultipleTpl<Scalar>::changeImpulseStatus(const std::string& nam
   if (it != impulses_.end()) {
     if (active && !it->second->active) {
       ni_ += it->second->impulse->get_ni();
-      active_.push_back(name);
+      std::vector<std::string>::iterator it =
+          std::lower_bound(active_.begin(), active_.end(), name, std::greater<std::string>());
+      active_.insert(it, name);
     } else if (!active && it->second->active) {
       ni_ -= it->second->impulse->get_ni();
       active_.erase(std::remove(active_.begin(), active_.end(), name), active_.end());


### PR DESCRIPTION
This PR parses the current active set of contacts (or impulses) to carry computations on the contact (or impulse) dynamics. This was the last piece of cake needed to follow the idea of global allocation of data.

Additionally, there are other general improvements:
 - sorted the active cost, contact and impulse vectors for easier reading.
 - used numpy array inside gepetto display for efficiency (and numpy matrix is tagged as deprecated)
 - created a display abstract for including other display methods
 - added meshcat displayer and integrated in couple of Jupyter notebooks (it needs to include force, frame trajectory and friction cone display).
 - used numpy array in all examples and notebooks.