### PR TITLE
Data allocation in solvers for contact-phase MPC applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The source code is released under the [BSD 3-Clause license](LICENSE).
 [![GitHub Release Date](https://img.shields.io/github/release-date/loco-3d/crocoddyl)](https://img.shields.io/github/release-date/loco-3d/crocoddyl)
 [![GitHub last commit](https://img.shields.io/github/last-commit/loco-3d/crocoddyl)](https://img.shields.io/github/last-commit/loco-3d/crocoddyl)
 
-If you want to follow the current developments, you can directly refer to the [devel branch](https://gepgitlab.laas.fr/loco-3d/cddp/tree/devel).
+If you want to follow the current developments, you can directly refer to the [devel branch](https://github.com/loco-3d/cddp/tree/devel).
 
 
 ## <img align="center" height="20" src="https://i.imgur.com/x1morBF.png"/> Installation
@@ -115,7 +115,7 @@ export PYTHONPATH=/opt/openrobots/lib/python2.7/site-packages:$PYTHONPATH
 **Crocoddyl** is c++ library with Python bindings for versatile and fast prototyping. It has the following dependencies:
 
 * [pinocchio](https://github.com/stack-of-tasks/pinocchio)
-* [example-robot-data](https://gepgitlab.laas.fr/gepetto/example-robot-data) (optional for examples, install Python loaders)
+* [example-robot-data](https://github.com/gepetto/example-robot-data) (optional for examples, install Python loaders)
 * [gepetto-viewer-corba](https://github.com/Gepetto/gepetto-viewer-corba) (optional for display)
 * [jupyter](https://jupyter.org/) (optional for notebooks)
 * [matplotlib](https://matplotlib.org/) (optional for examples)
@@ -144,11 +144,11 @@ python -m crocoddyl.examples.quadrupedal_gaits "display" "plot" # enable display
 ```
 
 If you want to learn about Crocoddyl, take a look at the Jupyter notebooks. Start in the following order.
-- [examples/notebooks/unicycle_towards_origin.ipynb](https://gepgitlab.laas.fr/loco-3d/crocoddyl/blob/devel/examples/notebooks/unicycle_towards_origin.ipynb)
-- [examples/notebooks/cartpole_swing_up.ipynb](https://gepgitlab.laas.fr/loco-3d/crocoddyl/blob/devel/examples/notebooks/cartpole_swing_up.py)
-- [examples/notebooks/arm_manipulation.ipynb](https://gepgitlab.laas.fr/loco-3d/crocoddyl/blob/devel/examples/notebooks/arm_manipulation.ipynb)
-- [examples/notebooks/bipedal_walking.ipynb](https://gepgitlab.laas.fr/loco-3d/crocoddyl/blob/devel/examples/notebooks/bipedal_walking.ipynb)
-- [examples/notebooks/introduction_to_crocoddyl.ipynb](https://gepgitlab.laas.fr/loco-3d/crocoddyl/blob/devel/examples/notebooks/introduction_to_crocoddyl.ipynb)
+- [examples/notebooks/unicycle_towards_origin.ipynb](https://github.com/loco-3d/crocoddyl/blob/devel/examples/notebooks/unicycle_towards_origin.ipynb)
+- [examples/notebooks/cartpole_swing_up.ipynb](https://github.com/loco-3d/crocoddyl/blob/devel/examples/notebooks/cartpole_swing_up.py)
+- [examples/notebooks/arm_manipulation.ipynb](https://github.com/loco-3d/crocoddyl/blob/devel/examples/notebooks/arm_manipulation.ipynb)
+- [examples/notebooks/bipedal_walking.ipynb](https://github.com/loco-3d/crocoddyl/blob/devel/examples/notebooks/bipedal_walking.ipynb)
+- [examples/notebooks/introduction_to_crocoddyl.ipynb](https://github.com/loco-3d/crocoddyl/blob/devel/examples/notebooks/introduction_to_crocoddyl.ipynb)
 
 
 ## Citing Crocoddyl
@@ -168,7 +168,7 @@ and the following one to reference this website:
 @misc{crocoddylweb,
    author = {Carlos Mastalli, Rohan Budhiraja and Nicolas Mansard and others},
    title = {Crocoddyl: a fast and flexible optimal control library for robot control under contact sequence},
-   howpublished = {https://gepgitlab.laas.fr/loco-3d/crocoddyl/wikis/home},
+   howpublished = {https://github.com/loco-3d/crocoddyl/wikis/home},
    year = {2019}
 }
 ```
@@ -181,12 +181,12 @@ The rest of the publications describes different component of **Crocoddyl**:
 - R. Budhiraja, J. Carpentier, C. Mastalli and N. Mansard. [Differential Dynamic Programming for Multi-Phase Rigid Contact Dynamics](https://cmastalli.github.io/publications/mddp18.html), IEEE RAS International Conference on Humanoid Robots (ICHR), 2018
 - Y. Tassa, N. Mansard, E. Todorov. [Control-Limited Differential Dynamic Programming](https://homes.cs.washington.edu/~todorov/papers/TassaICRA14.pdf), IEEE International Conference on Automation and Robotics (ICRA), 2014
 - R. Budhiraja, J. Carpentier and N. Mansard. [Dynamics Consensus between Centroidal and Whole-Body Models for Locomotion of Legged Robots](https://hal.laas.fr/hal-01875031/document), IEEE International Conference on Automation and Robotics (ICRA), 2019
-- T. G. Lembono, C. Mastally, P. Fernbach, N. Mansard and S. Calinon. [Learning How to Walk: Warm-starting Optimal Control Solver with Memory of Motion](https://arxiv.org/abs/2001.11751), IEEE International Conference on Robotics and Automation (ICRA), 2020
+- T. G. Lembono, C. Mastalli, P. Fernbach, N. Mansard and S. Calinon. [Learning How to Walk: Warm-starting Optimal Control Solver with Memory of Motion](https://cmastalli.github.io/publications/learningwalk20icra.html), IEEE International Conference on Robotics and Automation (ICRA), 2020
 
 
 ## Questions and Issues
 
-You have a question or an issue? You may either directly open a [new issue](https://gepgitlab.laas.fr/loco-3d/crocoddyl/issues) or use the mailing list <crocoddyl@laas.fr>.
+You have a question or an issue? You may either directly open a [new issue](https://github.com/loco-3d/crocoddyl/issues) or use the mailing list <crocoddyl@laas.fr>.
 
 
 ## Credits

--- a/bindings/python/crocoddyl/core/optctrl/shooting.cpp
+++ b/bindings/python/crocoddyl/core/optctrl/shooting.cpp
@@ -110,7 +110,16 @@ void exposeShootingProblem() {
       .add_property(
           "terminalData",
           bp::make_function(&ShootingProblem::get_terminalData, bp::return_value_policy<bp::return_by_value>()),
-          "terminal data");
+          "terminal data")
+      .add_property("nx",
+                    bp::make_function(&ShootingProblem::get_nx, bp::return_value_policy<bp::return_by_value>()),
+                    "dimension of state tuple")
+      .add_property("ndx",
+                    bp::make_function(&ShootingProblem::get_ndx, bp::return_value_policy<bp::return_by_value>()),
+                    "dimension of the tangent space of the state manifold")
+      .add_property("nu",
+                    bp::make_function(&ShootingProblem::get_nu, bp::return_value_policy<bp::return_by_value>()),
+                    "dimension of the control vector");
 }
 
 }  // namespace python

--- a/bindings/python/crocoddyl/core/optctrl/shooting.cpp
+++ b/bindings/python/crocoddyl/core/optctrl/shooting.cpp
@@ -111,14 +111,12 @@ void exposeShootingProblem() {
           "terminalData",
           bp::make_function(&ShootingProblem::get_terminalData, bp::return_value_policy<bp::return_by_value>()),
           "terminal data")
-      .add_property("nx",
-                    bp::make_function(&ShootingProblem::get_nx, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("nx", bp::make_function(&ShootingProblem::get_nx, bp::return_value_policy<bp::return_by_value>()),
                     "dimension of state tuple")
       .add_property("ndx",
                     bp::make_function(&ShootingProblem::get_ndx, bp::return_value_policy<bp::return_by_value>()),
                     "dimension of the tangent space of the state manifold")
-      .add_property("nu",
-                    bp::make_function(&ShootingProblem::get_nu, bp::return_value_policy<bp::return_by_value>()),
+      .add_property("nu", bp::make_function(&ShootingProblem::get_nu, bp::return_value_policy<bp::return_by_value>()),
                     "dimension of the control vector");
 }
 

--- a/bindings/python/crocoddyl/core/solver-base.cpp
+++ b/bindings/python/crocoddyl/core/solver-base.cpp
@@ -23,8 +23,8 @@ void exposeSolverAbstract() {
   bp::class_<SolverAbstract_wrap, boost::noncopyable>(
       "SolverAbstract",
       "Abstract class for optimal control solvers.\n\n"
-      "In crocoddyl, a solver resolves an optimal control solver which is formulated in a\n"
-      "problem abstraction. The main routines are computeDirection and tryStep. The former finds\n"
+      "A solver resolves an optimal control solver which is formulated in a shooting problem\n"
+      "abstraction. The main routines are computeDirection and tryStep. The former finds\n"
       "a search direction and typically computes the derivatives of each action model. The latter\n"
       "rollout the dynamics and cost (i.e. the action) to try the search direction found by\n"
       "computeDirection. Both functions used the current guess defined by setCandidate. Finally\n"
@@ -48,7 +48,7 @@ void exposeSolverAbstract() {
            "False).\n"
            ":param regInit: initial guess for the regularization value. Very low\n"
            "                values are typical used with very good guess points (init_xs, init_us).\n"
-           ":returns the optimal trajectory xopt, uopt and a boolean that describes if convergence was reached.")
+           ":returns A boolean that describes if convergence was reached.")
       .def("computeDirection", pure_virtual(&SolverAbstract_wrap::computeDirection), bp::args("self", "recalc"),
            "Compute the search direction (dx, du) for the current guess (xs, us).\n\n"
            "You must call setCandidate first in order to define the current\n"
@@ -90,7 +90,7 @@ void exposeSolverAbstract() {
       .def("setCallbacks", &SolverAbstract_wrap::setCallbacks, bp::args("self"),
            "Set a list of callback functions using for diagnostic.\n\n"
            "Each iteration, the solver calls these set of functions in order to\n"
-           "allowed user the diagnostic of the solver's performance.\n"
+           "allowed user the diagnostic of the its performance.\n"
            ":param callbacks: set of callback functions.")
       .def("getCallbacks", &SolverAbstract_wrap::getCallbacks, bp::return_value_policy<bp::copy_const_reference>(),
            bp::args("self"),

--- a/bindings/python/crocoddyl/core/solvers/ddp.cpp
+++ b/bindings/python/crocoddyl/core/solvers/ddp.cpp
@@ -78,7 +78,7 @@ void exposeSolverDDP() {
            "compute. These terms are computed by running calc.")
       .def("forwardPass", &SolverDDP::forwardPass, bp::args("self", " stepLength=1"),
            "Run the forward pass or rollout\n\n"
-           "It rollouts the action model give the computed policy (feedforward terns and feedback\n"
+           "It rollouts the action model given the computed policy (feedforward terns and feedback\n"
            "gains) by the backwardPass. We can define different step lengths\n"
            ":param stepLength: applied step length (<= 1. and >= 0.)")
       .add_property("Vxx", make_function(&SolverDDP::get_Vxx, bp::return_value_policy<bp::copy_const_reference>()),

--- a/doc/Doxyfile.extra.in
+++ b/doc/Doxyfile.extra.in
@@ -147,7 +147,7 @@ ENABLED_SECTIONS       = DEV
 # alphabetically by member name. If set to NO the members will appear in
 # declaration order.
 
-SORT_MEMBER_DOCS       = YES
+SORT_MEMBER_DOCS       = NO
 
 # If the SORT_BRIEF_DOCS tag is set to YES then doxygen will sort the
 # brief documentation of file, namespace and class members alphabetically

--- a/include/crocoddyl/core/optctrl/shooting.hpp
+++ b/include/crocoddyl/core/optctrl/shooting.hpp
@@ -191,6 +191,21 @@ class ShootingProblemTpl {
    */
   void set_terminalModel(boost::shared_ptr<ActionModelAbstract> model);
 
+  /**
+   * @brief Return the dimension of the state tuple
+   */
+  const std::size_t& get_nx() const;
+
+  /**
+   * @brief Return the dimension of the tangent space of the state manifold
+   */
+  const std::size_t& get_ndx() const;
+
+  /**
+   * @brief Return the dimension of the control vector
+   */
+  const std::size_t& get_nu() const;
+
  protected:
   Scalar cost_;                                                          //!< Total cost
   std::size_t T_;                                                        //!< number of running nodes
@@ -199,6 +214,9 @@ class ShootingProblemTpl {
   boost::shared_ptr<ActionDataAbstract> terminal_data_;                  //!< Terminal action data
   std::vector<boost::shared_ptr<ActionModelAbstract> > running_models_;  //!< Running action model
   std::vector<boost::shared_ptr<ActionDataAbstract> > running_datas_;    //!< Running action data
+  std::size_t nx_;                                                       //!< State dimension
+  std::size_t ndx_;                                                      //!< State rate dimension
+  std::size_t nu_;                                                       //!< Control dimension
 
  private:
   void allocateData();

--- a/include/crocoddyl/core/optctrl/shooting.hxx
+++ b/include/crocoddyl/core/optctrl/shooting.hxx
@@ -96,7 +96,11 @@ Scalar ShootingProblemTpl<Scalar>::calc(const std::vector<VectorXs>& xs, const s
 #pragma omp parallel for
 #endif
   for (std::size_t i = 0; i < T_; ++i) {
-    running_models_[i]->calc(running_datas_[i], xs[i], us[i]);
+    if (running_models_[i]->get_nu() != 0) {
+      running_models_[i]->calc(running_datas_[i], xs[i], us[i]);
+    } else {
+      running_models_[i]->calc(running_datas_[i], xs[i]);
+    }
   }
   terminal_model_->calc(terminal_data_, xs.back());
 
@@ -125,7 +129,11 @@ Scalar ShootingProblemTpl<Scalar>::calcDiff(const std::vector<VectorXs>& xs, con
 #pragma omp parallel for
 #endif
   for (i = 0; i < T_; ++i) {
-    running_models_[i]->calcDiff(running_datas_[i], xs[i], us[i]);
+    if (running_models_[i]->get_nu() != 0) {
+      running_models_[i]->calcDiff(running_datas_[i], xs[i], us[i]);
+    } else {
+      running_models_[i]->calcDiff(running_datas_[i], xs[i]);
+    }
   }
   terminal_model_->calcDiff(terminal_data_, xs.back());
 
@@ -154,9 +162,13 @@ void ShootingProblemTpl<Scalar>::rollout(const std::vector<VectorXs>& us, std::v
     const boost::shared_ptr<ActionModelAbstract>& model = running_models_[i];
     const boost::shared_ptr<ActionDataAbstract>& data = running_datas_[i];
     const VectorXs& x = xs[i];
-    const VectorXs& u = us[i];
 
-    model->calc(data, x, u);
+    if (model->get_nu() != 0) {
+      const VectorXs& u = us[i];
+      model->calc(data, x, u);
+    } else {
+      model->calc(data, x);
+    }
     xs[i + 1] = data->xnext;
   }
   terminal_model_->calc(terminal_data_, xs.back());

--- a/include/crocoddyl/core/optctrl/shooting.hxx
+++ b/include/crocoddyl/core/optctrl/shooting.hxx
@@ -436,12 +436,18 @@ void ShootingProblemTpl<Scalar>::set_terminalModel(boost::shared_ptr<ActionModel
 }
 
 template <typename Scalar>
-const std::size_t& ShootingProblemTpl<Scalar>::get_nx() const { return nx_; }
+const std::size_t& ShootingProblemTpl<Scalar>::get_nx() const {
+  return nx_;
+}
 
 template <typename Scalar>
-const std::size_t& ShootingProblemTpl<Scalar>::get_ndx() const { return ndx_; }
+const std::size_t& ShootingProblemTpl<Scalar>::get_ndx() const {
+  return ndx_;
+}
 
 template <typename Scalar>
-const std::size_t& ShootingProblemTpl<Scalar>::get_nu() const { return nu_; }
+const std::size_t& ShootingProblemTpl<Scalar>::get_nu() const {
+  return nu_;
+}
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/core/solver-base.hpp
+++ b/include/crocoddyl/core/solver-base.hpp
@@ -18,18 +18,6 @@ namespace crocoddyl {
 class CallbackAbstract;  // forward declaration
 static std::vector<Eigen::VectorXd> DEFAULT_VECTOR;
 
-// \begin{eqnarray*}
-// \mathbf{X}^*(\mathbf{\tilde{x}}_0), \mathbf{U}^*(\mathbf{\tilde{x}}_0) =
-// \begin{Bmatrix}
-// 	\mathbf{x}^*_0,\cdots,\mathbf{x}^*_N \\
-// 	\mathbf{u}^*_0,\cdots,\mathbf{u}^*_{N-1}
-// \end{Bmatrix} =
-// \argmin_{\mathbf{X},\mathbf{U}} && l_N (\mathbf{x}_N) +
-// 	\sum_{k=0}^{N-1} l_k(\mathbf{x}_t,\mathbf{u}_t) \\
-// \st && \mathbf{x}_0 = \mathbf{\tilde{x}}_0\\
-//     &&  \mathbf{x}_{k+1} = \mathbf{f}_k(\mathbf{x}_k,\mathbf{u}_k)
-// \end{eqnarray*}
-
 /**
  * @brief Abstract class for optimal control solvers
  *
@@ -295,7 +283,6 @@ class SolverAbstract {
  */
 class CallbackAbstract {
  public:
-
   /**
    * @brief Initialize the callback function
    */
@@ -304,7 +291,7 @@ class CallbackAbstract {
 
   /**
    * @brief Run the callback function given a solver
-   * 
+   *
    * @param[in]  solver solver to be diagnostic
    */
   virtual void operator()(SolverAbstract& solver) = 0;

--- a/include/crocoddyl/core/solver-base.hpp
+++ b/include/crocoddyl/core/solver-base.hpp
@@ -18,48 +18,254 @@ namespace crocoddyl {
 class CallbackAbstract;  // forward declaration
 static std::vector<Eigen::VectorXd> DEFAULT_VECTOR;
 
+// \begin{eqnarray*}
+// \mathbf{X}^*(\mathbf{\tilde{x}}_0), \mathbf{U}^*(\mathbf{\tilde{x}}_0) =
+// \begin{Bmatrix}
+// 	\mathbf{x}^*_0,\cdots,\mathbf{x}^*_N \\
+// 	\mathbf{u}^*_0,\cdots,\mathbf{u}^*_{N-1}
+// \end{Bmatrix} =
+// \argmin_{\mathbf{X},\mathbf{U}} && l_N (\mathbf{x}_N) +
+// 	\sum_{k=0}^{N-1} l_k(\mathbf{x}_t,\mathbf{u}_t) \\
+// \st && \mathbf{x}_0 = \mathbf{\tilde{x}}_0\\
+//     &&  \mathbf{x}_{k+1} = \mathbf{f}_k(\mathbf{x}_k,\mathbf{u}_k)
+// \end{eqnarray*}
+
+/**
+ * @brief Abstract class for optimal control solvers
+ *
+ * A solver resolves an optimal control solver of the form
+ * \f{eqnarray*}{
+ * \begin{Bmatrix}
+ * 	\mathbf{x}^*_0,\cdots,\mathbf{x}^*_{T} \\
+ * 	\mathbf{u}^*_0,\cdots,\mathbf{u}^*_{T-1}
+ * \end{Bmatrix} =
+ * \arg\min_{\mathbf{x}_s,\mathbf{u}_s} && l_T (\mathbf{x}_T) + \sum_{k=0}^{T-1} l_k(\mathbf{x}_t,\mathbf{u}_t) \\
+ * \operatorname{subject}\,\operatorname{to} && \mathbf{x}_0 = \mathbf{\tilde{x}}_0\\
+ * &&  \mathbf{x}_{k+1} = \mathbf{f}_k(\mathbf{x}_k,\mathbf{u}_k)\\
+ * &&  \mathbf{x}_k\in\mathcal{X}, \mathbf{u}_k\in\mathcal{U}
+ * \f}
+ * where \f$l_T(\mathbf{x}_T)\f$, \f$l_k(\mathbf{x}_t,\mathbf{u}_t)\f$ are the terminal and running cost functions,
+ * respectively, \f$\mathbf{f}_k(\mathbf{x}_k,\mathbf{u}_k)\f$ describes evolution of the system, and state and
+ * control admissible sets are defined by \f$\mathbf{x}_k\in\mathcal{X}\f$, \f$\mathbf{u}_k\in\mathcal{U}\f$.
+ * An action model, defined in the shooting problem, describes each node \f$k\f$. Inside the action model, we
+ * specialize the cost functions, the system evolution and the admissible sets.
+ *
+ * The main routines are `computeDirection()` and `tryStep()`. The former finds a search direction and typically
+ * computes the derivatives of each action model. The latter rollout the dynamics and cost (i.e. the action)
+ * to try the search direction found by computeDirection. Both functions used the current guess defined by
+ * setCandidate. Finally solve function is used to define when the search direction and length are
+ * computed in each iterate. It also describes the globalization strategy (i.e. regularization) of the
+ * numerical optimization.
+ *
+ * \sa `computeDirection()` and `tryStep()`
+ */
 class SolverAbstract {
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
+  /**
+   * @brief Initialize the solver
+   *
+   * @param[in] problem  Shooting problem
+   */
   explicit SolverAbstract(boost::shared_ptr<ShootingProblem> problem);
   virtual ~SolverAbstract();
 
+  /**
+   * @brief Compute the optimal trajectory \f$\mathbf{x}^*_s,\mathbf{u}^*_s\f$ as lists of \f$T+1\f$ and \f$T\f$ terms
+   *
+   * From an initial guess \p init_xs, \p init_us (feasible or not), iterate over `computeDirection()` and `tryStep()`
+   * until `stoppingCriteria()` is below threshold. It also describes the globalization strategy used during the
+   * numerical optimization.
+   *
+   * @param[in]  init_xs     initial guess for state trajectory with \f$T+1\f$ elements (default [])
+   * @param[in]  init_us     initial guess for control trajectory with \f$T\f$ elements (default [])
+   * @param[in]  maxiter     maximun allowed number of iterations (default 100)
+   * @param[in]  isFeasible  true if the \p init_xs are obtained from integrating the \p init_us (rollout) (default
+   * false)
+   * @param[in]  regInit     initial guess for the regularization value. Very low values are typical used with very
+   * good guess points (init_xs, init_us)
+   * @return A boolean that describes if convergence was reached.")
+   */
   virtual bool solve(const std::vector<Eigen::VectorXd>& init_xs = DEFAULT_VECTOR,
                      const std::vector<Eigen::VectorXd>& init_us = DEFAULT_VECTOR, const std::size_t& maxiter = 100,
                      const bool& is_feasible = false, const double& reg_init = 1e-9) = 0;
-  // TODO(cmastalli): computeDirection (polymorphism) returning descent direction and lambdas
+
+  /**
+   * @brief Compute the search direction \f$(\delta\mathbf{x},\delta\mathbf{u})\f$ for the current guess
+   * \f$(\mathbf{x}_s,\mathbf{u}_s)\f$
+   *
+   * You must call setCandidate first in order to define the current guess. A current guess defines a state
+   * and control trajectory \f$(\mathbf{x}_s,\mathbf{u}_s)\f$ of \f$T+1\f$ and \f$T\f$ elements, respectively.
+   *
+   * @param[in] recalc  True for recalculating the derivatives at current state and control
+   * @return  The search direction \f$(\delta\mathbf{x},\delta\mathbf{u})\f$ and the dual lambdas as lists of
+   * \f$T+1\f$, \f$T\f$ and \f$T+1\f$ lengths, respectively
+   */
   virtual void computeDirection(const bool& recalc) = 0;
+
+  /**
+   * @brief Try a predefined step length and compute its cost improvement
+   *
+   * It uses the search direction found by `computeDirection()` to try a determined step length \f$\alpha\f$; so you
+   * need to run first `computeDirection()`. Additionally it returns the cost improvement along the predefined step
+   * length.
+   *
+   * @param[in]  stepLength  step length
+   * @return  The cost improvement
+   */
   virtual double tryStep(const double& step_length = 1) = 0;
+
+  /**
+   * @brief Return a positive value that quantifies the algorithm termination
+   *
+   * These values typically represents the gradient norm which tell us that it's been reached the local minima.
+   * This function is used to evaluate the algorithm convergence. The stopping criteria strictly speaking depends on
+   * the search direction (calculated by `computeDirection()`) but it could also depend on the chosen step length,
+   * tested by `tryStep()`.
+   */
   virtual double stoppingCriteria() = 0;
+
+  /**
+   * @brief Return the expected improvement from a given current search direction
+   *
+   * For computing the expected improvement, you need to compute first the search direction by running
+   * `computeDirection()`.
+   */
   virtual const Eigen::Vector2d& expectedImprovement() = 0;
+
+  /**
+   * @brief Set the solver candidate warm-point values \f$(\mathbf{x}_s,\mathbf{u}_s)\f$
+   *
+   * The solver candidates are defined as a state and control trajectories \f$(\mathbf{x}_s,\mathbf{u}_s)\f$ of
+   * \f$T+1\f$ and \f$T\f$ elements, respectively. Additionally, we need to define is \f$(\mathbf{x}_s,\mathbf{u}_s)\f$
+   * pair is feasible, this means that the dynamics rollout give us produces \f$\mathbf{x}_s\f$.
+   *
+   * @param[in]  xs          state trajectory of \f$T+1\f$ elements (default [])
+   * @param[in]  us          control trajectory of \f$T\f$ elements (default [])
+   * @param[in]  isFeasible  true if the \p xs are obtained from integrating the \p us (rollout)
+   */
   void setCandidate(const std::vector<Eigen::VectorXd>& xs_warm = DEFAULT_VECTOR,
                     const std::vector<Eigen::VectorXd>& us_warm = DEFAULT_VECTOR, const bool& is_feasible = false);
 
+  /**
+   * @brief Set a list of callback functions using for diagnostic
+   *
+   * Each iteration, the solver calls these set of functions in order to allowed user the diagnostic of its
+   * performance.
+   *
+   * @param  callbacks  set of callback functions
+   */
   void setCallbacks(const std::vector<boost::shared_ptr<CallbackAbstract> >& callbacks);
+
+  /**
+   * @brief "Return the list of callback functions using for diagnostic
+   */
   const std::vector<boost::shared_ptr<CallbackAbstract> >& getCallbacks() const;
 
+  /**
+   * @brief Return the shooting problem
+   */
   const boost::shared_ptr<ShootingProblem>& get_problem() const;
+
+  /**
+   * @brief Return the state trajectory \f$\mathbf{x}_s\f$
+   */
   const std::vector<Eigen::VectorXd>& get_xs() const;
+
+  /**
+   * @brief Return the control trajectory \f$\mathbf{u}_s\f$
+   */
   const std::vector<Eigen::VectorXd>& get_us() const;
+
+  /**
+   * @brief Return the feasibility status of the \f$(\mathbf{x}_s,\mathbf{u}_s)\f$ trajectory
+   */
   const bool& get_is_feasible() const;
+
+  /**
+   * @brief Return the total cost
+   */
   const double& get_cost() const;
+
+  /**
+   * @brief Return the value computed by `stoppingCriteria()`
+   */
   const double& get_stop() const;
+
+  /**
+   * @brief Return the LQ approximation of the expected improvement
+   */
   const Eigen::Vector2d& get_d() const;
+
+  /**
+   * @brief Return the state regularization value
+   */
   const double& get_xreg() const;
+
+  /**
+   * @brief Return the control regularization value
+   */
   const double& get_ureg() const;
+
+  /**
+   * @brief Return the step length
+   */
   const double& get_steplength() const;
+
+  /**
+   * @brief Return the cost reduction
+   */
   const double& get_dV() const;
+
+  /**
+   * @brief Return the expected cost reduction
+   */
   const double& get_dVexp() const;
+
+  /**
+   * @brief Return the threshold used for accepting a step
+   */
   const double& get_th_acceptstep() const;
+
+  /**
+   * @brief Return the tolerance for stopping the algorithm
+   */
   const double& get_th_stop() const;
+
+  /**
+   * @brief Return the number of iterations performed by the solver
+   */
   const std::size_t& get_iter() const;
 
+  /**
+   * @brief Modify the state trajectory \f$\mathbf{x}_s\f$
+   */
   void set_xs(const std::vector<Eigen::VectorXd>& xs);
+
+  /**
+   * @brief Modify the control trajectory \f$\mathbf{u}_s\f$
+   */
   void set_us(const std::vector<Eigen::VectorXd>& us);
+
+  /**
+   * @brief Modify the state regularization value
+   */
   void set_xreg(const double& xreg);
+
+  /**
+   * @brief Modify the control regularization value
+   */
   void set_ureg(const double& ureg);
+
+  /**
+   * @brief Modify the threshold used for accepting step
+   */
   void set_th_acceptstep(const double& th_acceptstep);
+
+  /**
+   * @brief Modify the tolerance for stopping the algorithm
+   */
   void set_th_stop(const double& th_stop);
 
  protected:
@@ -69,23 +275,38 @@ class SolverAbstract {
   std::vector<boost::shared_ptr<CallbackAbstract> > callbacks_;  //!< Callback functions
   bool is_feasible_;                                             //!< Label that indicates is the iteration is feasible
   double cost_;                                                  //!< Total cost
-  double stop_;                                                  //!< Value computed by stoppingCriteria
+  double stop_;                                                  //!< Value computed by `stoppingCriteria()`
   Eigen::Vector2d d_;                                            //!< LQ approximation of the expected improvement
   double xreg_;                                                  //!< Current state regularization value
   double ureg_;                                                  //!< Current control regularization values
   double steplength_;                                            //!< Current applied step-length
-  double dV_;                                                    //!< Cost reduction obtained by tryStep
+  double dV_;                                                    //!< Cost reduction obtained by `tryStep()`
   double dVexp_;                                                 //!< Expected cost reduction
   double th_acceptstep_;                                         //!< Threshold used for accepting step
   double th_stop_;                                               //!< Tolerance for stopping the algorithm
   std::size_t iter_;                                             //!< Number of iteration performed by the solver
 };
 
+/**
+ * @brief Abstract class for solver callbacks
+ *
+ * A callback is used to diagnostic the behaviour of our solver in each iteration of it. For instance, it can be used
+ * to print values, record data or display motions.
+ */
 class CallbackAbstract {
  public:
+
+  /**
+   * @brief Initialize the callback function
+   */
   CallbackAbstract() {}
   virtual ~CallbackAbstract() {}
 
+  /**
+   * @brief Run the callback function given a solver
+   * 
+   * @param[in]  solver solver to be diagnostic
+   */
   virtual void operator()(SolverAbstract& solver) = 0;
 };
 

--- a/include/crocoddyl/core/solvers/ddp.hpp
+++ b/include/crocoddyl/core/solvers/ddp.hpp
@@ -16,10 +16,44 @@
 
 namespace crocoddyl {
 
+/**
+ * @brief DDP solver
+ *
+ * The DDP solver computes an optimal trajectory and control commands by iterates running `backwardPass()` and
+ * `forwardPass()`. The backward-pass updates locally the quadratic approximation of the problem and computes descent
+ * direction. If the warm-start is feasible, then it computes the gaps \f$\mathbf{\bar{f}}_s\f$ and run a modified
+ * Riccati sweep:
+ * \f{eqnarray*}
+ *   \mathbf{Q}_{\mathbf{x}_k} &=& \mathbf{l}_{\mathbf{x}_k} + \mathbf{f}^\top_{\mathbf{x}_k} (V_{\mathbf{x}_{k+1}} +
+ * V_{\mathbf{xx}_{k+1}}\mathbf{\bar{f}}_{k+1}),\\
+ *   \mathbf{Q}_{\mathbf{u}_k} &=& \mathbf{l}_{\mathbf{u}_k} + \mathbf{f}^\top_{\mathbf{u}_k} (V_{\mathbf{x}_{k+1}} +
+ * V_{\mathbf{xx}_{k+1}}\mathbf{\bar{f}}_{k+1}),\\
+ *   \mathbf{Q}_{\mathbf{xx}_k} &=& \mathbf{l}_{\mathbf{xx}_k} + \mathbf{f}^\top_{\mathbf{x}_k} V_{\mathbf{xx}_{k+1}}
+ * \mathbf{f}_{\mathbf{x}_k},\\
+ *   \mathbf{Q}_{\mathbf{xu}_k} &=& \mathbf{l}_{\mathbf{xu}_k} + \mathbf{f}^\top_{\mathbf{x}_k} V_{\mathbf{xx}_{k+1}}
+ * \mathbf{f}_{\mathbf{u}_k},\\
+ *   \mathbf{Q}_{\mathbf{uu}_k} &=& \mathbf{l}_{\mathbf{uu}_k} + \mathbf{f}^\top_{\mathbf{u}_k} V_{\mathbf{xx}_{k+1}}
+ * \mathbf{f}_{\mathbf{u}_k}.
+ * \f}
+ * Then, the forward-pass rollouts this new policy by integrating the system dynamics along a tuple of optimized
+ * control commands \f$\mathbf{u}^*_s\f$, i.e.
+ * \f{eqnarray}
+ *   \mathbf{\hat{x}}_0 &=& \mathbf{\tilde{x}}_0,\\
+ *   \mathbf{\hat{u}}_k &=& \mathbf{u}_k + \alpha\mathbf{k}_k + \mathbf{K}_k(\mathbf{\hat{x}}_k-\mathbf{x}_k),\\
+ *   \mathbf{\hat{x}}_{k+1} &=& \mathbf{f}_k(\mathbf{\hat{x}}_k,\mathbf{\hat{u}}_k).
+ * \f}
+ *
+ * \sa `backwardPass()` and `forwardPass()`
+ */
 class SolverDDP : public SolverAbstract {
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
+  /**
+   * @brief Initialize the DDP solver
+   *
+   * @param[in] problem  Shooting problem
+   */
   explicit SolverDDP(boost::shared_ptr<ShootingProblem> problem);
   virtual ~SolverDDP();
 
@@ -30,39 +64,210 @@ class SolverDDP : public SolverAbstract {
   virtual double tryStep(const double& steplength = 1);
   virtual double stoppingCriteria();
   virtual const Eigen::Vector2d& expectedImprovement();
+
+  /**
+   * @brief Update the Jacobian and Hessian of the optimal control problem
+   *
+   * These derivatives are computed around the guess state and control trajectory. These trajectory can be set by using
+   * `setCandidate()`.
+   *
+   * @return  The total cost around the guess trajectory
+   */
   virtual double calcDiff();
+
+  /**
+   * @brief Run the backward pass (Riccati sweep)
+   *
+   * It assumes that the Jacobian and Hessians of the optimal control problem have been compute (i.e. `calcDiff()`).
+   * The backward pass handles infeasible guess through a modified Riccati sweep:
+   * \f{eqnarray*}
+   *   \mathbf{Q}_{\mathbf{x}_k} &=& \mathbf{l}_{\mathbf{x}_k} + \mathbf{f}^\top_{\mathbf{x}_k} (V_{\mathbf{x}_{k+1}}
+   * +
+   * V_{\mathbf{xx}_{k+1}}\mathbf{\bar{f}}_{k+1}),\\
+   *   \mathbf{Q}_{\mathbf{u}_k} &=& \mathbf{l}_{\mathbf{u}_k} + \mathbf{f}^\top_{\mathbf{u}_k} (V_{\mathbf{x}_{k+1}}
+   * +
+   * V_{\mathbf{xx}_{k+1}}\mathbf{\bar{f}}_{k+1}),\\
+   *   \mathbf{Q}_{\mathbf{xx}_k} &=& \mathbf{l}_{\mathbf{xx}_k} + \mathbf{f}^\top_{\mathbf{x}_k}
+   * V_{\mathbf{xx}_{k+1}}
+   * \mathbf{f}_{\mathbf{x}_k},\\
+   *   \mathbf{Q}_{\mathbf{xu}_k} &=& \mathbf{l}_{\mathbf{xu}_k} + \mathbf{f}^\top_{\mathbf{x}_k}
+   * V_{\mathbf{xx}_{k+1}}
+   * \mathbf{f}_{\mathbf{u}_k},\\
+   *   \mathbf{Q}_{\mathbf{uu}_k} &=& \mathbf{l}_{\mathbf{uu}_k} + \mathbf{f}^\top_{\mathbf{u}_k}
+   * V_{\mathbf{xx}_{k+1}} \mathbf{f}_{\mathbf{u}_k}, \f} where
+   * \f$\mathbf{l}_{\mathbf{x}_k}\f$,\f$\mathbf{l}_{\mathbf{u}_k}\f$,\f$\mathbf{f}_{\mathbf{x}_k}\f$ and
+   * \f$\mathbf{f}_{\mathbf{u}_k}\f$ are the Jacobians of the cost function and dynamics,
+   * \f$\mathbf{l}_{\mathbf{xx}_k}\f$,\f$\mathbf{l}_{\mathbf{xu}_k}\f$ and \f$\mathbf{l}_{\mathbf{uu}_k}\f$ are the
+   * Hessians of the cost function, \f$V_{\mathbf{x}_{k+1}}\f$ and \f$V_{\mathbf{xx}_{k+1}}\f$ defines the
+   * linear-quadratic approximation of the Value function, and \f$\mathbf{\bar{f}}_{k+1}\f$ describes the gaps of the
+   * dynamics.
+   */
   virtual void backwardPass();
+
+  /**
+   * @brief Run the forward pass or rollout
+   *
+   * It rollouts the action model given the computed policy (feedforward terns and feedback gains) by the
+   * `backwardPass()`:
+   * \f{eqnarray}
+   *   \mathbf{\hat{x}}_0 &=& \mathbf{\tilde{x}}_0,\\
+   *   \mathbf{\hat{u}}_k &=& \mathbf{u}_k + \alpha\mathbf{k}_k + \mathbf{K}_k(\mathbf{\hat{x}}_k-\mathbf{x}_k),\\
+   *   \mathbf{\hat{x}}_{k+1} &=& \mathbf{f}_k(\mathbf{\hat{x}}_k,\mathbf{\hat{u}}_k).
+   * \f}
+   * We can define different step lengths \f$\alpha\f$.
+   *
+   * @param  stepLength  applied step length (\f$0\leq\alpha\leq1\f$)
+   */
   virtual void forwardPass(const double& stepLength);
 
+  /**
+   * @brief Compute the feedforward and feedback terms using a Cholesky decomposition
+   *
+   * To compute the feedforward \f$\mathbf{k}_k\f$ and feedback \f$\mathbf{K}_k\f$ terms, we use a Cholesky
+   * decomposition to solve \f$\mathbf{Q}_{\mathbf{uu}_k}^{-1}\f$ term:
+   * \f{eqnarray}
+   * \mathbf{k}_k &=& \mathbf{Q}_{\mathbf{uu}_k}^{-1}\mathbf{Q}_{\mathbf{u}},\\
+   * \mathbf{K}_k &=& \mathbf{Q}_{\mathbf{uu}_k}^{-1}\mathbf{Q}_{\mathbf{ux}}.
+   * \f}
+   *
+   * Note that if the Cholesky decomposition fails, then we re-start the backward pass and increase the
+   * state and control regularization values.
+   */
   virtual void computeGains(const std::size_t& t);
+
+  /**
+   * @brief Increase the state and control regularization values by a `regfactor_` factor
+   */
   void increaseRegularization();
+
+  /**
+   * @brief Decrease the state and control regularization values by a `regfactor_` factor
+   */
   void decreaseRegularization();
+
+  /**
+   * @brief Allocate all the internal data needed for the solver
+   */
   virtual void allocateData();
 
+  /**
+   * @brief Return the regularization factor used to decrease / increase it
+   */
   const double& get_regfactor() const;
+
+  /**
+   * @brief Return the minimum regularization value
+   */
   const double& get_regmin() const;
+
+  /**
+   * @brief Return the maximum regularization value
+   */
   const double& get_regmax() const;
+
+  /**
+   * @brief Return the set of step lengths using by the line-search procedure
+   */
   const std::vector<double>& get_alphas() const;
+
+  /**
+   * @brief Return the step-length threshold used to decrease regularization
+   */
   const double& get_th_stepdec() const;
+
+  /**
+   * @brief Return the step-length threshold used to increase regularization
+   */
   const double& get_th_stepinc() const;
+
+  /**
+   * @brief Return the tolerance of the expected gradient used for testing the step
+   */
   const double& get_th_grad() const;
+
+  /**
+   * @brief Return the Hessian of the Value function \f$V_{\mathbf{xx}_s}\f$
+   */
   const std::vector<Eigen::MatrixXd>& get_Vxx() const;
+
+  /**
+   * @brief Return the Hessian of the Value function \f$V_{\mathbf{x}_s}\f$
+   */
   const std::vector<Eigen::VectorXd>& get_Vx() const;
+
+  /**
+   * @brief Return the Hessian of the Hamiltonian function \f$\mathbf{Q}_{\mathbf{xx}_s}\f$
+   */
   const std::vector<Eigen::MatrixXd>& get_Qxx() const;
+
+  /**
+   * @brief Return the Hessian of the Hamiltonian function \f$\mathbf{Q}_{\mathbf{xu}_s}\f$
+   */
   const std::vector<Eigen::MatrixXd>& get_Qxu() const;
+
+  /**
+   * @brief Return the Hessian of the Hamiltonian function \f$\mathbf{Q}_{\mathbf{uu}_s}\f$
+   */
   const std::vector<Eigen::MatrixXd>& get_Quu() const;
+
+  /**
+   * @brief Return the Jacobian of the Hamiltonian function \f$\mathbf{Q}_{\mathbf{x}_s}\f$
+   */
   const std::vector<Eigen::VectorXd>& get_Qx() const;
+
+  /**
+   * @brief Return the Jacobian of the Hamiltonian function \f$\mathbf{Q}_{\mathbf{u}_s}\f$
+   */
   const std::vector<Eigen::VectorXd>& get_Qu() const;
+
+  /**
+   * @brief Return the feedback gains \f$\mathbf{K}_{s}\f$
+   */
   const std::vector<Eigen::MatrixXd>& get_K() const;
+
+  /**
+   * @brief Return the feedforward gains \f$\mathbf{k}_{s}\f$
+   */
   const std::vector<Eigen::VectorXd>& get_k() const;
+
+  /**
+   * @brief Return the gaps \f$\mathbf{\bar{f}}_{s}\f$
+   */
   const std::vector<Eigen::VectorXd>& get_fs() const;
 
+  /**
+   * @brief Modify the regularization factor used to decrease / increase it
+   */
   void set_regfactor(const double& reg_factor);
+
+  /**
+   * @brief Modify the minimum regularization value
+   */
   void set_regmin(const double& regmin);
+
+  /**
+   * @brief Modify the maximum regularization value
+   */
   void set_regmax(const double& regmax);
+
+  /**
+   * @brief Modify the set of step lengths using by the line-search procedure
+   */
   void set_alphas(const std::vector<double>& alphas);
+
+  /**
+   * @brief Modify the step-length threshold used to decrease regularization
+   */
   void set_th_stepdec(const double& th_step);
+
+  /**
+   * @brief Modify the step-length threshold used to increase regularization
+   */
   void set_th_stepinc(const double& th_step);
+
+  /**
+   * @brief Modify the tolerance of the expected gradient used for testing the step
+   */
   void set_th_grad(const double& th_grad);
 
  protected:
@@ -87,17 +292,17 @@ class SolverDDP : public SolverAbstract {
   std::vector<Eigen::VectorXd> k_;    //!< Feed-forward terms
   std::vector<Eigen::VectorXd> fs_;   //!< Gaps/defects between shooting nodes
 
-  Eigen::VectorXd xnext_;
-  Eigen::MatrixXd FxTVxx_p_;
-  std::vector<Eigen::MatrixXd> FuTVxx_p_;
-  Eigen::VectorXd fTVxx_p_;
-  std::vector<Eigen::LLT<Eigen::MatrixXd> > Quu_llt_;
-  std::vector<Eigen::VectorXd> Quuk_;
-  std::vector<double> alphas_;  //!< Set of step lengths using by the line-search procedure
-  double th_grad_;              //!< Tolerance of the expected gradient used for testing the step
-  double th_stepdec_;           //!< Step-length threshold used to decrease regularization
-  double th_stepinc_;           //!< Step-length threshold used to increase regularization
-  bool was_feasible_;           //!< Label that indicates in the previous iterate was feasible
+  Eigen::VectorXd xnext_;                              //!< Next state
+  Eigen::MatrixXd FxTVxx_p_;                           //!< fxTVxx_p_
+  std::vector<Eigen::MatrixXd> FuTVxx_p_;              //!< fuTVxx_p_
+  Eigen::VectorXd fTVxx_p_;                            //!< fTVxx_p term
+  std::vector<Eigen::LLT<Eigen::MatrixXd> > Quu_llt_;  //!< Cholesky LLT solver
+  std::vector<Eigen::VectorXd> Quuk_;                  //!< Quuk term
+  std::vector<double> alphas_;                         //!< Set of step lengths using by the line-search procedure
+  double th_grad_;     //!< Tolerance of the expected gradient used for testing the step
+  double th_stepdec_;  //!< Step-length threshold used to decrease regularization
+  double th_stepinc_;  //!< Step-length threshold used to increase regularization
+  bool was_feasible_;  //!< Label that indicates in the previous iterate was feasible
 };
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/core/solvers/ddp.hpp
+++ b/include/crocoddyl/core/solvers/ddp.hpp
@@ -17,7 +17,7 @@
 namespace crocoddyl {
 
 /**
- * @brief DDP solver
+ * @brief Differential Dynamic Programming (DDP) solver
  *
  * The DDP solver computes an optimal trajectory and control commands by iterates running `backwardPass()` and
  * `forwardPass()`. The backward-pass updates locally the quadratic approximation of the problem and computes descent

--- a/include/crocoddyl/core/solvers/fddp.hpp
+++ b/include/crocoddyl/core/solvers/fddp.hpp
@@ -16,28 +16,86 @@
 
 namespace crocoddyl {
 
+/**
+ * @brief Feasibility-driven Differential Dynamic Programming (FDDP) solver
+ *
+ * The FDDP solver computes an optimal trajectory and control commands by iterates running `backwardPass()` and
+ * `forwardPass()`. The backward pass accepts infeasible guess as described in the `SolverDDP::backwardPass()`.
+ * Additionally, the forward pass handles infeasibility simulations that resembles the numerical behaviour of
+ * a multiple-shooting formulation, i.e.:
+ * \f{eqnarray}
+ *   \mathbf{\hat{x}}_0 &=& \mathbf{\tilde{x}}_0 - (1 - \alpha)\mathbf{\bar{f}}_0,\\
+ *   \mathbf{\hat{u}}_k &=& \mathbf{u}_k + \alpha\mathbf{k}_k + \mathbf{K}_k(\mathbf{\hat{x}}_k-\mathbf{x}_k),\\
+ *   \mathbf{\hat{x}}_{k+1} &=& \mathbf{f}_k(\mathbf{\hat{x}}_k,\mathbf{\hat{u}}_k) - (1 -
+ * \alpha)\mathbf{\bar{f}}_{k+1}.
+ * \f}
+ * Note that the forward pass keeps the gaps \f$\mathbf{\bar{f}}_s\f$ open according to the step length \f$\alpha\f$
+ * that has been accepted. This solver has shown empirically greater globalization strategy. Additionally, the
+ * expected improvement computation considers the gaps in the dynamics:
+ * \f{equation}
+ *   \Delta J(\alpha) = \Delta_1\alpha + \frac{1}{2}\Delta_2\alpha^2,
+ * \f}
+ * with
+ * \f{eqnarray}
+ *   \Delta_1 = \sum_{k=0}^{N-1} \mathbf{k}_k^\top\mathbf{Q}_{\mathbf{u}_k} +\mathbf{\bar{f}}_k^\top(V_{\mathbf{x}_k} -
+ *   V_{\mathbf{xx}_k}\mathbf{x}_k),\nonumber\\ \Delta_2 = \sum_{k=0}^{N-1}
+ *   \mathbf{k}_k^\top\mathbf{Q}_{\mathbf{uu}_k}\mathbf{k}_k + \mathbf{\bar{f}}_k^\top(2 V_{\mathbf{xx}_k}\mathbf{x}_k
+ * - V_{\mathbf{xx}_k}\mathbf{\bar{f}}_k). \f}
+ *
+ * For more details about the feasibility-driven differential dynamic programming algorithm see:
+ * \include mastalli-icra20.bib
+ *
+ * \sa `backwardPass()`, `forwardPass()`, `expectedImprovement()` and `updateExpectedImprovement()`
+ */
 class SolverFDDP : public SolverDDP {
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
+  /**
+   * @brief Initialize the FDDP solver
+   */
   explicit SolverFDDP(boost::shared_ptr<ShootingProblem> problem);
   virtual ~SolverFDDP();
 
   virtual bool solve(const std::vector<Eigen::VectorXd>& init_xs = DEFAULT_VECTOR,
                      const std::vector<Eigen::VectorXd>& init_us = DEFAULT_VECTOR, const std::size_t& maxiter = 100,
                      const bool& is_feasible = false, const double& regInit = 1e-9);
+
+  /**
+   * @copybrief SolverAbstract::expectedImprovement
+   *
+   * This function requires to first run `updateExpectedImprovement()`. The expected improvement computation considers
+   * the gaps in the dynamics: \f{equation} \Delta J(\alpha) = \Delta_1\alpha + \frac{1}{2}\Delta_2\alpha^2, \f} with
+   * \f{eqnarray}
+   *   \Delta_1 = \sum_{k=0}^{N-1} \mathbf{k}_k^\top\mathbf{Q}_{\mathbf{u}_k} +\mathbf{\bar{f}}_k^\top(V_{\mathbf{x}_k}
+   * - V_{\mathbf{xx}_k}\mathbf{x}_k),\nonumber\\ \Delta_2 = \sum_{k=0}^{N-1}
+   *   \mathbf{k}_k^\top\mathbf{Q}_{\mathbf{uu}_k}\mathbf{k}_k + \mathbf{\bar{f}}_k^\top(2
+   * V_{\mathbf{xx}_k}\mathbf{x}_k
+   * - V_{\mathbf{xx}_k}\mathbf{\bar{f}}_k). \f}
+   */
   virtual const Eigen::Vector2d& expectedImprovement();
+
+  /**
+   * @brief Update internal values for computing the expected improvement
+   */
   void updateExpectedImprovement();
   virtual double calcDiff();
   virtual void forwardPass(const double& stepLength);
 
+  /**
+   * @brief Return the threshold used for accepting step along ascent direction
+   */
   double get_th_acceptnegstep() const;
+
+  /**
+   * @brief Modify the threshold used for accepting step along ascent direction
+   */
   void set_th_acceptnegstep(const double& th_acceptnegstep);
 
  protected:
-  double dg_;
-  double dq_;
-  double dv_;
+  double dg_;  //!< Internal data for computing the expected improvement
+  double dq_;  //!< Internal data for computing the expected improvement
+  double dv_;  //!< Internal data for computing the expected improvement
 
  private:
   double th_acceptnegstep_;  //!< Threshold used for accepting step along ascent direction

--- a/include/crocoddyl/core/state-base.hpp
+++ b/include/crocoddyl/core/state-base.hpp
@@ -29,7 +29,7 @@ inline bool is_a_Jcomponent(Jcomponent firstsecond) {
 inline bool is_a_AssignmentOp(AssignmentOp op) { return (op == setto || op == addto || op == rmfrom); }
 
 /**
- * @brief This class abstract state representations
+ * @brief Abstract class for the state representation
  *
  * A state is represented by its operators: difference, integrates, transport and their derivatives.
  * The difference operator returns the value of \f$\mathbf{x}_{1}\ominus\mathbf{x}_{0}\f$ operation.
@@ -38,6 +38,8 @@ inline bool is_a_AssignmentOp(AssignmentOp op) { return (op == setto || op == ad
  * given a tangential velocity (\f$T_\mathbf{x} \mathcal{M}\f$). Therefore the points \f$\mathbf{x}\f$,
  * \f$\mathbf{x}_{0}\f$ and \f$\mathbf{x}_{1}\f$ belong to the manifold \f$\mathcal{M}\f$; and \f$\delta\mathbf{x}\f$
  * or \f$\mathbf{x}_{1}\ominus\mathbf{x}_{0}\f$ lie on its tangential space.
+ *
+ * \sa `diff()`, `integrate()`, `Jdiff()`, `Jintegrate()` and `JintegrateTransport()`
  */
 template <typename _Scalar>
 class StateAbstractTpl {

--- a/include/crocoddyl/multibody/utils/quadruped-gaits.hpp
+++ b/include/crocoddyl/multibody/utils/quadruped-gaits.hpp
@@ -57,7 +57,7 @@ class SimpleQuadrupedGaitProblem {
 
   boost::shared_ptr<ActionModelAbstract> createFootSwitchModel(
       const std::vector<pinocchio::FrameIndex>& supportFootIds, const std::vector<FramePlacement>& swingFootTask,
-      bool pseudoImpulse = true);
+      bool pseudoImpulse = false);
 
   boost::shared_ptr<ActionModelAbstract> createPseudoImpulseModel(
       const std::vector<pinocchio::FrameIndex>& supportFootIds, const std::vector<FramePlacement>& swingFootTask);

--- a/src/core/solver-base.cpp
+++ b/src/core/solver-base.cpp
@@ -30,10 +30,9 @@ SolverAbstract::SolverAbstract(boost::shared_ptr<ShootingProblem> problem)
   us_.resize(T);
   for (std::size_t t = 0; t < T; ++t) {
     const boost::shared_ptr<ActionModelAbstract>& model = problem_->get_runningModels()[t];
-    const std::size_t& nu = model->get_nu();
 
     xs_[t] = model->get_state()->zero();
-    us_[t] = Eigen::VectorXd::Zero(nu);
+    us_[t] = Eigen::VectorXd::Zero(problem_->get_nu());
   }
   xs_.back() = problem_->get_terminalModel()->get_state()->zero();
 }
@@ -57,8 +56,7 @@ void SolverAbstract::setCandidate(const std::vector<Eigen::VectorXd>& xs_warm,
 
   if (us_warm.size() == 0) {
     for (std::size_t t = 0; t < T; ++t) {
-      const std::size_t& nu = problem_->get_runningModels()[t]->get_nu();
-      us_[t] = Eigen::VectorXd::Zero(nu);
+      us_[t] = Eigen::VectorXd::Zero(problem_->get_nu());
     }
   } else {
     assert_pretty(us_warm.size() == T,
@@ -111,16 +109,13 @@ void SolverAbstract::set_xs(const std::vector<Eigen::VectorXd>& xs) {
                  << "xs list has to be " + std::to_string(T + 1));
   }
 
+  const std::size_t& nx = problem_->get_nx();
   for (std::size_t t = 0; t < T; ++t) {
-    const boost::shared_ptr<ActionModelAbstract>& model = problem_->get_runningModels()[t];
-    const std::size_t& nx = model->get_state()->get_nx();
     if (static_cast<std::size_t>(xs[t].size()) != nx) {
       throw_pretty("Invalid argument: "
                    << "xs[" + std::to_string(t) + "] has wrong dimension (it should be " + std::to_string(nx) + ")")
     }
   }
-  const boost::shared_ptr<ActionModelAbstract>& model = problem_->get_terminalModel();
-  const std::size_t& nx = model->get_state()->get_nx();
   if (static_cast<std::size_t>(xs[T].size()) != nx) {
     throw_pretty("Invalid argument: "
                  << "xs[" + std::to_string(T) + "] has wrong dimension (it should be " + std::to_string(nx) + ")")
@@ -135,10 +130,9 @@ void SolverAbstract::set_us(const std::vector<Eigen::VectorXd>& us) {
                  << "us list has to be " + std::to_string(T));
   }
 
+  const std::size_t& nu = problem_->get_nu();
   for (std::size_t t = 0; t < T; ++t) {
-    const boost::shared_ptr<ActionModelAbstract>& model = problem_->get_runningModels()[t];
-    const std::size_t& nu = model->get_nu();
-    if (static_cast<std::size_t>(us[t].size()) != nu && nu != 0) {
+    if (static_cast<std::size_t>(us[t].size()) != nu) {
       throw_pretty("Invalid argument: "
                    << "us[" + std::to_string(t) + "] has wrong dimension (it should be " + std::to_string(nu) + ")")
     }

--- a/src/core/solvers/box-ddp.cpp
+++ b/src/core/solvers/box-ddp.cpp
@@ -97,11 +97,15 @@ void SolverBoxDDP::forwardPass(const double& steplength) {
 
     xs_try_[t] = xnext_;
     m->get_state()->diff(xs_[t], xs_try_[t], dx_[t]);
-    us_try_[t].noalias() = us_[t] - k_[t] * steplength - K_[t] * dx_[t];
-    if (m->get_has_control_limits()) {  // clamp control
-      us_try_[t] = us_try_[t].cwiseMax(m->get_u_lb()).cwiseMin(m->get_u_ub());
+    if (m->get_nu() != 0) {
+      us_try_[t].noalias() = us_[t] - k_[t] * steplength - K_[t] * dx_[t];
+      if (m->get_has_control_limits()) {  // clamp control
+        us_try_[t] = us_try_[t].cwiseMax(m->get_u_lb()).cwiseMin(m->get_u_ub());
+      }
+      m->calc(d, xs_try_[t], us_try_[t]);
+    } else {
+      m->calc(d, xs_try_[t]);
     }
-    m->calc(d, xs_try_[t], us_try_[t]);
     xnext_ = d->xnext;
     cost_try_ += d->cost;
 

--- a/src/core/solvers/box-ddp.cpp
+++ b/src/core/solvers/box-ddp.cpp
@@ -89,9 +89,12 @@ void SolverBoxDDP::forwardPass(const double& steplength) {
   cost_try_ = 0.;
   xnext_ = problem_->get_x0();
   const std::size_t& T = problem_->get_T();
+  const std::vector<boost::shared_ptr<ActionModelAbstract> >& models = problem_->get_runningModels();
+  const std::vector<boost::shared_ptr<ActionDataAbstract> >& datas = problem_->get_runningDatas();
   for (std::size_t t = 0; t < T; ++t) {
-    const boost::shared_ptr<ActionModelAbstract>& m = problem_->get_runningModels()[t];
-    const boost::shared_ptr<ActionDataAbstract>& d = problem_->get_runningDatas()[t];
+    const boost::shared_ptr<ActionModelAbstract>& m = models[t];
+    const boost::shared_ptr<ActionDataAbstract>& d = datas[t];
+
     xs_try_[t] = xnext_;
     m->get_state()->diff(xs_[t], xs_try_[t], dx_[t]);
     us_try_[t].noalias() = us_[t] - k_[t] * steplength - K_[t] * dx_[t];
@@ -112,7 +115,6 @@ void SolverBoxDDP::forwardPass(const double& steplength) {
 
   const boost::shared_ptr<ActionModelAbstract>& m = problem_->get_terminalModel();
   const boost::shared_ptr<ActionDataAbstract>& d = problem_->get_terminalData();
-
   if ((is_feasible_) || (steplength == 1)) {
     xs_try_.back() = xnext_;
   } else {

--- a/src/core/solvers/box-ddp.cpp
+++ b/src/core/solvers/box-ddp.cpp
@@ -33,21 +33,14 @@ SolverBoxDDP::~SolverBoxDDP() {}
 void SolverBoxDDP::allocateData() {
   SolverDDP::allocateData();
 
-  std::size_t nu_max = 0;
   const std::size_t& T = problem_->get_T();
   Quu_inv_.resize(T);
+  const std::size_t& nu = problem_->get_nu();
   for (std::size_t t = 0; t < T; ++t) {
-    const boost::shared_ptr<ActionModelAbstract>& model = problem_->get_runningModels()[t];
-    const std::size_t& nu = model->get_nu();
-
-    // Store the largest number of controls across all models to allocate du_lb_, du_ub_
-    if (nu > nu_max) nu_max = nu;
-
     Quu_inv_[t] = Eigen::MatrixXd::Zero(nu, nu);
   }
-
-  du_lb_.resize(nu_max);
-  du_ub_.resize(nu_max);
+  du_lb_.resize(nu);
+  du_ub_.resize(nu);
 }
 
 void SolverBoxDDP::computeGains(const std::size_t& t) {

--- a/src/core/solvers/box-fddp.cpp
+++ b/src/core/solvers/box-fddp.cpp
@@ -89,10 +89,13 @@ void SolverBoxFDDP::forwardPass(const double& steplength) {
   cost_try_ = 0.;
   xnext_ = problem_->get_x0();
   const std::size_t& T = problem_->get_T();
+  const std::vector<boost::shared_ptr<ActionModelAbstract> >& models = problem_->get_runningModels();
+  const std::vector<boost::shared_ptr<ActionDataAbstract> >& datas = problem_->get_runningDatas();
   if ((is_feasible_) || (steplength == 1)) {
     for (std::size_t t = 0; t < T; ++t) {
-      const boost::shared_ptr<ActionModelAbstract>& m = problem_->get_runningModels()[t];
-      const boost::shared_ptr<ActionDataAbstract>& d = problem_->get_runningDatas()[t];
+      const boost::shared_ptr<ActionModelAbstract>& m = models[t];
+      const boost::shared_ptr<ActionDataAbstract>& d = datas[t];
+
       xs_try_[t] = xnext_;
       m->get_state()->diff(xs_[t], xs_try_[t], dx_[t]);
       us_try_[t].noalias() = us_[t] - k_[t] * steplength - K_[t] * dx_[t];
@@ -122,8 +125,9 @@ void SolverBoxFDDP::forwardPass(const double& steplength) {
     }
   } else {
     for (std::size_t t = 0; t < T; ++t) {
-      const boost::shared_ptr<ActionModelAbstract>& m = problem_->get_runningModels()[t];
-      const boost::shared_ptr<ActionDataAbstract>& d = problem_->get_runningDatas()[t];
+      const boost::shared_ptr<ActionModelAbstract>& m = models[t];
+      const boost::shared_ptr<ActionDataAbstract>& d = datas[t];
+
       m->get_state()->integrate(xnext_, fs_[t] * (steplength - 1), xs_try_[t]);
       m->get_state()->diff(xs_[t], xs_try_[t], dx_[t]);
       us_try_[t].noalias() = us_[t] - k_[t] * steplength - K_[t] * dx_[t];

--- a/src/core/solvers/box-fddp.cpp
+++ b/src/core/solvers/box-fddp.cpp
@@ -98,11 +98,15 @@ void SolverBoxFDDP::forwardPass(const double& steplength) {
 
       xs_try_[t] = xnext_;
       m->get_state()->diff(xs_[t], xs_try_[t], dx_[t]);
-      us_try_[t].noalias() = us_[t] - k_[t] * steplength - K_[t] * dx_[t];
-      if (m->get_has_control_limits()) {  // clamp control
-        us_try_[t] = us_try_[t].cwiseMax(m->get_u_lb()).cwiseMin(m->get_u_ub());
+      if (m->get_nu() != 0) {
+        us_try_[t].noalias() = us_[t] - k_[t] * steplength - K_[t] * dx_[t];
+        if (m->get_has_control_limits()) {  // clamp control
+          us_try_[t] = us_try_[t].cwiseMax(m->get_u_lb()).cwiseMin(m->get_u_ub());
+        }
+        m->calc(d, xs_try_[t], us_try_[t]);
+      } else {
+        m->calc(d, xs_try_[t]);
       }
-      m->calc(d, xs_try_[t], us_try_[t]);
       xnext_ = d->xnext;
       cost_try_ += d->cost;
 
@@ -130,11 +134,15 @@ void SolverBoxFDDP::forwardPass(const double& steplength) {
 
       m->get_state()->integrate(xnext_, fs_[t] * (steplength - 1), xs_try_[t]);
       m->get_state()->diff(xs_[t], xs_try_[t], dx_[t]);
-      us_try_[t].noalias() = us_[t] - k_[t] * steplength - K_[t] * dx_[t];
-      if (m->get_has_control_limits()) {  // clamp control
-        us_try_[t] = us_try_[t].cwiseMax(m->get_u_lb()).cwiseMin(m->get_u_ub());
+      if (m->get_nu() != 0) {
+        us_try_[t].noalias() = us_[t] - k_[t] * steplength - K_[t] * dx_[t];
+        if (m->get_has_control_limits()) {  // clamp control
+          us_try_[t] = us_try_[t].cwiseMax(m->get_u_lb()).cwiseMin(m->get_u_ub());
+        }
+        m->calc(d, xs_try_[t], us_try_[t]);
+      } else {
+        m->calc(d, xs_try_[t]);
       }
-      m->calc(d, xs_try_[t], us_try_[t]);
       xnext_ = d->xnext;
       cost_try_ += d->cost;
 

--- a/src/core/solvers/box-fddp.cpp
+++ b/src/core/solvers/box-fddp.cpp
@@ -33,21 +33,14 @@ SolverBoxFDDP::~SolverBoxFDDP() {}
 void SolverBoxFDDP::allocateData() {
   SolverDDP::allocateData();
 
-  std::size_t nu_max = 0;
   const std::size_t& T = problem_->get_T();
   Quu_inv_.resize(T);
+  const std::size_t& nu = problem_->get_nu();
   for (std::size_t t = 0; t < T; ++t) {
-    const boost::shared_ptr<ActionModelAbstract>& model = problem_->get_runningModels()[t];
-    const std::size_t& nu = model->get_nu();
-
-    // Store the largest number of controls across all models to allocate du_lb_, du_ub_
-    if (nu > nu_max) nu_max = nu;
-
     Quu_inv_[t] = Eigen::MatrixXd::Zero(nu, nu);
   }
-
-  du_lb_.resize(nu_max);
-  du_ub_.resize(nu_max);
+  du_lb_.resize(nu);
+  du_ub_.resize(nu);
 }
 
 void SolverBoxFDDP::computeGains(const std::size_t& t) {

--- a/src/core/solvers/ddp.cpp
+++ b/src/core/solvers/ddp.cpp
@@ -346,12 +346,10 @@ void SolverDDP::allocateData() {
   Quu_llt_.resize(T);
   Quuk_.resize(T);
 
+  const std::size_t& nx = problem_->get_nx();
+  const std::size_t& ndx = problem_->get_ndx();
+  const std::size_t& nu = problem_->get_nu();
   for (std::size_t t = 0; t < T; ++t) {
-    const boost::shared_ptr<ActionModelAbstract>& model = problem_->get_runningModels()[t];
-    const std::size_t& nx = model->get_state()->get_nx();
-    const std::size_t& ndx = model->get_state()->get_ndx();
-    const std::size_t& nu = model->get_nu();
-
     Vxx_[t] = Eigen::MatrixXd::Zero(ndx, ndx);
     Vx_[t] = Eigen::VectorXd::Zero(ndx);
     Qxx_[t] = Eigen::MatrixXd::Zero(ndx, ndx);
@@ -375,7 +373,6 @@ void SolverDDP::allocateData() {
     Quu_llt_[t] = Eigen::LLT<Eigen::MatrixXd>(nu);
     Quuk_[t] = Eigen::VectorXd(nu);
   }
-  const std::size_t& ndx = problem_->get_terminalModel()->get_state()->get_ndx();
   Vxx_.back() = Eigen::MatrixXd::Zero(ndx, ndx);
   Vx_.back() = Eigen::VectorXd::Zero(ndx);
   xs_try_.back() = problem_->get_terminalModel()->get_state()->zero();

--- a/src/core/solvers/ddp.cpp
+++ b/src/core/solvers/ddp.cpp
@@ -346,10 +346,11 @@ void SolverDDP::allocateData() {
   Quu_llt_.resize(T);
   Quuk_.resize(T);
 
-  const std::size_t& nx = problem_->get_nx();
   const std::size_t& ndx = problem_->get_ndx();
   const std::size_t& nu = problem_->get_nu();
+  const std::vector<boost::shared_ptr<ActionModelAbstract> >& models = problem_->get_runningModels();
   for (std::size_t t = 0; t < T; ++t) {
+    const boost::shared_ptr<ActionModelAbstract>& model = models[t];
     Vxx_[t] = Eigen::MatrixXd::Zero(ndx, ndx);
     Vx_[t] = Eigen::VectorXd::Zero(ndx);
     Qxx_[t] = Eigen::MatrixXd::Zero(ndx, ndx);
@@ -364,9 +365,9 @@ void SolverDDP::allocateData() {
     if (t == 0) {
       xs_try_[t] = problem_->get_x0();
     } else {
-      xs_try_[t] = Eigen::VectorXd::Constant(nx, NAN);
+      xs_try_[t] = model->get_state()->zero();
     }
-    us_try_[t] = Eigen::VectorXd::Constant(nu, NAN);
+    us_try_[t] = Eigen::VectorXd::Zero(nu);
     dx_[t] = Eigen::VectorXd::Zero(ndx);
 
     FuTVxx_p_[t] = Eigen::MatrixXd::Zero(nu, ndx);

--- a/src/core/solvers/ddp.cpp
+++ b/src/core/solvers/ddp.cpp
@@ -156,9 +156,11 @@ double SolverDDP::calcDiff() {
     problem_->get_runningModels()[0]->get_state()->diff(xs_[0], x0, fs_[0]);
 
     const std::size_t& T = problem_->get_T();
+    const std::vector<boost::shared_ptr<ActionModelAbstract> >& models = problem_->get_runningModels();
+    const std::vector<boost::shared_ptr<ActionDataAbstract> >& datas = problem_->get_runningDatas();
     for (std::size_t t = 0; t < T; ++t) {
-      const boost::shared_ptr<ActionModelAbstract>& model = problem_->get_runningModels()[t];
-      const boost::shared_ptr<ActionDataAbstract>& d = problem_->get_runningDatas()[t];
+      const boost::shared_ptr<ActionModelAbstract>& model = models[t];
+      const boost::shared_ptr<ActionDataAbstract>& d = datas[t];
       model->get_state()->diff(xs_[t + 1], d->xnext, fs_[t + 1]);
     }
   } else if (!was_feasible_) {  // closing the gaps
@@ -182,8 +184,9 @@ void SolverDDP::backwardPass() {
     Vx_.back().noalias() += Vxx_.back() * fs_.back();
   }
 
+  const std::vector<boost::shared_ptr<ActionDataAbstract> >& datas = problem_->get_runningDatas();
   for (int t = static_cast<int>(problem_->get_T()) - 1; t >= 0; --t) {
-    const boost::shared_ptr<ActionDataAbstract>& d = problem_->get_runningDatas()[t];
+    const boost::shared_ptr<ActionDataAbstract>& d = datas[t];
     const Eigen::MatrixXd& Vxx_p = Vxx_[t + 1];
     const Eigen::VectorXd& Vx_p = Vx_[t + 1];
 
@@ -243,9 +246,11 @@ void SolverDDP::forwardPass(const double& steplength) {
   }
   cost_try_ = 0.;
   const std::size_t& T = problem_->get_T();
+  const std::vector<boost::shared_ptr<ActionModelAbstract> >& models = problem_->get_runningModels();
+  const std::vector<boost::shared_ptr<ActionDataAbstract> >& datas = problem_->get_runningDatas();
   for (std::size_t t = 0; t < T; ++t) {
-    const boost::shared_ptr<ActionModelAbstract>& m = problem_->get_runningModels()[t];
-    const boost::shared_ptr<ActionDataAbstract>& d = problem_->get_runningDatas()[t];
+    const boost::shared_ptr<ActionModelAbstract>& m = models[t];
+    const boost::shared_ptr<ActionDataAbstract>& d = datas[t];
 
     m->get_state()->diff(xs_[t], xs_try_[t], dx_[t]);
     us_try_[t].noalias() = us_[t];

--- a/src/core/solvers/ddp.cpp
+++ b/src/core/solvers/ddp.cpp
@@ -132,8 +132,11 @@ double SolverDDP::tryStep(const double& steplength) {
 double SolverDDP::stoppingCriteria() {
   stop_ = 0.;
   const std::size_t& T = this->problem_->get_T();
+  const std::vector<boost::shared_ptr<ActionModelAbstract> >& models = problem_->get_runningModels();
   for (std::size_t t = 0; t < T; ++t) {
-    stop_ += Qu_[t].squaredNorm();
+    if (models[t]->get_nu() != 0) {
+      stop_ += Qu_[t].squaredNorm();
+    }
   }
   return stop_;
 }
@@ -141,9 +144,12 @@ double SolverDDP::stoppingCriteria() {
 const Eigen::Vector2d& SolverDDP::expectedImprovement() {
   d_.fill(0);
   const std::size_t& T = this->problem_->get_T();
+  const std::vector<boost::shared_ptr<ActionModelAbstract> >& models = problem_->get_runningModels();
   for (std::size_t t = 0; t < T; ++t) {
-    d_[0] += Qu_[t].dot(k_[t]);
-    d_[1] -= k_[t].dot(Quuk_[t]);
+    if (models[t]->get_nu() != 0) {
+      d_[0] += Qu_[t].dot(k_[t]);
+      d_[1] -= k_[t].dot(Quuk_[t]);
+    }
   }
   return d_;
 }
@@ -184,41 +190,48 @@ void SolverDDP::backwardPass() {
     Vx_.back().noalias() += Vxx_.back() * fs_.back();
   }
 
+  const std::vector<boost::shared_ptr<ActionModelAbstract> >& models = problem_->get_runningModels();
   const std::vector<boost::shared_ptr<ActionDataAbstract> >& datas = problem_->get_runningDatas();
   for (int t = static_cast<int>(problem_->get_T()) - 1; t >= 0; --t) {
+    const boost::shared_ptr<ActionModelAbstract>& m = models[t];
     const boost::shared_ptr<ActionDataAbstract>& d = datas[t];
     const Eigen::MatrixXd& Vxx_p = Vxx_[t + 1];
     const Eigen::VectorXd& Vx_p = Vx_[t + 1];
+    const std::size_t& nu = m->get_nu();
 
     Qxx_[t] = d->Lxx;
-    Qxu_[t] = d->Lxu;
-    Quu_[t] = d->Luu;
     Qx_[t] = d->Lx;
-    Qu_[t] = d->Lu;
     FxTVxx_p_.noalias() = d->Fx.transpose() * Vxx_p;
-    FuTVxx_p_[t].noalias() = d->Fu.transpose() * Vxx_p;
     Qxx_[t].noalias() += FxTVxx_p_ * d->Fx;
-    Qxu_[t].noalias() += FxTVxx_p_ * d->Fu;
-    Quu_[t].noalias() += FuTVxx_p_[t] * d->Fu;
     Qx_[t].noalias() += d->Fx.transpose() * Vx_p;
-    Qu_[t].noalias() += d->Fu.transpose() * Vx_p;
+    if (nu != 0) {
+      Qxu_[t] = d->Lxu;
+      Quu_[t] = d->Luu;
+      Qu_[t] = d->Lu;
+      FuTVxx_p_[t].noalias() = d->Fu.transpose() * Vxx_p;
+      Qxu_[t].noalias() += FxTVxx_p_ * d->Fu;
+      Quu_[t].noalias() += FuTVxx_p_[t] * d->Fu;
+      Qu_[t].noalias() += d->Fu.transpose() * Vx_p;
 
-    if (!std::isnan(ureg_)) {
-      Quu_[t].diagonal().array() += ureg_;
+      if (!std::isnan(ureg_)) {
+        Quu_[t].diagonal().array() += ureg_;
+      }
     }
 
     computeGains(t);
 
     Vx_[t] = Qx_[t];
-    if (std::isnan(ureg_)) {
-      Vx_[t].noalias() -= K_[t].transpose() * Qu_[t];
-    } else {
-      Quuk_[t].noalias() = Quu_[t] * k_[t];
-      Vx_[t].noalias() += K_[t].transpose() * Quuk_[t];
-      Vx_[t].noalias() -= 2 * (K_[t].transpose() * Qu_[t]);
-    }
     Vxx_[t] = Qxx_[t];
-    Vxx_[t].noalias() -= Qxu_[t] * K_[t];
+    if (nu != 0) {
+      if (std::isnan(ureg_)) {
+        Vx_[t].noalias() -= K_[t].transpose() * Qu_[t];
+      } else {
+        Quuk_[t].noalias() = Quu_[t] * k_[t];
+        Vx_[t].noalias() += K_[t].transpose() * Quuk_[t];
+        Vx_[t].noalias() -= 2 * (K_[t].transpose() * Qu_[t]);
+      }
+      Vxx_[t].noalias() -= Qxu_[t] * K_[t];
+    }
     Vxx_[t] = 0.5 * (Vxx_[t] + Vxx_[t].transpose()).eval();
 
     if (!std::isnan(xreg_)) {
@@ -253,10 +266,14 @@ void SolverDDP::forwardPass(const double& steplength) {
     const boost::shared_ptr<ActionDataAbstract>& d = datas[t];
 
     m->get_state()->diff(xs_[t], xs_try_[t], dx_[t]);
-    us_try_[t].noalias() = us_[t];
-    us_try_[t].noalias() -= k_[t] * steplength;
-    us_try_[t].noalias() -= K_[t] * dx_[t];
-    m->calc(d, xs_try_[t], us_try_[t]);
+    if (m->get_nu() != 0) {
+      us_try_[t].noalias() = us_[t];
+      us_try_[t].noalias() -= k_[t] * steplength;
+      us_try_[t].noalias() -= K_[t] * dx_[t];
+      m->calc(d, xs_try_[t], us_try_[t]);
+    } else {
+      m->calc(d, xs_try_[t]);
+    }
     xs_try_[t + 1] = d->xnext;
     cost_try_ += d->cost;
 

--- a/src/core/solvers/kkt.cpp
+++ b/src/core/solvers/kkt.cpp
@@ -253,11 +253,10 @@ void SolverKKT::allocateData() {
   nx_ = 0;
   ndx_ = 0;
   nu_ = 0;
+  const std::size_t& nx = problem_->get_nx();
+  const std::size_t& ndx = problem_->get_ndx();
+  const std::size_t& nu = problem_->get_nu();
   for (std::size_t t = 0; t < T; ++t) {
-    const boost::shared_ptr<ActionModelAbstract>& model = problem_->get_runningModels()[t];
-    const std::size_t& nx = model->get_state()->get_nx();
-    const std::size_t& ndx = model->get_state()->get_ndx();
-    const std::size_t& nu = model->get_nu();
     if (t == 0) {
       xs_try_[t] = problem_->get_x0();
     } else {
@@ -272,8 +271,8 @@ void SolverKKT::allocateData() {
     nu_ += nu;
   }
   const boost::shared_ptr<ActionModelAbstract>& model = problem_->get_terminalModel();
-  nx_ += model->get_state()->get_nx();
-  ndx_ += model->get_state()->get_ndx();
+  nx_ += nx;
+  ndx_ += ndx;
   xs_try_.back() = problem_->get_terminalModel()->get_state()->zero();
   dxs_.back() = Eigen::VectorXd::Zero(model->get_state()->get_ndx());
   lambdas_.back() = Eigen::VectorXd::Zero(model->get_state()->get_ndx());

--- a/src/core/solvers/kkt.cpp
+++ b/src/core/solvers/kkt.cpp
@@ -92,9 +92,10 @@ void SolverKKT::computeDirection(const bool& recalc) {
 
   std::size_t ix = 0;
   std::size_t iu = 0;
+  const std::vector<boost::shared_ptr<ActionModelAbstract> >& models = problem_->get_runningModels();
   for (std::size_t t = 0; t < T; ++t) {
-    const std::size_t& ndxi = problem_->get_runningModels()[t]->get_state()->get_ndx();
-    const std::size_t& nui = problem_->get_runningModels()[t]->get_nu();
+    const std::size_t& ndxi = models[t]->get_state()->get_ndx();
+    const std::size_t& nui = models[t]->get_nu();
     dxs_[t] = p_x.segment(ix, ndxi);
     dus_[t] = p_u.segment(iu, nui);
     lambdas_[t] = dual_.segment(ix, ndxi);
@@ -108,8 +109,9 @@ void SolverKKT::computeDirection(const bool& recalc) {
 
 double SolverKKT::tryStep(const double& steplength) {
   const std::size_t& T = problem_->get_T();
+  const std::vector<boost::shared_ptr<ActionModelAbstract> >& models = problem_->get_runningModels();
   for (std::size_t t = 0; t < T; ++t) {
-    const boost::shared_ptr<ActionModelAbstract>& m = problem_->get_runningModels()[t];
+    const boost::shared_ptr<ActionModelAbstract>& m = models[t];
 
     m->get_state()->integrate(xs_[t], steplength * dxs_[t], xs_try_[t]);
     us_try_[t] = us_[t];
@@ -125,10 +127,12 @@ double SolverKKT::stoppingCriteria() {
   const std::size_t& T = problem_->get_T();
   std::size_t ix = 0;
   std::size_t iu = 0;
+  const std::vector<boost::shared_ptr<ActionModelAbstract> >& models = problem_->get_runningModels();
+  const std::vector<boost::shared_ptr<ActionDataAbstract> >& datas = problem_->get_runningDatas();
   for (std::size_t t = 0; t < T; ++t) {
-    const boost::shared_ptr<ActionDataAbstract>& d = problem_->get_runningDatas()[t];
-    const std::size_t& ndxi = problem_->get_runningModels()[t]->get_state()->get_ndx();
-    const std::size_t& nui = problem_->get_runningModels()[t]->get_nu();
+    const boost::shared_ptr<ActionDataAbstract>& d = datas[t];
+    const std::size_t& ndxi = models[t]->get_state()->get_ndx();
+    const std::size_t& nui = models[t]->get_nu();
 
     dF.segment(ix, ndxi) = lambdas_[t];
     dF.segment(ix, ndxi).noalias() -= d->Fx.transpose() * lambdas_[t + 1];

--- a/src/core/solvers/kkt.cpp
+++ b/src/core/solvers/kkt.cpp
@@ -114,8 +114,10 @@ double SolverKKT::tryStep(const double& steplength) {
     const boost::shared_ptr<ActionModelAbstract>& m = models[t];
 
     m->get_state()->integrate(xs_[t], steplength * dxs_[t], xs_try_[t]);
-    us_try_[t] = us_[t];
-    us_try_[t] += steplength * dus_[t];
+    if (m->get_nu() != 0) {
+      us_try_[t] = us_[t];
+      us_try_[t] += steplength * dus_[t];
+    }
   }
   const boost::shared_ptr<ActionModelAbstract> m = problem_->get_terminalModel();
   m->get_state()->integrate(xs_[T], steplength * dxs_[T], xs_try_[T]);


### PR DESCRIPTION
This PR solves the issue #780 by applying the solution 1. It consists of:
 1. do not performances useless matrix-matrix multiplications when `nu=0`
 2. store a unique `nx`, `ndx` and `nu` in the shooting problem
 3. use 2 for allocating the solver data

Additionally, there are other tasks that this PR includes:
 1. Added doxygen documentation of  `SolverAbstract`, `SolverDDP` and `SolverFDDP`
 2. Tiny improvement in the doxygen documentation of `StateAbstractTpl`
 3. Configure doxygen to do not sort alphabetically the functions
 4. Updated the REAME file (cherry-pick from `release/v1.3.0` branch)
