### PR TITLE
Set inactive forces and their derivatives to zero + DAM documentation + fixed bug in updateNode

### DIFF
--- a/bindings/python/crocoddyl/core/diff-action-base.cpp
+++ b/bindings/python/crocoddyl/core/diff-action-base.cpp
@@ -31,14 +31,9 @@ void exposeDifferentialActionAbstract() {
           ":param nu: dimension of control vector\n"
           ":param nr: dimension of cost-residual vector (default 1)"))
       .def("calc", pure_virtual(&DifferentialActionModelAbstract_wrap::calc), bp::args("self", "data", "x", "u"),
-           "Compute the state evolution and cost value.\n\n"
-           "First, it describes the time-continuous evolution of our dynamical system\n"
-           "in which along predefined integrated action self we might obtain the\n"
-           "next discrete state. Indeed it computes the time derivatives of the\n"
-           "state from a predefined dynamical system. Additionally it computes the\n"
-           "cost value associated to this state and control pair.\n"
+           "Compute the system acceleration and cost value.\n\n"
            ":param data: differential action data\n"
-           ":param x: state vector\n"
+           ":param x: state tuple\n"
            ":param u: control input")
       .def<void (DifferentialActionModelAbstract::*)(const boost::shared_ptr<DifferentialActionDataAbstract>&,
                                                      const Eigen::Ref<const Eigen::VectorXd>&)>(

--- a/bindings/python/crocoddyl/multibody/contact-base.cpp
+++ b/bindings/python/crocoddyl/multibody/contact-base.cpp
@@ -51,6 +51,9 @@ void exposeContactAbstract() {
       .def("setZeroForce", &ContactModelAbstract_wrap::setZeroForce, bp::args("self", "data"),
            "Set zero the spatial force.\n\n"
            ":param data: contact data")
+      .def("setZeroForceDiff", &ContactModelAbstract_wrap::setZeroForceDiff, bp::args("self", "data"),
+           "Set zero the derivatives of the spatial force.\n\n"
+           ":param data: contact data")
       .def("createData", &ContactModelAbstract_wrap::createData, bp::with_custodian_and_ward_postcall<0, 2>(),
            bp::args("self", "data"),
            "Create the contact data.\n\n"

--- a/bindings/python/crocoddyl/multibody/contact-base.cpp
+++ b/bindings/python/crocoddyl/multibody/contact-base.cpp
@@ -48,6 +48,9 @@ void exposeContactAbstract() {
            ":param data: contact data\n"
            ":param df_dx: Jacobian of the force with respect to the state\n"
            ":param df_du: Jacobian of the force with respect to the control")
+      .def("setZeroForce", &ContactModelAbstract_wrap::setZeroForce, bp::args("self", "data"),
+           "Set zero the spatial force.\n\n"
+           ":param data: contact data")
       .def("createData", &ContactModelAbstract_wrap::createData, bp::with_custodian_and_ward_postcall<0, 2>(),
            bp::args("self", "data"),
            "Create the contact data.\n\n"

--- a/bindings/python/crocoddyl/multibody/costs/contact-force.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/contact-force.cpp
@@ -87,9 +87,10 @@ void exposeCostContactForce() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
-      .add_property(
-          "reference", bp::make_function(&CostModelContactForce::get_fref, bp::return_internal_reference<>()),
-          &CostModelContactForce::set_reference<FrameForce>, "reference spatial contact force in the contact coordinates")
+      .add_property("reference",
+                    bp::make_function(&CostModelContactForce::get_fref, bp::return_internal_reference<>()),
+                    &CostModelContactForce::set_reference<FrameForce>,
+                    "reference spatial contact force in the contact coordinates")
       .add_property("fref", bp::make_function(&CostModelContactForce::get_fref, bp::return_internal_reference<>()),
                     &CostModelContactForce::set_fref, "reference spatial contact force in the contact coordinates");
 

--- a/bindings/python/crocoddyl/multibody/costs/contact-impulse.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/contact-impulse.cpp
@@ -73,7 +73,8 @@ void exposeCostContactImpulse() {
                     &CostModelContactImpulse::set_reference<FrameForce>,
                     "reference spatial contact impulse in the contact coordinates")
       .add_property("fref", bp::make_function(&CostModelContactImpulse::get_fref, bp::return_internal_reference<>()),
-                    &CostModelContactImpulse::set_fref, "reference spatial contact impulse in the contact coordinates");
+                    &CostModelContactImpulse::set_fref,
+                    "reference spatial contact impulse in the contact coordinates");
 
   bp::register_ptr_to_python<boost::shared_ptr<CostDataContactImpulse> >();
 

--- a/bindings/python/crocoddyl/multibody/impulse-base.cpp
+++ b/bindings/python/crocoddyl/multibody/impulse-base.cpp
@@ -44,6 +44,9 @@ void exposeImpulseAbstract() {
       .def("setZeroForce", &ImpulseModelAbstract_wrap::setZeroForce, bp::args("self", "data"),
            "Set zero the spatial force.\n\n"
            ":param data: contact data")
+      .def("setZeroForceDiff", &ImpulseModelAbstract_wrap::setZeroForceDiff, bp::args("self", "data"),
+           "Set zero the derivatives of the spatial force.\n\n"
+           ":param data: contact data")
       .def("createData", &ImpulseModelAbstract_wrap::createData, bp::with_custodian_and_ward_postcall<0, 2>(),
            bp::args("self", "data"),
            "Create the impulse data.\n\n"

--- a/bindings/python/crocoddyl/multibody/impulse-base.cpp
+++ b/bindings/python/crocoddyl/multibody/impulse-base.cpp
@@ -41,6 +41,9 @@ void exposeImpulseAbstract() {
            "Update the Jacobian of the impulse force.\n\n"
            ":param data: impulse data\n"
            ":param df_dx: Jacobian of the impulse force (dimension ni*ndx)")
+      .def("setZeroForce", &ImpulseModelAbstract_wrap::setZeroForce, bp::args("self", "data"),
+           "Set zero the spatial force.\n\n"
+           ":param data: contact data")
       .def("createData", &ImpulseModelAbstract_wrap::createData, bp::with_custodian_and_ward_postcall<0, 2>(),
            bp::args("self", "data"),
            "Create the impulse data.\n\n"

--- a/include/crocoddyl/core/activations/quadratic-barrier.hpp
+++ b/include/crocoddyl/core/activations/quadratic-barrier.hpp
@@ -105,8 +105,9 @@ class ActivationModelQuadraticBarrierTpl : public ActivationModelAbstractTpl<_Sc
 
     boost::shared_ptr<Data> d = boost::static_pointer_cast<Data>(data);
     data->Ar = (d->rlb_min_ + d->rub_max_).matrix();
-    data->Arr.diagonal() =
-      (((r - bounds_.lb).array() <= Scalar(0.)) + ((r - bounds_.ub).array() >= Scalar(0.))).matrix().template cast<Scalar>();
+    data->Arr.diagonal() = (((r - bounds_.lb).array() <= Scalar(0.)) + ((r - bounds_.ub).array() >= Scalar(0.)))
+                               .matrix()
+                               .template cast<Scalar>();
   };
 
   virtual boost::shared_ptr<ActivationDataAbstract> createData() {

--- a/include/crocoddyl/core/diff-action-base.hpp
+++ b/include/crocoddyl/core/diff-action-base.hpp
@@ -104,7 +104,7 @@ class DifferentialActionModelAbstractTpl {
 
   /**
    * @copybrief
-   * 
+   *
    * @param[in] data  Differential action data
    * @param[in] x     State point
    */
@@ -112,7 +112,7 @@ class DifferentialActionModelAbstractTpl {
 
   /**
    * @copybrief
-   * 
+   *
    * @param[in] data  Differential action data
    * @param[in] x     State point
    */

--- a/include/crocoddyl/core/diff-action-base.hpp
+++ b/include/crocoddyl/core/diff-action-base.hpp
@@ -20,25 +20,29 @@
 namespace crocoddyl {
 
 /**
- * @brief This class DifferentialActionModelAbstract represents a first-order
- * ODE, i.e.
- * \f[
- * \mathbf{\dot{v}} = \mathbf{f}(\mathbf{q}, \mathbf{v}, \boldsymbol{\tau})
- * \f]
- * where \f$ xout = \mathbf{\dot{v}} \f$ and represents the  acceleration of the
- * system. Note that Jacobians Fx and Fu in the
- * DifferentialActionDataAbstract are in \f$ \mathbb{R}^{nv\times ndx} \f$ and
- * \f$ \mathbb{R}^{nv\times nu} \f$, respectively.
+ * @brief Abstract class for differential action model
  *
- * Then we use the acceleration to integrate the system, and as consequence we
- * obtain:
+ * A differential action model describes a time-continuous action model with a first-order ODE, i.e.
  * \f[
- * \mathbf{\dot{x}} = (\mathbf{v}, \mathbf{\dot{v}}) = \mathbf{f}(\mathbf{x},\mathbf{u})
+ * \dot{\mathbf{v}} = \mathbf{f}(\mathbf{q}, \mathbf{v}, \mathbf{u})
  * \f]
- * where this \f$ f \f$ function is different to the other one.
- * So \f$ xout \f$ is interpreted here as \f$ vdout \f$ or \f$ aout \f$.
+ * where the configuration \f$\mathbf{q}\in\mathcal{Q}\f$ lies in the configuration manifold described with a
+ * `nq`-tuple, the velocity \f$\mathbf{v}\in T_{\mathbf{q}}\mathcal{Q}\f$ its a tangent vector to this manifold with
+ * `nv` dimension, and \f$\mathbf{u}\in\mathbb{R}^{nu}\f$ is the input commands. Both, configuration and velocity,
+ * describes the system space \f$\mathbf{x}\in\mathbf{X}\f$ which lies in the state manifold. Note that the
+ * acceleration \f$\dot{\mathbf{v}}\in T_{\mathbf{q}}\mathcal{Q}\f$ lies also in the tangent space of the configuration
+ * manifold.
+ *
+ * `calc` computes the acceleration and cost and `calcDiff` computes the derivatives of the dynamics and cost function.
+ * Concretely speaking, `calcDiff` builds a linear-quadratic approximation of the differential action, where the
+ * dynamics and cost functions have linear and quadratic forms, respectively. \f$\mathbf{f_x}\in\mathbb{R}^{nv\times
+ * ndx}\f$, \f$\mathbf{f_u}\in\mathbb{R}^{nv\times nu}\f$ are the Jacobians of the dynamics;
+ * \f$\mathbf{l_x}\in\mathbb{R}^{ndx}\f$, \f$\mathbf{l_u}\in\mathbb{R}^{nu}\f$,
+ * \f$\mathbf{l_{xx}}\in\mathbb{R}^{ndx\times ndx}\f$, \f$\mathbf{l_{xu}}\in\mathbb{R}^{ndx\times nu}\f$,
+ * \f$\mathbf{l_{uu}}\in\mathbb{R}^{nu\times nu}\f$ are the Jacobians and Hessians of the cost function, respectely.
+ *
+ * \sa `calc()`, `calcDiff()`, `createData()`
  */
-
 template <typename _Scalar>
 class DifferentialActionModelAbstractTpl {
  public:
@@ -51,29 +55,107 @@ class DifferentialActionModelAbstractTpl {
   typedef typename MathBase::VectorXs VectorXs;
   typedef typename MathBase::MatrixXs MatrixXs;
 
+  /**
+   * @brief Initialize the differential action model
+   *
+   * @param[in] state  State Dimension of state configuration tuple
+   * @param[in] nu     Dimension of control vector
+   * @param[in] nr     Dimension of cost-residual vector
+   */
   DifferentialActionModelAbstractTpl(boost::shared_ptr<StateAbstract> state, const std::size_t& nu,
                                      const std::size_t& nr = 0);
   virtual ~DifferentialActionModelAbstractTpl();
 
+  /**
+   * @brief Compute the system acceleration and cost value
+   *
+   * @param[in] data  Differential action data
+   * @param[in] x     State point
+   * @param[in] u     Control input
+   */
   virtual void calc(const boost::shared_ptr<DifferentialActionDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,
                     const Eigen::Ref<const VectorXs>& u) = 0;
+
+  /**
+   * @brief Compute the derivatives of the dynamics and cost functions
+   *
+   * It computes the partial derivatives of the dynamical system and the cost function. It assumes that calc has been
+   * run first. This function builds a quadratic approximation of the time-continuous action model (i.e. dynamical
+   * system and cost function).
+   *
+   * @param[in] data  Differential action data
+   * @param[in] x     State point
+   * @param[in] u     Control input
+   */
   virtual void calcDiff(const boost::shared_ptr<DifferentialActionDataAbstract>& data,
                         const Eigen::Ref<const VectorXs>& x, const Eigen::Ref<const VectorXs>& u) = 0;
+
+  /**
+   * @brief Create the differential action data
+   *
+   * @return the differential action data
+   */
   virtual boost::shared_ptr<DifferentialActionDataAbstract> createData();
+
+  /**
+   * @brief Checks that a specific data belongs to this model
+   */
   virtual bool checkData(const boost::shared_ptr<DifferentialActionDataAbstract>& data);
 
+  /**
+   * @copybrief
+   * 
+   * @param[in] data  Differential action data
+   * @param[in] x     State point
+   */
   void calc(const boost::shared_ptr<DifferentialActionDataAbstract>& data, const Eigen::Ref<const VectorXs>& x);
+
+  /**
+   * @copybrief
+   * 
+   * @param[in] data  Differential action data
+   * @param[in] x     State point
+   */
   void calcDiff(const boost::shared_ptr<DifferentialActionDataAbstract>& data, const Eigen::Ref<const VectorXs>& x);
 
+  /**
+   * @brief Return the dimension of the control input
+   */
   const std::size_t& get_nu() const;
+
+  /**
+   * @brief Return the dimension of the cost-residual vector
+   */
   const std::size_t& get_nr() const;
+
+  /**
+   * @brief Return the state
+   */
   const boost::shared_ptr<StateAbstract>& get_state() const;
 
+  /**
+   * @brief Return the control lower bound
+   */
   const VectorXs& get_u_lb() const;
+
+  /**
+   * @brief Return the control upper bound
+   */
   const VectorXs& get_u_ub() const;
+
+  /**
+   * @brief Indicates if there are defined control limits
+   */
   bool const& get_has_control_limits() const;
 
+  /**
+   * @brief Modify the control lower bounds
+   */
   void set_u_lb(const VectorXs& u_lb);
+
+  /**
+   * @brief Modify the control upper bounds
+   */
   void set_u_ub(const VectorXs& u_ub);
 
  protected:

--- a/include/crocoddyl/core/optctrl/shooting.hxx
+++ b/include/crocoddyl/core/optctrl/shooting.hxx
@@ -307,7 +307,7 @@ void ShootingProblemTpl<Scalar>::updateNode(std::size_t i, boost::shared_ptr<Act
                  << "nu node is not bigger than the maximun nu")
   }
 
-  if (i == T_ + 1) {
+  if (i == T_) {
     terminal_model_ = model;
     terminal_data_ = data;
   } else {

--- a/include/crocoddyl/multibody/contact-base.hpp
+++ b/include/crocoddyl/multibody/contact-base.hpp
@@ -42,6 +42,7 @@ class ContactModelAbstractTpl {
   void updateForceDiff(const boost::shared_ptr<ContactDataAbstract>& data, const MatrixXs& df_dx,
                        const MatrixXs& df_du) const;
   void setZeroForce(const boost::shared_ptr<ContactDataAbstract>& data) const;
+  void setZeroForceDiff(const boost::shared_ptr<ContactDataAbstract>& data) const;
 
   virtual boost::shared_ptr<ContactDataAbstract> createData(pinocchio::DataTpl<Scalar>* const data);
 

--- a/include/crocoddyl/multibody/contact-base.hpp
+++ b/include/crocoddyl/multibody/contact-base.hpp
@@ -41,6 +41,8 @@ class ContactModelAbstractTpl {
   virtual void updateForce(const boost::shared_ptr<ContactDataAbstract>& data, const VectorXs& force) = 0;
   void updateForceDiff(const boost::shared_ptr<ContactDataAbstract>& data, const MatrixXs& df_dx,
                        const MatrixXs& df_du) const;
+  void setZeroForce(const boost::shared_ptr<ContactDataAbstract>& data) const;
+
   virtual boost::shared_ptr<ContactDataAbstract> createData(pinocchio::DataTpl<Scalar>* const data);
 
   const boost::shared_ptr<StateMultibody>& get_state() const;

--- a/include/crocoddyl/multibody/contact-base.hxx
+++ b/include/crocoddyl/multibody/contact-base.hxx
@@ -43,6 +43,12 @@ void ContactModelAbstractTpl<Scalar>::setZeroForce(const boost::shared_ptr<Conta
 }
 
 template <typename Scalar>
+void ContactModelAbstractTpl<Scalar>::setZeroForceDiff(const boost::shared_ptr<ContactDataAbstract>& data) const {
+  data->df_dx.setZero();
+  data->df_du.setZero();
+}
+
+template <typename Scalar>
 boost::shared_ptr<ContactDataAbstractTpl<Scalar> > ContactModelAbstractTpl<Scalar>::createData(
     pinocchio::DataTpl<Scalar>* const data) {
   return boost::allocate_shared<ContactDataAbstract>(Eigen::aligned_allocator<ContactDataAbstract>(), this, data);

--- a/include/crocoddyl/multibody/contact-base.hxx
+++ b/include/crocoddyl/multibody/contact-base.hxx
@@ -38,6 +38,11 @@ void ContactModelAbstractTpl<Scalar>::updateForceDiff(const boost::shared_ptr<Co
 }
 
 template <typename Scalar>
+void ContactModelAbstractTpl<Scalar>::setZeroForce(const boost::shared_ptr<ContactDataAbstract>& data) const {
+  data->f.setZero();
+}
+
+template <typename Scalar>
 boost::shared_ptr<ContactDataAbstractTpl<Scalar> > ContactModelAbstractTpl<Scalar>::createData(
     pinocchio::DataTpl<Scalar>* const data) {
   return boost::allocate_shared<ContactDataAbstract>(Eigen::aligned_allocator<ContactDataAbstract>(), this, data);

--- a/include/crocoddyl/multibody/contacts/multiple-contacts.hxx
+++ b/include/crocoddyl/multibody/contacts/multiple-contacts.hxx
@@ -224,15 +224,16 @@ void ContactModelMultipleTpl<Scalar>::updateForceDiff(const boost::shared_ptr<Co
   for (it_m = contacts_.begin(), end_m = contacts_.end(), it_d = data->contacts.begin(), end_d = data->contacts.end();
        it_m != end_m || it_d != end_d; ++it_m, ++it_d) {
     const boost::shared_ptr<ContactItem>& m_i = it_m->second;
+    const boost::shared_ptr<ContactDataAbstract>& d_i = it_d->second;
+    assert_pretty(it_m->first == it_d->first, "it doesn't match the contact name between data and model");
     if (m_i->active) {
-      const boost::shared_ptr<ContactDataAbstract>& d_i = it_d->second;
-      assert_pretty(it_m->first == it_d->first, "it doesn't match the contact name between data and model");
-
       std::size_t const& nc_i = m_i->contact->get_nc();
       const Eigen::Block<const MatrixXs> df_dx_i = df_dx.block(nc, 0, nc_i, ndx);
       const Eigen::Block<const MatrixXs> df_du_i = df_du.block(nc, 0, nc_i, nu_);
       m_i->contact->updateForceDiff(d_i, df_dx_i, df_du_i);
       nc += nc_i;
+    } else {
+      m_i->contact->setZeroForceDiff(d_i);
     }
   }
 }

--- a/include/crocoddyl/multibody/contacts/multiple-contacts.hxx
+++ b/include/crocoddyl/multibody/contacts/multiple-contacts.hxx
@@ -173,15 +173,16 @@ void ContactModelMultipleTpl<Scalar>::updateForce(const boost::shared_ptr<Contac
   for (it_m = contacts_.begin(), end_m = contacts_.end(), it_d = data->contacts.begin(), end_d = data->contacts.end();
        it_m != end_m || it_d != end_d; ++it_m, ++it_d) {
     const boost::shared_ptr<ContactItem>& m_i = it_m->second;
+    const boost::shared_ptr<ContactDataAbstract>& d_i = it_d->second;
+    assert_pretty(it_m->first == it_d->first, "it doesn't match the contact name between data and model");
     if (m_i->active) {
-      const boost::shared_ptr<ContactDataAbstract>& d_i = it_d->second;
-      assert_pretty(it_m->first == it_d->first, "it doesn't match the contact name between data and model");
-
       const std::size_t& nc_i = m_i->contact->get_nc();
       const Eigen::VectorBlock<const VectorXs, Eigen::Dynamic> force_i = force.segment(nc, nc_i);
       m_i->contact->updateForce(d_i, force_i);
       data->fext[d_i->joint] = d_i->f;
       nc += nc_i;
+    } else {
+      m_i->contact->setZeroForce(d_i);
     }
   }
 }

--- a/include/crocoddyl/multibody/impulse-base.hpp
+++ b/include/crocoddyl/multibody/impulse-base.hpp
@@ -39,6 +39,7 @@ class ImpulseModelAbstractTpl {
   virtual void updateForce(const boost::shared_ptr<ImpulseDataAbstract>& data, const VectorXs& force) = 0;
   void updateForceDiff(const boost::shared_ptr<ImpulseDataAbstract>& data, const MatrixXs& df_dx) const;
   void setZeroForce(const boost::shared_ptr<ImpulseDataAbstract>& data) const;
+  void setZeroForceDiff(const boost::shared_ptr<ImpulseDataAbstract>& data) const;
 
   virtual boost::shared_ptr<ImpulseDataAbstract> createData(pinocchio::DataTpl<Scalar>* const data);
 

--- a/include/crocoddyl/multibody/impulse-base.hpp
+++ b/include/crocoddyl/multibody/impulse-base.hpp
@@ -38,6 +38,7 @@ class ImpulseModelAbstractTpl {
 
   virtual void updateForce(const boost::shared_ptr<ImpulseDataAbstract>& data, const VectorXs& force) = 0;
   void updateForceDiff(const boost::shared_ptr<ImpulseDataAbstract>& data, const MatrixXs& df_dx) const;
+  void setZeroForce(const boost::shared_ptr<ImpulseDataAbstract>& data) const;
 
   virtual boost::shared_ptr<ImpulseDataAbstract> createData(pinocchio::DataTpl<Scalar>* const data);
 

--- a/include/crocoddyl/multibody/impulse-base.hxx
+++ b/include/crocoddyl/multibody/impulse-base.hxx
@@ -29,6 +29,11 @@ void ImpulseModelAbstractTpl<Scalar>::updateForceDiff(const boost::shared_ptr<Im
 }
 
 template <typename Scalar>
+void ImpulseModelAbstractTpl<Scalar>::setZeroForce(const boost::shared_ptr<ImpulseDataAbstract>& data) const {
+  data->f.setZero();
+}
+
+template <typename Scalar>
 boost::shared_ptr<ImpulseDataAbstractTpl<Scalar> > ImpulseModelAbstractTpl<Scalar>::createData(
     pinocchio::DataTpl<Scalar>* const data) {
   return boost::allocate_shared<ImpulseDataAbstract>(Eigen::aligned_allocator<ImpulseDataAbstract>(), this, data);

--- a/include/crocoddyl/multibody/impulse-base.hxx
+++ b/include/crocoddyl/multibody/impulse-base.hxx
@@ -34,6 +34,11 @@ void ImpulseModelAbstractTpl<Scalar>::setZeroForce(const boost::shared_ptr<Impul
 }
 
 template <typename Scalar>
+void ImpulseModelAbstractTpl<Scalar>::setZeroForceDiff(const boost::shared_ptr<ImpulseDataAbstract>& data) const {
+  data->df_dx.setZero();
+}
+
+template <typename Scalar>
 boost::shared_ptr<ImpulseDataAbstractTpl<Scalar> > ImpulseModelAbstractTpl<Scalar>::createData(
     pinocchio::DataTpl<Scalar>* const data) {
   return boost::allocate_shared<ImpulseDataAbstract>(Eigen::aligned_allocator<ImpulseDataAbstract>(), this, data);

--- a/include/crocoddyl/multibody/impulses/multiple-impulses.hxx
+++ b/include/crocoddyl/multibody/impulses/multiple-impulses.hxx
@@ -165,15 +165,16 @@ void ImpulseModelMultipleTpl<Scalar>::updateForce(const boost::shared_ptr<Impuls
   for (it_m = impulses_.begin(), end_m = impulses_.end(), it_d = data->impulses.begin(), end_d = data->impulses.end();
        it_m != end_m || it_d != end_d; ++it_m, ++it_d) {
     const boost::shared_ptr<ImpulseItem>& m_i = it_m->second;
+    const boost::shared_ptr<ImpulseDataAbstract>& d_i = it_d->second;
+    assert_pretty(it_m->first == it_d->first, "it doesn't match the impulse name between data and model");
     if (m_i->active) {
-      const boost::shared_ptr<ImpulseDataAbstract>& d_i = it_d->second;
-      assert_pretty(it_m->first == it_d->first, "it doesn't match the impulse name between data and model");
-
       const std::size_t& ni_i = m_i->impulse->get_ni();
       const Eigen::VectorBlock<const VectorXs, Eigen::Dynamic> force_i = force.segment(ni, ni_i);
       m_i->impulse->updateForce(d_i, force_i);
       data->fext[d_i->joint] = d_i->f;
       ni += ni_i;
+    } else {
+      m_i->impulse->setZeroForce(d_i);
     }
   }
 }

--- a/include/crocoddyl/multibody/impulses/multiple-impulses.hxx
+++ b/include/crocoddyl/multibody/impulses/multiple-impulses.hxx
@@ -211,14 +211,15 @@ void ImpulseModelMultipleTpl<Scalar>::updateForceDiff(const boost::shared_ptr<Im
   for (it_m = impulses_.begin(), end_m = impulses_.end(), it_d = data->impulses.begin(), end_d = data->impulses.end();
        it_m != end_m || it_d != end_d; ++it_m, ++it_d) {
     const boost::shared_ptr<ImpulseItem>& m_i = it_m->second;
+    const boost::shared_ptr<ImpulseDataAbstract>& d_i = it_d->second;
+    assert_pretty(it_m->first == it_d->first, "it doesn't match the impulse name between data and model");
     if (m_i->active) {
-      const boost::shared_ptr<ImpulseDataAbstract>& d_i = it_d->second;
-      assert_pretty(it_m->first == it_d->first, "it doesn't match the impulse name between data and model");
-
       const std::size_t& ni_i = m_i->impulse->get_ni();
       const Eigen::Block<const MatrixXs> df_dx_i = df_dx.block(ni, 0, ni_i, ndx);
       m_i->impulse->updateForceDiff(d_i, df_dx_i);
       ni += ni_i;
+    } else {
+      m_i->impulse->setZeroForceDiff(d_i);
     }
   }
 }


### PR DESCRIPTION
These "set-to-zero-force" changes doesn't affect the computation performed by the solvers. However, for conciseness, it is a good idea to set force and their derivatives to zero.

Additionally, the PR fixes a bug in the definition of the terminal node in `ShootingProblem::updateNode`.