### PR TITLE
Functionalities needed for cyclic MPC formulations

### DIFF
--- a/benchmark/arm-manipulation-codegen.cpp
+++ b/benchmark/arm-manipulation-codegen.cpp
@@ -52,8 +52,8 @@ int main(int argc, char* argv[]) {
   x0 << q0, Eigen::VectorXd::Random(state->get_nv());
 
   // Defining the shooting problem for both cases: with and without code generation
-  std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstract> > runningModels(N, runningModel);
-  std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstract> > cg_runningModels(N, cg_runningModel);
+  boost::circular_buffer<boost::shared_ptr<crocoddyl::ActionModelAbstract> > runningModels(N, runningModel);
+  boost::circular_buffer<boost::shared_ptr<crocoddyl::ActionModelAbstract> > cg_runningModels(N, cg_runningModel);
   boost::shared_ptr<crocoddyl::ShootingProblem> problem =
       boost::make_shared<crocoddyl::ShootingProblem>(x0, runningModels, terminalModel);
   boost::shared_ptr<crocoddyl::ShootingProblem> cg_problem =

--- a/benchmark/arm-manipulation-optctrl.cpp
+++ b/benchmark/arm-manipulation-optctrl.cpp
@@ -35,7 +35,7 @@ int main(int argc, char* argv[]) {
 
   // For this optimal control problem, we define 100 knots (or running action
   // models) plus a terminal knot
-  std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstract> > runningModels(N, runningModel);
+  boost::circular_buffer<boost::shared_ptr<crocoddyl::ActionModelAbstract> > runningModels(N, runningModel);
   boost::shared_ptr<crocoddyl::ShootingProblem> problem =
       boost::make_shared<crocoddyl::ShootingProblem>(x0, runningModels, terminalModel);
   std::vector<Eigen::VectorXd> xs(N + 1, x0);

--- a/benchmark/arm-manipulation-timings.cpp
+++ b/benchmark/arm-manipulation-timings.cpp
@@ -99,7 +99,7 @@ int main(int argc, char* argv[]) {
   boost::shared_ptr<crocoddyl::ActionModelAbstract> terminalModel =
       boost::make_shared<crocoddyl::IntegratedActionModelEuler>(terminalDAM, 1e-3);
 
-  std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstract> > runningModels(N, runningModel);
+  boost::circular_buffer<boost::shared_ptr<crocoddyl::ActionModelAbstract> > runningModels(N, runningModel);
 
   boost::shared_ptr<crocoddyl::ShootingProblem> problem =
       boost::make_shared<crocoddyl::ShootingProblem>(x0, runningModels, terminalModel);

--- a/benchmark/bipedal-timings.cpp
+++ b/benchmark/bipedal-timings.cpp
@@ -119,7 +119,7 @@ int main(int argc, char* argv[]) {
   boost::shared_ptr<crocoddyl::ActionModelAbstract> terminalModel =
       boost::make_shared<crocoddyl::IntegratedActionModelEuler>(terminalDAM, 1e-3);
 
-  std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstract> > runningModels(N, runningModel);
+  boost::circular_buffer<boost::shared_ptr<crocoddyl::ActionModelAbstract> > runningModels(N, runningModel);
 
   boost::shared_ptr<crocoddyl::ShootingProblem> problem =
       boost::make_shared<crocoddyl::ShootingProblem>(x0, runningModels, terminalModel);

--- a/benchmark/bipedal-with-contact-codegen.cpp
+++ b/benchmark/bipedal-with-contact-codegen.cpp
@@ -51,8 +51,8 @@ int main(int argc, char* argv[]) {
   Eigen::VectorXd x0(state->rand());
 
   // Defining the shooting problem for both cases: with and without code generation
-  std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstract> > runningModels(N, runningModel);
-  std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstract> > cg_runningModels(N, cg_runningModel);
+  boost::circular_buffer<boost::shared_ptr<crocoddyl::ActionModelAbstract> > runningModels(N, runningModel);
+  boost::circular_buffer<boost::shared_ptr<crocoddyl::ActionModelAbstract> > cg_runningModels(N, cg_runningModel);
   boost::shared_ptr<crocoddyl::ShootingProblem> problem =
       boost::make_shared<crocoddyl::ShootingProblem>(x0, runningModels, terminalModel);
   boost::shared_ptr<crocoddyl::ShootingProblem> cg_problem =

--- a/benchmark/lqr-optctrl.cpp
+++ b/benchmark/lqr-optctrl.cpp
@@ -28,7 +28,7 @@ int main(int argc, char* argv[]) {
   boost::shared_ptr<crocoddyl::ActionModelAbstract> model = boost::make_shared<crocoddyl::ActionModelLQR>(NX, NU);
   std::vector<Eigen::VectorXd> xs(N + 1, x0);
   std::vector<Eigen::VectorXd> us(N, Eigen::VectorXd::Zero(NU));
-  std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstract> > runningModels(N, model);
+  boost::circular_buffer<boost::shared_ptr<crocoddyl::ActionModelAbstract> > runningModels(N, model);
 
   // Formulating the optimal control problem
   boost::shared_ptr<crocoddyl::ShootingProblem> problem =

--- a/benchmark/unicycle-optctrl.cpp
+++ b/benchmark/unicycle-optctrl.cpp
@@ -25,7 +25,7 @@ int main(int argc, char* argv[]) {
   boost::shared_ptr<crocoddyl::ActionModelAbstract> model = boost::make_shared<crocoddyl::ActionModelUnicycle>();
   std::vector<Eigen::VectorXd> xs(N + 1, x0);
   std::vector<Eigen::VectorXd> us(N, Eigen::Vector2d::Zero());
-  std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstract> > runningModels(N, model);
+  boost::circular_buffer<boost::shared_ptr<crocoddyl::ActionModelAbstract> > runningModels(N, model);
 
   // Formulating the optimal control problem
   boost::shared_ptr<crocoddyl::ShootingProblem> problem =

--- a/bindings/python/crocoddyl/core/optctrl/shooting.cpp
+++ b/bindings/python/crocoddyl/core/optctrl/shooting.cpp
@@ -31,7 +31,7 @@ void exposeShootingProblem() {
       "ShootingProblem",
       "Declare a shooting problem.\n\n"
       "A shooting problem declares the initial state, a set of running action models and a\n"
-      "terminal action model. It has two main methods - calc, calcDiff and rollout. The\n"
+      "terminal action model. It has three main methods - calc, calcDiff and rollout. The\n"
       "first computes the set of next states and cost values per each action model. calcDiff\n"
       "updates the derivatives of all action models. The last rollouts the stacks of actions\n"
       "models.",
@@ -39,7 +39,7 @@ void exposeShootingProblem() {
                boost::shared_ptr<ActionModelAbstract> >(bp::args("self", "x0", "runningModels", "terminalModel"),
                                                         "Initialize the shooting problem and allocate its data.\n\n"
                                                         ":param x0: initial state\n"
-                                                        ":param runningModels: running action models\n"
+                                                        ":param runningModels: running action models (size T)\n"
                                                         ":param terminalModel: terminal action model"))
       .def(bp::init<Eigen::VectorXd, std::vector<boost::shared_ptr<ActionModelAbstract> >,
                     boost::shared_ptr<ActionModelAbstract>, std::vector<boost::shared_ptr<ActionDataAbstract> >,
@@ -47,27 +47,28 @@ void exposeShootingProblem() {
           bp::args("self", "x0", "runningModels", "terminalModel", "runningDatas", "terminalData"),
           "Initialize the shooting problem (models and datas).\n\n"
           ":param x0: initial state\n"
-          ":param runningModels: running action models\n"
+          ":param runningModels: running action models (size T)\n"
           ":param terminalModel: terminal action model\n"
-          ":param runningDatas: running action datas\n"
+          ":param runningDatas: running action datas  (size T)\n"
           ":param terminalData: terminal action data"))
       .def("calc", &ShootingProblem::calc, bp::args("self", "xs", "us"),
            "Compute the cost and the next states.\n\n"
-           "First, it computes the next state and cost for each action model\n"
-           "along a state and control trajectory.\n"
-           ":param xs: time-discrete state trajectory\n"
-           ":param us: time-discrete control sequence\n"
+           "For each node k, and along the state xs and control us trajectories, it computes the next state x_{k+1}\n"
+           " and cost l_k.\n"
+           ":param xs: time-discrete state trajectory (size T+1)\n"
+           ":param us: time-discrete control sequence (size T)\n"
            ":returns the total cost value")
       .def("calcDiff", &ShootingProblem::calcDiff, bp::args("self", "xs", "us"),
-           "Compute the cost-and-dynamics derivatives.\n\n"
-           "These quantities are computed along a given pair of trajectories xs\n"
-           "(states) and us (controls).\n"
-           ":param xs: time-discrete state trajectory\n"
-           ":param us: time-discrete control sequence\n")
+           "Compute the derivatives of the cost and dynamics.\n\n"
+           "For each node k, and along the state x_s and control u_s trajectories, it computes the derivatives of\n"
+           "the cost (lx, lu, lxx, lxu, luu) and dynamics (fx, fu).\n"
+           ":param xs: time-discrete state trajectory (size T+1)\n"
+           ":param us: time-discrete control sequence (size T)\n"
+           ":returns the total cost value")
       .def("rollout", &ShootingProblem::rollout_us, bp::args("self", "us"),
            "Integrate the dynamics given a control sequence.\n\n"
            "Rollout the dynamics give a sequence of control commands\n"
-           ":param us: time-discrete control sequence")
+           ":param us: time-discrete control sequence (size T)")
       .def("updateNode", &ShootingProblem::updateNode, bp::args("self", "i", "model", "data"),
            "Update the model and data for a specific node.\n\n"
            ":param i: index of the node (0 <= i <= T + 1)\n"
@@ -78,7 +79,7 @@ void exposeShootingProblem() {
            ":param i: index of the node (0 <= i <= T + 1)\n"
            ":param model: new model")
       .add_property("T", bp::make_function(&ShootingProblem::get_T, bp::return_value_policy<bp::return_by_value>()),
-                    "number of nodes")
+                    "number of running nodes")
       .add_property("x0", bp::make_function(&ShootingProblem::get_x0, bp::return_internal_reference<>()),
                     &ShootingProblem::set_x0, "initial state")
       .add_property(

--- a/bindings/python/crocoddyl/core/optctrl/shooting.cpp
+++ b/bindings/python/crocoddyl/core/optctrl/shooting.cpp
@@ -19,12 +19,12 @@ void exposeShootingProblem() {
   // Register custom converters between std::vector and Python list
   typedef boost::shared_ptr<ActionModelAbstract> ActionModelPtr;
   typedef boost::shared_ptr<ActionDataAbstract> ActionDataPtr;
-  bp::to_python_converter<std::vector<ActionModelPtr, std::allocator<ActionModelPtr> >,
-                          vector_to_list<ActionModelPtr, false> >();
-  bp::to_python_converter<std::vector<ActionDataPtr, std::allocator<ActionDataPtr> >,
-                          vector_to_list<ActionDataPtr, false> >();
-  list_to_vector().from_python<std::vector<ActionModelPtr, std::allocator<ActionModelPtr> > >();
-  list_to_vector().from_python<std::vector<ActionDataPtr, std::allocator<ActionDataPtr> > >();
+  bp::to_python_converter<boost::circular_buffer<ActionModelPtr, std::allocator<ActionModelPtr> >,
+                          cbuffer_to_list<ActionModelPtr, false> >();
+  bp::to_python_converter<boost::circular_buffer<ActionDataPtr, std::allocator<ActionDataPtr> >,
+                          cbuffer_to_list<ActionDataPtr, false> >();
+  list_to_vector().from_python<boost::circular_buffer<ActionModelPtr, std::allocator<ActionModelPtr> > >();
+  list_to_vector().from_python<boost::circular_buffer<ActionDataPtr, std::allocator<ActionDataPtr> > >();
 
   bp::register_ptr_to_python<boost::shared_ptr<ShootingProblem> >();
 
@@ -36,14 +36,15 @@ void exposeShootingProblem() {
       "first computes the set of next states and cost values per each action model. calcDiff\n"
       "updates the derivatives of all action models. The last rollouts the stacks of actions\n"
       "models.",
-      bp::init<Eigen::VectorXd, std::vector<boost::shared_ptr<ActionModelAbstract> >,
+      bp::init<Eigen::VectorXd, boost::circular_buffer<boost::shared_ptr<ActionModelAbstract> >,
                boost::shared_ptr<ActionModelAbstract> >(bp::args("self", "x0", "runningModels", "terminalModel"),
                                                         "Initialize the shooting problem and allocate its data.\n\n"
                                                         ":param x0: initial state\n"
                                                         ":param runningModels: running action models (size T)\n"
                                                         ":param terminalModel: terminal action model"))
-      .def(bp::init<Eigen::VectorXd, std::vector<boost::shared_ptr<ActionModelAbstract> >,
-                    boost::shared_ptr<ActionModelAbstract>, std::vector<boost::shared_ptr<ActionDataAbstract> >,
+      .def(bp::init<Eigen::VectorXd, boost::circular_buffer<boost::shared_ptr<ActionModelAbstract> >,
+                    boost::shared_ptr<ActionModelAbstract>,
+                    boost::circular_buffer<boost::shared_ptr<ActionDataAbstract> >,
                     boost::shared_ptr<ActionDataAbstract> >(
           bp::args("self", "x0", "runningModels", "terminalModel", "runningDatas", "terminalData"),
           "Initialize the shooting problem (models and datas).\n\n"

--- a/bindings/python/crocoddyl/core/optctrl/shooting.cpp
+++ b/bindings/python/crocoddyl/core/optctrl/shooting.cpp
@@ -71,6 +71,10 @@ void exposeShootingProblem() {
            "Integrate the dynamics given a control sequence.\n\n"
            "Rollout the dynamics give a sequence of control commands\n"
            ":param us: time-discrete control sequence (size T)")
+      .def("pushBackRunningNode", &ShootingProblem::pushBackRunningNode, bp::args("self", "model", "data"),
+           "Put a running node onto the end of the circular buffer container and remove the first one.\n\n"
+           ":param model: new model\n"
+           ":param data: new data")
       .def("updateNode", &ShootingProblem::updateNode, bp::args("self", "i", "model", "data"),
            "Update the model and data for a specific node.\n\n"
            ":param i: index of the node (0 <= i <= T + 1)\n"

--- a/bindings/python/crocoddyl/core/optctrl/shooting.cpp
+++ b/bindings/python/crocoddyl/core/optctrl/shooting.cpp
@@ -24,6 +24,7 @@ void exposeShootingProblem() {
   bp::to_python_converter<std::vector<ActionDataPtr, std::allocator<ActionDataPtr> >,
                           vector_to_list<ActionDataPtr, false> >();
   list_to_vector().from_python<std::vector<ActionModelPtr, std::allocator<ActionModelPtr> > >();
+  list_to_vector().from_python<std::vector<ActionDataPtr, std::allocator<ActionDataPtr> > >();
 
   bp::register_ptr_to_python<boost::shared_ptr<ShootingProblem> >();
 

--- a/bindings/python/crocoddyl/core/optctrl/shooting.cpp
+++ b/bindings/python/crocoddyl/core/optctrl/shooting.cpp
@@ -68,6 +68,11 @@ void exposeShootingProblem() {
            "Integrate the dynamics given a control sequence.\n\n"
            "Rollout the dynamics give a sequence of control commands\n"
            ":param us: time-discrete control sequence")
+      .def("updateNode", &ShootingProblem::updateNode, bp::args("self", "i", "model", "data"),
+           "Update the model and data for a specific node.\n\n"
+           ":param i: index of the node (0 <= i <= T + 1)\n"
+           ":param model: new model\n"
+           ":param data: new data")
       .def("updateModel", &ShootingProblem::updateModel, bp::args("self", "i", "model"),
            "Update a model and allocated new data for a specific node.\n\n"
            ":param i: index of the node (0 <= i <= T + 1)\n"

--- a/bindings/python/crocoddyl/core/optctrl/shooting.cpp
+++ b/bindings/python/crocoddyl/core/optctrl/shooting.cpp
@@ -36,12 +36,21 @@ void exposeShootingProblem() {
       "updates the derivatives of all action models. The last rollouts the stacks of actions\n"
       "models.",
       bp::init<Eigen::VectorXd, std::vector<boost::shared_ptr<ActionModelAbstract> >,
-               boost::shared_ptr<ActionModelAbstract> >(
-          bp::args("self", "initialState", "runningModels", "terminalModel"),
-          "Initialize the shooting problem.\n\n"
-          ":param initialState: initial state\n"
+               boost::shared_ptr<ActionModelAbstract> >(bp::args("self", "x0", "runningModels", "terminalModel"),
+                                                        "Initialize the shooting problem and allocate its data.\n\n"
+                                                        ":param x0: initial state\n"
+                                                        ":param runningModels: running action models\n"
+                                                        ":param terminalModel: terminal action model"))
+      .def(bp::init<Eigen::VectorXd, std::vector<boost::shared_ptr<ActionModelAbstract> >,
+                    boost::shared_ptr<ActionModelAbstract>, std::vector<boost::shared_ptr<ActionDataAbstract> >,
+                    boost::shared_ptr<ActionDataAbstract> >(
+          bp::args("self", "x0", "runningModels", "terminalModel", "runningDatas", "terminalData"),
+          "Initialize the shooting problem (models and datas).\n\n"
+          ":param x0: initial state\n"
           ":param runningModels: running action models\n"
-          ":param terminalModel: terminal action model"))
+          ":param terminalModel: terminal action model\n"
+          ":param runningDatas: running action datas\n"
+          ":param terminalData: terminal action data"))
       .def("calc", &ShootingProblem::calc, bp::args("self", "xs", "us"),
            "Compute the cost and the next states.\n\n"
            "First, it computes the next state and cost for each action model\n"

--- a/bindings/python/crocoddyl/utils/vector-converter.hpp
+++ b/bindings/python/crocoddyl/utils/vector-converter.hpp
@@ -11,6 +11,7 @@
 
 #include <Eigen/Dense>
 #include <vector>
+#include <boost/circular_buffer.hpp>
 #include <boost/python/stl_iterator.hpp>
 #include <boost/python/to_python_converter.hpp>
 
@@ -25,6 +26,25 @@ template <class T, bool NoProxy = true>
 struct vector_to_list {
   static PyObject* convert(const std::vector<T>& vec) {
     typedef typename std::vector<T>::const_iterator const_iter;
+    bp::list* l = new boost::python::list();
+    for (const_iter it = vec.begin(); it != vec.end(); ++it) {
+      if (NoProxy) {
+        l->append(boost::ref(*it));
+      } else {
+        l->append(*it);
+      }
+    }
+    return l->ptr();
+  }
+  static PyTypeObject const* get_pytype() { return &PyList_Type; }
+};
+
+/// @note Registers converter from a provided type to the python
+///       iterable type to the.
+template <class T, bool NoProxy = true>
+struct cbuffer_to_list {
+  static PyObject* convert(const boost::circular_buffer<T>& vec) {
+    typedef typename boost::circular_buffer<T>::const_iterator const_iter;
     bp::list* l = new boost::python::list();
     for (const_iter it = vec.begin(); it != vec.end(); ++it) {
       if (NoProxy) {

--- a/include/crocoddyl/core/action-base.hpp
+++ b/include/crocoddyl/core/action-base.hpp
@@ -40,6 +40,7 @@ class ActionModelAbstractTpl {
   virtual void calcDiff(const boost::shared_ptr<ActionDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,
                         const Eigen::Ref<const VectorXs>& u) = 0;
   virtual boost::shared_ptr<ActionDataAbstract> createData();
+  virtual bool checkData(const boost::shared_ptr<ActionDataAbstract>& data);
 
   void calc(const boost::shared_ptr<ActionDataAbstract>& data, const Eigen::Ref<const VectorXs>& x);
   void calcDiff(const boost::shared_ptr<ActionDataAbstract>& data, const Eigen::Ref<const VectorXs>& x);

--- a/include/crocoddyl/core/action-base.hxx
+++ b/include/crocoddyl/core/action-base.hxx
@@ -84,6 +84,11 @@ boost::shared_ptr<ActionDataAbstractTpl<Scalar> > ActionModelAbstractTpl<Scalar>
 }
 
 template <typename Scalar>
+bool ActionModelAbstractTpl<Scalar>::checkData(const boost::shared_ptr<ActionDataAbstract>&) {
+  return false;
+}
+
+template <typename Scalar>
 const std::size_t& ActionModelAbstractTpl<Scalar>::get_nu() const {
   return nu_;
 }

--- a/include/crocoddyl/core/actions/diff-lqr.hpp
+++ b/include/crocoddyl/core/actions/diff-lqr.hpp
@@ -37,6 +37,7 @@ class DifferentialActionModelLQRTpl : public DifferentialActionModelAbstractTpl<
   virtual void calcDiff(const boost::shared_ptr<DifferentialActionDataAbstract>& data,
                         const Eigen::Ref<const VectorXs>& x, const Eigen::Ref<const VectorXs>& u);
   virtual boost::shared_ptr<DifferentialActionDataAbstract> createData();
+  virtual bool checkData(const boost::shared_ptr<DifferentialActionDataAbstract>& data);
 
   const MatrixXs& get_Fq() const;
   const MatrixXs& get_Fv() const;

--- a/include/crocoddyl/core/actions/diff-lqr.hxx
+++ b/include/crocoddyl/core/actions/diff-lqr.hxx
@@ -84,6 +84,16 @@ boost::shared_ptr<DifferentialActionDataAbstractTpl<Scalar> > DifferentialAction
 }
 
 template <typename Scalar>
+bool DifferentialActionModelLQRTpl<Scalar>::checkData(const boost::shared_ptr<DifferentialActionDataAbstract>& data) {
+  boost::shared_ptr<Data> d = boost::dynamic_pointer_cast<Data>(data);
+  if (d != NULL) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+template <typename Scalar>
 const typename MathBaseTpl<Scalar>::MatrixXs& DifferentialActionModelLQRTpl<Scalar>::get_Fq() const {
   return Fq_;
 }

--- a/include/crocoddyl/core/actions/lqr.hpp
+++ b/include/crocoddyl/core/actions/lqr.hpp
@@ -37,6 +37,7 @@ class ActionModelLQRTpl : public ActionModelAbstractTpl<_Scalar> {
   virtual void calcDiff(const boost::shared_ptr<ActionDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,
                         const Eigen::Ref<const VectorXs>& u);
   virtual boost::shared_ptr<ActionDataAbstract> createData();
+  virtual bool checkData(const boost::shared_ptr<ActionDataAbstract>& data);
 
   const MatrixXs& get_Fx() const;
   const MatrixXs& get_Fu() const;

--- a/include/crocoddyl/core/actions/lqr.hxx
+++ b/include/crocoddyl/core/actions/lqr.hxx
@@ -75,6 +75,16 @@ boost::shared_ptr<ActionDataAbstractTpl<Scalar> > ActionModelLQRTpl<Scalar>::cre
 }
 
 template <typename Scalar>
+bool ActionModelLQRTpl<Scalar>::checkData(const boost::shared_ptr<ActionDataAbstract>& data) {
+  boost::shared_ptr<Data> d = boost::dynamic_pointer_cast<Data>(data);
+  if (d != NULL) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+template <typename Scalar>
 const typename MathBaseTpl<Scalar>::MatrixXs& ActionModelLQRTpl<Scalar>::get_Fx() const {
   return Fx_;
 }

--- a/include/crocoddyl/core/actions/unicycle.hpp
+++ b/include/crocoddyl/core/actions/unicycle.hpp
@@ -37,6 +37,7 @@ class ActionModelUnicycleTpl : public ActionModelAbstractTpl<_Scalar> {
   virtual void calcDiff(const boost::shared_ptr<ActionDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,
                         const Eigen::Ref<const VectorXs>& u);
   virtual boost::shared_ptr<ActionDataAbstract> createData();
+  virtual bool checkData(const boost::shared_ptr<ActionDataAbstract>& data);
 
   const Vector2s& get_cost_weights() const;
   void set_cost_weights(const Vector2s& weights);

--- a/include/crocoddyl/core/actions/unicycle.hxx
+++ b/include/crocoddyl/core/actions/unicycle.hxx
@@ -78,6 +78,16 @@ boost::shared_ptr<ActionDataAbstractTpl<Scalar> > ActionModelUnicycleTpl<Scalar>
 }
 
 template <typename Scalar>
+bool ActionModelUnicycleTpl<Scalar>::checkData(const boost::shared_ptr<ActionDataAbstract>& data) {
+  boost::shared_ptr<Data> d = boost::dynamic_pointer_cast<Data>(data);
+  if (d != NULL) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+template <typename Scalar>
 const typename MathBaseTpl<Scalar>::Vector2s& ActionModelUnicycleTpl<Scalar>::get_cost_weights() const {
   return cost_weights_;
 }

--- a/include/crocoddyl/core/diff-action-base.hpp
+++ b/include/crocoddyl/core/diff-action-base.hpp
@@ -60,6 +60,7 @@ class DifferentialActionModelAbstractTpl {
   virtual void calcDiff(const boost::shared_ptr<DifferentialActionDataAbstract>& data,
                         const Eigen::Ref<const VectorXs>& x, const Eigen::Ref<const VectorXs>& u) = 0;
   virtual boost::shared_ptr<DifferentialActionDataAbstract> createData();
+  virtual bool checkData(const boost::shared_ptr<DifferentialActionDataAbstract>& data);
 
   void calc(const boost::shared_ptr<DifferentialActionDataAbstract>& data, const Eigen::Ref<const VectorXs>& x);
   void calcDiff(const boost::shared_ptr<DifferentialActionDataAbstract>& data, const Eigen::Ref<const VectorXs>& x);

--- a/include/crocoddyl/core/diff-action-base.hxx
+++ b/include/crocoddyl/core/diff-action-base.hxx
@@ -45,6 +45,11 @@ DifferentialActionModelAbstractTpl<Scalar>::createData() {
 }
 
 template <typename Scalar>
+bool DifferentialActionModelAbstractTpl<Scalar>::checkData(const boost::shared_ptr<DifferentialActionDataAbstract>&) {
+  return false;
+}
+
+template <typename Scalar>
 const std::size_t& DifferentialActionModelAbstractTpl<Scalar>::get_nu() const {
   return nu_;
 }

--- a/include/crocoddyl/core/integrator/euler.hpp
+++ b/include/crocoddyl/core/integrator/euler.hpp
@@ -38,6 +38,7 @@ class IntegratedActionModelEulerTpl : public ActionModelAbstractTpl<_Scalar> {
   virtual void calcDiff(const boost::shared_ptr<ActionDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,
                         const Eigen::Ref<const VectorXs>& u);
   virtual boost::shared_ptr<ActionDataAbstract> createData();
+  virtual bool checkData(const boost::shared_ptr<ActionDataAbstract>& data);
 
   const boost::shared_ptr<DifferentialActionModelAbstract>& get_differential() const;
   const Scalar& get_dt() const;

--- a/include/crocoddyl/core/integrator/euler.hxx
+++ b/include/crocoddyl/core/integrator/euler.hxx
@@ -136,6 +136,16 @@ boost::shared_ptr<ActionDataAbstractTpl<Scalar> > IntegratedActionModelEulerTpl<
 }
 
 template <typename Scalar>
+bool IntegratedActionModelEulerTpl<Scalar>::checkData(const boost::shared_ptr<ActionDataAbstract>& data) {
+  boost::shared_ptr<Data> d = boost::dynamic_pointer_cast<Data>(data);
+  if (data != NULL) {
+    return differential_->checkData(d->differential);
+  } else {
+    return false;
+  }
+}
+
+template <typename Scalar>
 const boost::shared_ptr<DifferentialActionModelAbstractTpl<Scalar> >&
 IntegratedActionModelEulerTpl<Scalar>::get_differential() const {
   return differential_;

--- a/include/crocoddyl/core/optctrl/shooting.hpp
+++ b/include/crocoddyl/core/optctrl/shooting.hpp
@@ -111,6 +111,8 @@ class ShootingProblemTpl {
    */
   std::vector<VectorXs> rollout_us(const std::vector<VectorXs>& us);
 
+  void pushBackRunningNode(boost::shared_ptr<ActionModelAbstract> model, boost::shared_ptr<ActionDataAbstract> data);
+
   /**
    * @brief Update the model and data for a specific node
    *

--- a/include/crocoddyl/core/optctrl/shooting.hpp
+++ b/include/crocoddyl/core/optctrl/shooting.hpp
@@ -18,6 +18,15 @@
 
 namespace crocoddyl {
 
+/**
+ * @brief This class encapsulates a shooting problem
+ *
+ * A shooting problem encapsulates the initial state \f$\mathbf{x}_{0}\in\mathcal{M}\f$, a set of running action models
+ * and a terminal action model for a discretized trajectory into \f$T\f$ nodes. It has three main methods - `calc`,
+ * `calcDiff` and `rollout`. The first computes the set of next states and cost values per each node \f$k\f$. Instead,
+ * `calcDiff` updates the derivatives of all action models. Finally, `rollout` integrates the system dynamics. This
+ * class is used to decouple problem formulation and resolution.
+ */
 template <typename _Scalar>
 class ShootingProblemTpl {
  public:
@@ -29,43 +38,147 @@ class ShootingProblemTpl {
   typedef MathBaseTpl<Scalar> MathBase;
   typedef typename MathBase::VectorXs VectorXs;
 
+  /**
+   * @brief Initialize the shooting problem and allocate its data
+   *
+   * @param[in] x0              Initial state
+   * @param[in] running_models  Running action models (size \f$T\f$)
+   * @param[in] terminal_model  Terminal action model
+   */
   ShootingProblemTpl(const VectorXs& x0, const std::vector<boost::shared_ptr<ActionModelAbstract> >& running_models,
                      boost::shared_ptr<ActionModelAbstract> terminal_model);
+
+  /**
+   * @brief Initialize the shooting problem (models and datas)
+   *
+   * @param[in] x0              Initial state
+   * @param[in] running_models  Running action models (size \f$T\f$)
+   * @param[in] terminal_model  Terminal action model
+   * @param[in] running_datas   Running action datas (size \f$T\f$)
+   * @param[in] terminal_data   Terminal action data
+   */
   ShootingProblemTpl(const VectorXs& x0, const std::vector<boost::shared_ptr<ActionModelAbstract> >& running_models,
                      boost::shared_ptr<ActionModelAbstract> terminal_model,
                      const std::vector<boost::shared_ptr<ActionDataAbstract> >& running_datas,
                      boost::shared_ptr<ActionDataAbstract> terminal_data);
+  /**
+   * @brief Initialize the shooting problem
+   */
   ShootingProblemTpl(const ShootingProblemTpl<Scalar>& problem);
   ~ShootingProblemTpl();
 
+  /**
+   * @brief Compute the cost and the next states
+   *
+   * For each node \f$k\f$, and along the state \f$\mathbf{x_{s}}\f$ and control \f$\mathbf{u_{s}}\f$ trajectory, it
+   * computes the next state \f$\mathbf{x}_{k+1}\f$ and cost \f$l_{k}\f$.
+   *
+   * @param[in] xs  time-discrete state trajectory \f$\mathbf{x_{s}}\f$ (size \f$T+1\f$)
+   * @param[in] us  time-discrete control sequence \f$\mathbf{u_{s}}\f$ (size \f$T\f$)
+   * @return The total cost value \f$l_{k}\f$
+   */
   Scalar calc(const std::vector<VectorXs>& xs, const std::vector<VectorXs>& us);
+
+  /**
+   * @brief Compute the derivatives of the cost and dynamics
+   *
+   * For each node \f$k\f$, and along the state \f$\mathbf{x_{s}}\f$ and control \f$\mathbf{u_{s}}\f$ trajectory, it
+   * computes the derivatives of the cost
+   * \f$(\mathbf{l}_{\mathbf{x}}, \mathbf{l}_{\mathbf{u}}, \mathbf{l}_{\mathbf{xx}}, \mathbf{l}_{\mathbf{xu}},
+   * \mathbf{l}_{\mathbf{uu}})\f$ and dynamics \f$(\mathbf{f}_{\mathbf{x}}, \mathbf{f}_{\mathbf{u}})\f$.
+   *
+   * @param[in] xs  time-discrete state trajectory \f$\mathbf{x_{s}}\f$ (size \f$T+1\f$)
+   * @param[in] us  time-discrete control sequence \f$\mathbf{u_{s}}\f$ (size \f$T\f$)
+   * @return The total cost value \f$l_{k}\f$
+   */
   Scalar calcDiff(const std::vector<VectorXs>& xs, const std::vector<VectorXs>& us);
+
+  /**
+   * @brief Integrate the dynamics given a control sequence
+   *
+   * @param[in] xs  time-discrete state trajectory \f$\mathbf{x_{s}}\f$ (size \f$T+1\f$)
+   * @param[in] us  time-discrete control sequence \f$\mathbf{u_{s}}\f$ (size \f$T\f$)
+   */
   void rollout(const std::vector<VectorXs>& us, std::vector<VectorXs>& xs);
+
+  /**
+   * @copybrief rollout
+   *
+   * @param[in] us  time-discrete control sequence \f$\mathbf{u_{s}}\f$ (size \f$T\f$)
+   */
   std::vector<VectorXs> rollout_us(const std::vector<VectorXs>& us);
 
+  /**
+   * @brief Update the model and data for a specific node
+   *
+   * @param[in] i      Node index \f$(0\leq i \leq T+1)\f$
+   * @param[in] model  Action model
+   * @param[in] data   Action data
+   */
   void updateNode(std::size_t i, boost::shared_ptr<ActionModelAbstract> model,
                   boost::shared_ptr<ActionDataAbstract> data);
+
+  /**
+   * @brief Update a model and allocated new data for a specific node
+   *
+   * @param[in] i      Node index \f$(0\leq i \leq T+1)\f$
+   * @param[in] model  Action model
+   */
   void updateModel(std::size_t i, boost::shared_ptr<ActionModelAbstract> model);
 
+  /**
+   * @brief Return the number of running nodes
+   */
   const std::size_t& get_T() const;
+
+  /**
+   * @brief Return the initial state
+   */
   const VectorXs& get_x0() const;
+
+  /**
+   * @brief Return the running models
+   */
   const std::vector<boost::shared_ptr<ActionModelAbstract> >& get_runningModels() const;
+
+  /**
+   * @brief Return the terminal model
+   */
   const boost::shared_ptr<ActionModelAbstract>& get_terminalModel() const;
+
+  /**
+   * @brief Return the running datas
+   */
   const std::vector<boost::shared_ptr<ActionDataAbstract> >& get_runningDatas() const;
+
+  /**
+   * @brief Return the terminal data
+   */
   const boost::shared_ptr<ActionDataAbstract>& get_terminalData() const;
 
+  /**
+   * @brief Modify the initial state
+   */
   void set_x0(const VectorXs& x0_in);
+
+  /**
+   * @brief Modify the running models and allocate new data
+   */
   void set_runningModels(const std::vector<boost::shared_ptr<ActionModelAbstract> >& models);
+
+  /**
+   * @brief Modify the terminal model and allocate new data
+   */
   void set_terminalModel(boost::shared_ptr<ActionModelAbstract> model);
 
  protected:
-  Scalar cost_;
-  std::size_t T_;
-  VectorXs x0_;
-  boost::shared_ptr<ActionModelAbstract> terminal_model_;
-  boost::shared_ptr<ActionDataAbstract> terminal_data_;
-  std::vector<boost::shared_ptr<ActionModelAbstract> > running_models_;
-  std::vector<boost::shared_ptr<ActionDataAbstract> > running_datas_;
+  Scalar cost_;                                                          //!< Total cost
+  std::size_t T_;                                                        //!< number of running nodes
+  VectorXs x0_;                                                          //!< Initial state
+  boost::shared_ptr<ActionModelAbstract> terminal_model_;                //!< Terminal action model
+  boost::shared_ptr<ActionDataAbstract> terminal_data_;                  //!< Terminal action data
+  std::vector<boost::shared_ptr<ActionModelAbstract> > running_models_;  //!< Running action model
+  std::vector<boost::shared_ptr<ActionDataAbstract> > running_datas_;    //!< Running action data
 
  private:
   void allocateData();

--- a/include/crocoddyl/core/optctrl/shooting.hpp
+++ b/include/crocoddyl/core/optctrl/shooting.hpp
@@ -43,6 +43,8 @@ class ShootingProblemTpl {
   void rollout(const std::vector<VectorXs>& us, std::vector<VectorXs>& xs);
   std::vector<VectorXs> rollout_us(const std::vector<VectorXs>& us);
 
+  void updateNode(std::size_t i, boost::shared_ptr<ActionModelAbstract> model,
+                  boost::shared_ptr<ActionDataAbstract> data);
   void updateModel(std::size_t i, boost::shared_ptr<ActionModelAbstract> model);
 
   const std::size_t& get_T() const;

--- a/include/crocoddyl/core/optctrl/shooting.hpp
+++ b/include/crocoddyl/core/optctrl/shooting.hpp
@@ -11,6 +11,7 @@
 
 #include <stdexcept>
 #include <vector>
+#include <boost/circular_buffer.hpp>
 #include "crocoddyl/core/fwd.hpp"
 #include "crocoddyl/core/utils/exception.hpp"
 #include "crocoddyl/core/action-base.hpp"
@@ -45,7 +46,8 @@ class ShootingProblemTpl {
    * @param[in] running_models  Running action models (size \f$T\f$)
    * @param[in] terminal_model  Terminal action model
    */
-  ShootingProblemTpl(const VectorXs& x0, const std::vector<boost::shared_ptr<ActionModelAbstract> >& running_models,
+  ShootingProblemTpl(const VectorXs& x0,
+                     const boost::circular_buffer<boost::shared_ptr<ActionModelAbstract> >& running_models,
                      boost::shared_ptr<ActionModelAbstract> terminal_model);
 
   /**
@@ -57,9 +59,10 @@ class ShootingProblemTpl {
    * @param[in] running_datas   Running action datas (size \f$T\f$)
    * @param[in] terminal_data   Terminal action data
    */
-  ShootingProblemTpl(const VectorXs& x0, const std::vector<boost::shared_ptr<ActionModelAbstract> >& running_models,
+  ShootingProblemTpl(const VectorXs& x0,
+                     const boost::circular_buffer<boost::shared_ptr<ActionModelAbstract> >& running_models,
                      boost::shared_ptr<ActionModelAbstract> terminal_model,
-                     const std::vector<boost::shared_ptr<ActionDataAbstract> >& running_datas,
+                     const boost::circular_buffer<boost::shared_ptr<ActionDataAbstract> >& running_datas,
                      boost::shared_ptr<ActionDataAbstract> terminal_data);
   /**
    * @brief Initialize the shooting problem
@@ -139,7 +142,7 @@ class ShootingProblemTpl {
   /**
    * @brief Return the running models
    */
-  const std::vector<boost::shared_ptr<ActionModelAbstract> >& get_runningModels() const;
+  const boost::circular_buffer<boost::shared_ptr<ActionModelAbstract> >& get_runningModels() const;
 
   /**
    * @brief Return the terminal model
@@ -149,7 +152,7 @@ class ShootingProblemTpl {
   /**
    * @brief Return the running datas
    */
-  const std::vector<boost::shared_ptr<ActionDataAbstract> >& get_runningDatas() const;
+  const boost::circular_buffer<boost::shared_ptr<ActionDataAbstract> >& get_runningDatas() const;
 
   /**
    * @brief Return the terminal data
@@ -164,7 +167,7 @@ class ShootingProblemTpl {
   /**
    * @brief Modify the running models and allocate new data
    */
-  void set_runningModels(const std::vector<boost::shared_ptr<ActionModelAbstract> >& models);
+  void set_runningModels(const boost::circular_buffer<boost::shared_ptr<ActionModelAbstract> >& models);
 
   /**
    * @brief Modify the terminal model and allocate new data
@@ -172,13 +175,13 @@ class ShootingProblemTpl {
   void set_terminalModel(boost::shared_ptr<ActionModelAbstract> model);
 
  protected:
-  Scalar cost_;                                                          //!< Total cost
-  std::size_t T_;                                                        //!< number of running nodes
-  VectorXs x0_;                                                          //!< Initial state
-  boost::shared_ptr<ActionModelAbstract> terminal_model_;                //!< Terminal action model
-  boost::shared_ptr<ActionDataAbstract> terminal_data_;                  //!< Terminal action data
-  std::vector<boost::shared_ptr<ActionModelAbstract> > running_models_;  //!< Running action model
-  std::vector<boost::shared_ptr<ActionDataAbstract> > running_datas_;    //!< Running action data
+  Scalar cost_;                                                                     //!< Total cost
+  std::size_t T_;                                                                   //!< number of running nodes
+  VectorXs x0_;                                                                     //!< Initial state
+  boost::shared_ptr<ActionModelAbstract> terminal_model_;                           //!< Terminal action model
+  boost::shared_ptr<ActionDataAbstract> terminal_data_;                             //!< Terminal action data
+  boost::circular_buffer<boost::shared_ptr<ActionModelAbstract> > running_models_;  //!< Running action model
+  boost::circular_buffer<boost::shared_ptr<ActionDataAbstract> > running_datas_;    //!< Running action data
 
  private:
   void allocateData();

--- a/include/crocoddyl/core/optctrl/shooting.hpp
+++ b/include/crocoddyl/core/optctrl/shooting.hpp
@@ -31,6 +31,11 @@ class ShootingProblemTpl {
 
   ShootingProblemTpl(const VectorXs& x0, const std::vector<boost::shared_ptr<ActionModelAbstract> >& running_models,
                      boost::shared_ptr<ActionModelAbstract> terminal_model);
+  ShootingProblemTpl(const VectorXs& x0, const std::vector<boost::shared_ptr<ActionModelAbstract> >& running_models,
+                     boost::shared_ptr<ActionModelAbstract> terminal_model,
+                     const std::vector<boost::shared_ptr<ActionDataAbstract> >& running_datas,
+                     boost::shared_ptr<ActionDataAbstract> terminal_data);
+  ShootingProblemTpl(const ShootingProblemTpl<Scalar>& problem);
   ~ShootingProblemTpl();
 
   Scalar calc(const std::vector<VectorXs>& xs, const std::vector<VectorXs>& us);

--- a/include/crocoddyl/core/optctrl/shooting.hxx
+++ b/include/crocoddyl/core/optctrl/shooting.hxx
@@ -15,7 +15,7 @@ namespace crocoddyl {
 
 template <typename Scalar>
 ShootingProblemTpl<Scalar>::ShootingProblemTpl(
-    const VectorXs& x0, const std::vector<boost::shared_ptr<ActionModelAbstract> >& running_models,
+    const VectorXs& x0, const boost::circular_buffer<boost::shared_ptr<ActionModelAbstract> >& running_models,
     boost::shared_ptr<ActionModelAbstract> terminal_model)
     : cost_(Scalar(0.)),
       T_(running_models.size()),
@@ -32,9 +32,9 @@ ShootingProblemTpl<Scalar>::ShootingProblemTpl(
 
 template <typename Scalar>
 ShootingProblemTpl<Scalar>::ShootingProblemTpl(
-    const VectorXs& x0, const std::vector<boost::shared_ptr<ActionModelAbstract> >& running_models,
+    const VectorXs& x0, const boost::circular_buffer<boost::shared_ptr<ActionModelAbstract> >& running_models,
     boost::shared_ptr<ActionModelAbstract> terminal_model,
-    const std::vector<boost::shared_ptr<ActionDataAbstract> >& running_datas,
+    const boost::circular_buffer<boost::shared_ptr<ActionDataAbstract> >& running_datas,
     boost::shared_ptr<ActionDataAbstract> terminal_data)
     : cost_(Scalar(0.)),
       T_(running_models.size()),
@@ -219,6 +219,7 @@ const typename MathBaseTpl<Scalar>::VectorXs& ShootingProblemTpl<Scalar>::get_x0
 
 template <typename Scalar>
 void ShootingProblemTpl<Scalar>::allocateData() {
+  running_datas_.set_capacity(T_);
   for (std::size_t i = 0; i < T_; ++i) {
     const boost::shared_ptr<ActionModelAbstract>& model = running_models_[i];
     running_datas_.push_back(model->createData());
@@ -227,7 +228,7 @@ void ShootingProblemTpl<Scalar>::allocateData() {
 }
 
 template <typename Scalar>
-const std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstractTpl<Scalar> > >&
+const boost::circular_buffer<boost::shared_ptr<crocoddyl::ActionModelAbstractTpl<Scalar> > >&
 ShootingProblemTpl<Scalar>::get_runningModels() const {
   return running_models_;
 }
@@ -239,7 +240,7 @@ const boost::shared_ptr<crocoddyl::ActionModelAbstractTpl<Scalar> >& ShootingPro
 }
 
 template <typename Scalar>
-const std::vector<boost::shared_ptr<crocoddyl::ActionDataAbstractTpl<Scalar> > >&
+const boost::circular_buffer<boost::shared_ptr<crocoddyl::ActionDataAbstractTpl<Scalar> > >&
 ShootingProblemTpl<Scalar>::get_runningDatas() const {
   return running_datas_;
 }
@@ -261,7 +262,7 @@ void ShootingProblemTpl<Scalar>::set_x0(const VectorXs& x0_in) {
 
 template <typename Scalar>
 void ShootingProblemTpl<Scalar>::set_runningModels(
-    const std::vector<boost::shared_ptr<ActionModelAbstract> >& models) {
+    const boost::circular_buffer<boost::shared_ptr<ActionModelAbstract> >& models) {
   T_ = models.size();
   running_models_ = models;
   running_datas_.clear();

--- a/include/crocoddyl/core/optctrl/shooting.hxx
+++ b/include/crocoddyl/core/optctrl/shooting.hxx
@@ -172,6 +172,17 @@ std::vector<typename MathBaseTpl<Scalar>::VectorXs> ShootingProblemTpl<Scalar>::
 }
 
 template <typename Scalar>
+void ShootingProblemTpl<Scalar>::pushBackRunningNode(boost::shared_ptr<ActionModelAbstract> model,
+                                                     boost::shared_ptr<ActionDataAbstract> data) {
+  if (!model->checkData(data)) {
+    throw_pretty("Invalid argument: "
+                 << "action data is not consistent with the action model")
+  }
+  running_models_.push_back(model);
+  running_datas_.push_back(data);
+}
+
+template <typename Scalar>
 void ShootingProblemTpl<Scalar>::updateNode(std::size_t i, boost::shared_ptr<ActionModelAbstract> model,
                                             boost::shared_ptr<ActionDataAbstract> data) {
   if (i > T_ + 1) {

--- a/include/crocoddyl/core/optctrl/shooting.hxx
+++ b/include/crocoddyl/core/optctrl/shooting.hxx
@@ -54,6 +54,18 @@ ShootingProblemTpl<Scalar>::ShootingProblemTpl(
                  << "the number of running models and datas are not the same (" + std::to_string(T_) +
                         " != " + std::to_string(Td) + ")")
   }
+  for (std::size_t i = 0; i < T_; ++i) {
+    const boost::shared_ptr<ActionModelAbstract>& model = running_models_[i];
+    const boost::shared_ptr<ActionDataAbstract>& data = running_datas_[i];
+    if (!model->checkData(data)) {
+      throw_pretty("Invalid argument: "
+                   << "action data in " << i << " node is not consistent with the action model")
+    }
+  }
+  if (!terminal_model->checkData(terminal_data)) {
+    throw_pretty("Invalid argument: "
+                 << "terminal action data is not consistent with the terminal action model")
+  }
 }
 
 template <typename Scalar>
@@ -166,6 +178,11 @@ void ShootingProblemTpl<Scalar>::updateNode(std::size_t i, boost::shared_ptr<Act
     throw_pretty("Invalid argument: "
                  << "i is bigger than the allocated horizon (it should be lower than " + std::to_string(T_) + ")");
   }
+  if (!model->checkData(data)) {
+    throw_pretty("Invalid argument: "
+                 << "action data is not consistent with the action model")
+  }
+
   if (i == T_ + 1) {
     terminal_model_ = model;
     terminal_data_ = data;

--- a/include/crocoddyl/core/optctrl/shooting.hxx
+++ b/include/crocoddyl/core/optctrl/shooting.hxx
@@ -160,13 +160,30 @@ std::vector<typename MathBaseTpl<Scalar>::VectorXs> ShootingProblemTpl<Scalar>::
 }
 
 template <typename Scalar>
+void ShootingProblemTpl<Scalar>::updateNode(std::size_t i, boost::shared_ptr<ActionModelAbstract> model,
+                                            boost::shared_ptr<ActionDataAbstract> data) {
+  if (i > T_ + 1) {
+    throw_pretty("Invalid argument: "
+                 << "i is bigger than the allocated horizon (it should be lower than " + std::to_string(T_) + ")");
+  }
+  if (i == T_ + 1) {
+    terminal_model_ = model;
+    terminal_data_ = data;
+  } else {
+    running_models_[i] = model;
+    running_datas_[i] = data;
+  }
+}
+
+template <typename Scalar>
 void ShootingProblemTpl<Scalar>::updateModel(std::size_t i, boost::shared_ptr<ActionModelAbstract> model) {
   if (i > T_ + 1) {
     throw_pretty("Invalid argument: "
                  << "i is bigger than the allocated horizon (it should be lower than " + std::to_string(T_) + ")");
   }
   if (i == T_ + 1) {
-    set_terminalModel(model);
+    terminal_model_ = model;
+    terminal_data_ = terminal_model_->createData();
   } else {
     running_models_[i] = model;
     running_datas_[i] = model->createData();

--- a/include/crocoddyl/core/optctrl/shooting.hxx
+++ b/include/crocoddyl/core/optctrl/shooting.hxx
@@ -31,6 +31,42 @@ ShootingProblemTpl<Scalar>::ShootingProblemTpl(
 }
 
 template <typename Scalar>
+ShootingProblemTpl<Scalar>::ShootingProblemTpl(
+    const VectorXs& x0, const std::vector<boost::shared_ptr<ActionModelAbstract> >& running_models,
+    boost::shared_ptr<ActionModelAbstract> terminal_model,
+    const std::vector<boost::shared_ptr<ActionDataAbstract> >& running_datas,
+    boost::shared_ptr<ActionDataAbstract> terminal_data)
+    : cost_(Scalar(0.)),
+      T_(running_models.size()),
+      x0_(x0),
+      terminal_model_(terminal_model),
+      terminal_data_(terminal_data),
+      running_models_(running_models),
+      running_datas_(running_datas) {
+  if (static_cast<std::size_t>(x0.size()) != running_models_[0]->get_state()->get_nx()) {
+    throw_pretty("Invalid argument: "
+                 << "x0 has wrong dimension (it should be " +
+                        std::to_string(running_models_[0]->get_state()->get_nx()) + ")");
+  }
+  std::size_t Td = running_datas.size();
+  if (Td != T_) {
+    throw_pretty("Invalid argument: "
+                 << "the number of running models and datas are not the same (" + std::to_string(T_) +
+                        " != " + std::to_string(Td) + ")")
+  }
+}
+
+template <typename Scalar>
+ShootingProblemTpl<Scalar>::ShootingProblemTpl(const ShootingProblemTpl<Scalar>& problem)
+    : cost_(Scalar(0.)),
+      T_(problem.get_T()),
+      x0_(problem.get_x0()),
+      terminal_model_(problem.get_terminalModel()),
+      terminal_data_(problem.get_terminalData()),
+      running_models_(problem.get_runningModels()),
+      running_datas_(problem.get_runningDatas()) {}
+
+template <typename Scalar>
 ShootingProblemTpl<Scalar>::~ShootingProblemTpl() {}
 
 template <typename Scalar>

--- a/include/crocoddyl/multibody/actions/contact-fwddyn.hpp
+++ b/include/crocoddyl/multibody/actions/contact-fwddyn.hpp
@@ -51,6 +51,7 @@ class DifferentialActionModelContactFwdDynamicsTpl : public DifferentialActionMo
   virtual void calcDiff(const boost::shared_ptr<DifferentialActionDataAbstract>& data,
                         const Eigen::Ref<const VectorXs>& x, const Eigen::Ref<const VectorXs>& u);
   virtual boost::shared_ptr<DifferentialActionDataAbstract> createData();
+  virtual bool checkData(const boost::shared_ptr<DifferentialActionDataAbstract>& data);
 
   const boost::shared_ptr<ActuationModelFloatingBase>& get_actuation() const;
   const boost::shared_ptr<ContactModelMultiple>& get_contacts() const;

--- a/include/crocoddyl/multibody/actions/contact-fwddyn.hxx
+++ b/include/crocoddyl/multibody/actions/contact-fwddyn.hxx
@@ -160,6 +160,17 @@ DifferentialActionModelContactFwdDynamicsTpl<Scalar>::createData() {
 }
 
 template <typename Scalar>
+bool DifferentialActionModelContactFwdDynamicsTpl<Scalar>::checkData(
+    const boost::shared_ptr<DifferentialActionDataAbstract>& data) {
+  boost::shared_ptr<Data> d = boost::dynamic_pointer_cast<Data>(data);
+  if (d != NULL) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+template <typename Scalar>
 pinocchio::ModelTpl<Scalar>& DifferentialActionModelContactFwdDynamicsTpl<Scalar>::get_pinocchio() const {
   return pinocchio_;
 }

--- a/include/crocoddyl/multibody/actions/free-fwddyn.hpp
+++ b/include/crocoddyl/multibody/actions/free-fwddyn.hpp
@@ -46,6 +46,7 @@ class DifferentialActionModelFreeFwdDynamicsTpl : public DifferentialActionModel
   virtual void calcDiff(const boost::shared_ptr<DifferentialActionDataAbstract>& data,
                         const Eigen::Ref<const VectorXs>& x, const Eigen::Ref<const VectorXs>& u);
   boost::shared_ptr<DifferentialActionDataAbstract> createData();
+  virtual bool checkData(const boost::shared_ptr<DifferentialActionDataAbstract>& data);
 
   const boost::shared_ptr<ActuationModelAbstract>& get_actuation() const;
   const boost::shared_ptr<CostModelSum>& get_costs() const;

--- a/include/crocoddyl/multibody/actions/free-fwddyn.hxx
+++ b/include/crocoddyl/multibody/actions/free-fwddyn.hxx
@@ -123,6 +123,17 @@ DifferentialActionModelFreeFwdDynamicsTpl<Scalar>::createData() {
 }
 
 template <typename Scalar>
+bool DifferentialActionModelFreeFwdDynamicsTpl<Scalar>::checkData(
+    const boost::shared_ptr<DifferentialActionDataAbstract>& data) {
+  boost::shared_ptr<Data> d = boost::dynamic_pointer_cast<Data>(data);
+  if (d != NULL) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+template <typename Scalar>
 pinocchio::ModelTpl<Scalar>& DifferentialActionModelFreeFwdDynamicsTpl<Scalar>::get_pinocchio() const {
   return pinocchio_;
 }

--- a/include/crocoddyl/multibody/actions/impulse-fwddyn.hpp
+++ b/include/crocoddyl/multibody/actions/impulse-fwddyn.hpp
@@ -57,6 +57,7 @@ class ActionModelImpulseFwdDynamicsTpl : public ActionModelAbstractTpl<_Scalar> 
   virtual void calcDiff(const boost::shared_ptr<ActionDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,
                         const Eigen::Ref<const VectorXs>& u);
   virtual boost::shared_ptr<ActionDataAbstract> createData();
+  virtual bool checkData(const boost::shared_ptr<ActionDataAbstract>& data);
 
   const boost::shared_ptr<ImpulseModelMultiple>& get_impulses() const;
   const boost::shared_ptr<CostModelSum>& get_costs() const;

--- a/include/crocoddyl/multibody/actions/impulse-fwddyn.hxx
+++ b/include/crocoddyl/multibody/actions/impulse-fwddyn.hxx
@@ -138,6 +138,16 @@ boost::shared_ptr<ActionDataAbstractTpl<Scalar> > ActionModelImpulseFwdDynamicsT
 }
 
 template <typename Scalar>
+bool ActionModelImpulseFwdDynamicsTpl<Scalar>::checkData(const boost::shared_ptr<ActionDataAbstract>& data) {
+  boost::shared_ptr<Data> d = boost::dynamic_pointer_cast<Data>(data);
+  if (d != NULL) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+template <typename Scalar>
 pinocchio::ModelTpl<Scalar>& ActionModelImpulseFwdDynamicsTpl<Scalar>::get_pinocchio() const {
   return pinocchio_;
 }

--- a/include/crocoddyl/multibody/utils/quadruped-gaits.hpp
+++ b/include/crocoddyl/multibody/utils/quadruped-gaits.hpp
@@ -45,7 +45,7 @@ class SimpleQuadrupedGaitProblem {
                                                                      const std::size_t stepKnots,
                                                                      const std::size_t supportKnots);
 
-  std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstract> > createFootStepModels(
+  boost::circular_buffer<boost::shared_ptr<crocoddyl::ActionModelAbstract> > createFootStepModels(
       double timeStep, Eigen::Vector3d& comPos0, std::vector<Eigen::Vector3d>& feetPos0, double stepLength,
       double stepHeight, std::size_t numKnots, const std::vector<pinocchio::FrameIndex>& supportFootIds,
       const std::vector<pinocchio::FrameIndex>& swingFootIds);

--- a/unittest/factory/solver.cpp
+++ b/unittest/factory/solver.cpp
@@ -54,7 +54,7 @@ boost::shared_ptr<crocoddyl::SolverAbstract> SolverFactory::create(SolverTypes::
                                                                    size_t T) const {
   boost::shared_ptr<crocoddyl::SolverAbstract> solver;
   boost::shared_ptr<crocoddyl::ActionModelAbstract> model = ActionModelFactory().create(action_type);
-  std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstract> > running_models(T, model);
+  boost::circular_buffer<boost::shared_ptr<crocoddyl::ActionModelAbstract> > running_models(T, model);
   boost::shared_ptr<crocoddyl::ShootingProblem> problem =
       boost::make_shared<crocoddyl::ShootingProblem>(model->get_state()->zero(), running_models, model);
 

--- a/unittest/test_actions.cpp
+++ b/unittest/test_actions.cpp
@@ -18,6 +18,17 @@ using namespace crocoddyl::unittest;
 
 //----------------------------------------------------------------------------//
 
+void test_check_data(ActionModelTypes::Type action_model_type) {
+  // create the model
+  ActionModelFactory factory;
+  const boost::shared_ptr<crocoddyl::ActionModelAbstract>& model = factory.create(action_model_type);
+
+  // create the corresponding data object
+  const boost::shared_ptr<crocoddyl::ActionDataAbstract>& data = model->createData();
+
+  BOOST_CHECK(model->checkData(data));
+}
+
 void test_calc_returns_state(ActionModelTypes::Type action_model_type) {
   // create the model
   ActionModelFactory factory;
@@ -100,6 +111,7 @@ void register_action_model_unit_tests(ActionModelTypes::Type action_model_type) 
   test_name << "test_" << action_model_type;
   std::cout << "Running " << test_name.str() << std::endl;
   test_suite* ts = BOOST_TEST_SUITE(test_name.str());
+  ts->add(BOOST_TEST_CASE(boost::bind(&test_check_data, action_model_type)));
   ts->add(BOOST_TEST_CASE(boost::bind(&test_calc_returns_state, action_model_type)));
   ts->add(BOOST_TEST_CASE(boost::bind(&test_calc_returns_a_cost, action_model_type)));
   ts->add(BOOST_TEST_CASE(boost::bind(&test_partial_derivatives_against_numdiff, action_model_type)));

--- a/unittest/test_diff_actions.cpp
+++ b/unittest/test_diff_actions.cpp
@@ -17,6 +17,17 @@ using namespace crocoddyl::unittest;
 
 //----------------------------------------------------------------------------//
 
+void test_check_data(DifferentialActionModelTypes::Type action_type) {
+  // create the model
+  DifferentialActionModelFactory factory;
+  const boost::shared_ptr<crocoddyl::DifferentialActionModelAbstract>& model = factory.create(action_type);
+
+  // create the corresponding data object
+  const boost::shared_ptr<crocoddyl::DifferentialActionDataAbstract>& data = model->createData();
+
+  BOOST_CHECK(model->checkData(data));
+}
+
 void test_calc_returns_state(DifferentialActionModelTypes::Type action_type) {
   // create the model
   DifferentialActionModelFactory factory;
@@ -99,6 +110,7 @@ void register_action_model_unit_tests(DifferentialActionModelTypes::Type action_
   test_name << "test_" << action_type;
   std::cout << "Running " << test_name.str() << std::endl;
   test_suite* ts = BOOST_TEST_SUITE(test_name.str());
+  ts->add(BOOST_TEST_CASE(boost::bind(&test_check_data, action_type)));
   ts->add(BOOST_TEST_CASE(boost::bind(&test_calc_returns_state, action_type)));
   ts->add(BOOST_TEST_CASE(boost::bind(&test_calc_returns_a_cost, action_type)));
   ts->add(BOOST_TEST_CASE(boost::bind(&test_partial_derivatives_against_numdiff, action_type)));


### PR DESCRIPTION
This PR proposes to use `boost::circular_buffer` to store action models and datas in the shooting problem class. It simplifies the cyclic MPC formulation when the user might need to update the first action model and move on the remaining models. It could be easily do it through a `push_back` method implementing in this PR as well (i.e. `pushBackRunningNode`). I have bench the use of `boost::circular_buffer` against `std::vectors`, and the computation time remains the same.

Additionally, this PR includes the `updateNode` function and extra constructor that allows user to pass the datas. It is quite useful since users can have the control of data allocation. Again it is very important for any MPC application.

Finally, the PR includes a `checkData` method for all action models (and diff-action models) to allow the shooting problem does data checking which protects us against user mistakes. These new functionality is tested in our unittest!


**Important note**
I want to include few other things here:
 - a `pushBackRunningModel` function similar to `pushBackRunningNode` but we internal data allocation.
 - doxygen documentation of all the shooting-problem methods.

However, I wanted to share the code for discussion: @proyan and @nmansard.
