### PR TITLE
CoP cost

### DIFF
--- a/bindings/python/crocoddyl/multibody/costs/contact-cop-position.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/contact-cop-position.cpp
@@ -17,14 +17,29 @@ void exposeCostContactCoPPosition() {
   bp::class_<CostModelContactCoPPosition, bp::bases<CostModelAbstract> >(
       "CostModelContactCoPPosition",
       bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActivationModelAbstract>, FrameCoPSupport, int>(
-          bp::args("self", "state", "activation",
-                   "cop_support"
-                   "nu"),
+          bp::args("self", "state", "activation", "cop_support", "nu"),
           "Initialize the contact CoP position cost model.\n\n"
           ":param state: state of the multibody system\n"
-          ":param activation: activation model\n"
-          ":param cop_support: contact frame ID and cop support region"
+          ":param activation: activation model (default ActivationModelQuadraticBarrier)\n"
+          ":param cop_support: contact frame ID and cop support region\n"
           ":param nu: dimension of control vector"))
+      .def(bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActivationModelAbstract>, FrameCoPSupport>(
+          bp::args("self", "state", "activation", "cop_support"),
+          "Initialize the contact CoP position cost model.\n\n"
+          ":param state: state of the multibody system\n"
+          ":param activation: activation model (default ActivationModelQuadraticBarrier)\n"
+          ":param cop_support: contact frame ID and cop support region"))
+      .def(bp::init<boost::shared_ptr<StateMultibody>, FrameCoPSupport, int>(
+          bp::args("self", "state", "cop_support", "nu"),
+          "Initialize the contact CoP position cost model.\n\n"
+          ":param state: state of the multibody system\n"
+          ":param cop_support: contact frame ID and cop support region\n"
+          ":param nu: dimension of control vector"))
+      .def(bp::init<boost::shared_ptr<StateMultibody>, FrameCoPSupport>(
+          bp::args("self", "state", "cop_support"),
+          "Initialize the contact CoP position cost model.\n\n"
+          ":param state: state of the multibody system\n"
+          ":param cop_support: contact frame ID and cop support region"))
       .def<void (CostModelContactCoPPosition::*)(const boost::shared_ptr<CostDataAbstract>&,
                                                  const Eigen::Ref<const Eigen::VectorXd>&,
                                                  const Eigen::Ref<const Eigen::VectorXd>&)>(

--- a/bindings/python/crocoddyl/multibody/costs/contact-cop-position.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/contact-cop-position.cpp
@@ -16,14 +16,15 @@ namespace python {
 void exposeCostContactCoPPosition() {
   bp::class_<CostModelContactCoPPosition, bp::bases<CostModelAbstract> >(
       "CostModelContactCoPPosition",
-      bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActivationModelAbstract>, FrameFootGeometry, 
-      const Eigen::Ref<const Eigen::VectorXd>&>(
-          bp::args("self", "state", "activation", "foot_geom", "normal"),
+      bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActivationModelAbstract>, FrameCoPSupport, 
+      const Eigen::Ref<const Eigen::VectorXd>&, int>(
+          bp::args("self", "state", "activation", "cop_support", "normal", "nu"),
           "Initialize the contact CoP position cost model.\n\n"
           ":param state: state of the multibody system\n"
           ":param activation: activation model\n"
-          ":param foot_geom: 2d geometry of the contact surface"
-          ":param normal: vector normal to the contact surface"))
+          ":param cop_support: contact frame ID and cop support region"
+          ":param normal: vector normal to the contact surface"
+          ":param nu: dimension of control vector"))
       .def<void (CostModelContactCoPPosition::*)(const boost::shared_ptr<CostDataAbstract>&,
                                                   const Eigen::Ref<const Eigen::VectorXd>&,
                                                   const Eigen::Ref<const Eigen::VectorXd>&)>(
@@ -48,8 +49,8 @@ void exposeCostContactCoPPosition() {
            ":param data: shared data\n"
            ":return cost data.")
       .add_property("reference",
-                    bp::make_function(&CostModelContactCoPPosition::get_footGeom, bp::return_internal_reference<>()),
-                    &CostModelContactCoPPosition::set_reference<FrameFootGeometry>, "reference foot geometry");
+                    bp::make_function(&CostModelContactCoPPosition::get_copSupport, bp::return_internal_reference<>()),
+                    &CostModelContactCoPPosition::set_reference<FrameCoPSupport>, "reference foot geometry");
 
   bp::register_ptr_to_python<boost::shared_ptr<CostDataContactCoPPosition> >();
 

--- a/bindings/python/crocoddyl/multibody/costs/contact-cop-position.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/contact-cop-position.cpp
@@ -16,12 +16,14 @@ namespace python {
 void exposeCostContactCoPPosition() {
   bp::class_<CostModelContactCoPPosition, bp::bases<CostModelAbstract> >(
       "CostModelContactCoPPosition",
-      bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActivationModelAbstract>, FrameFootGeometry>(
-          bp::args("self", "state", "activation", "foot_geom"),
+      bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActivationModelAbstract>, FrameFootGeometry, 
+      const Eigen::Ref<const Eigen::VectorXd>&>(
+          bp::args("self", "state", "activation", "foot_geom", "normal"),
           "Initialize the contact CoP position cost model.\n\n"
           ":param state: state of the multibody system\n"
           ":param activation: activation model\n"
-          ":param foot_geom: 2d geometry of the contact surface"))
+          ":param foot_geom: 2d geometry of the contact surface"
+          ":param normal: vector normal to the contact surface"))
       .def<void (CostModelContactCoPPosition::*)(const boost::shared_ptr<CostDataAbstract>&,
                                                   const Eigen::Ref<const Eigen::VectorXd>&,
                                                   const Eigen::Ref<const Eigen::VectorXd>&)>(

--- a/bindings/python/crocoddyl/multibody/costs/contact-cop-position.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/contact-cop-position.cpp
@@ -17,13 +17,12 @@ void exposeCostContactCoPPosition() {
   bp::class_<CostModelContactCoPPosition, bp::bases<CostModelAbstract> >(
       "CostModelContactCoPPosition",
       bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActivationModelAbstract>, FrameCoPSupport, 
-      const Eigen::Ref<const Eigen::VectorXd>&, int>(
-          bp::args("self", "state", "activation", "cop_support", "normal", "nu"),
+      int>(
+          bp::args("self", "state", "activation", "cop_support" "nu"),
           "Initialize the contact CoP position cost model.\n\n"
           ":param state: state of the multibody system\n"
           ":param activation: activation model\n"
           ":param cop_support: contact frame ID and cop support region"
-          ":param normal: vector normal to the contact surface"
           ":param nu: dimension of control vector"))
       .def<void (CostModelContactCoPPosition::*)(const boost::shared_ptr<CostDataAbstract>&,
                                                   const Eigen::Ref<const Eigen::VectorXd>&,

--- a/bindings/python/crocoddyl/multibody/costs/contact-cop-position.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/contact-cop-position.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2018-2020, University of Edinburgh
+// Copyright (C) 2020, University of Duisburg-Essen, University of Edinburgh
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -28,16 +28,16 @@ void exposeCostContactCoPPosition() {
           "calc", &CostModelContactCoPPosition::calc, bp::args("self", "data", "x", "u"),
           "Compute the contact CoP position cost.\n\n"
           ":param data: cost data\n"
-          ":param x: time-discrete state vector\n"
-          ":param u: time-discrete control input")
+          ":param x: state vector\n"
+          ":param u: control input")
       .def<void (CostModelContactCoPPosition::*)(const boost::shared_ptr<CostDataAbstract>&,
                                                   const Eigen::Ref<const Eigen::VectorXd>&,
                                                   const Eigen::Ref<const Eigen::VectorXd>&)>(
           "calcDiff", &CostModelContactCoPPosition::calcDiff, bp::args("self", "data", "x", "u"),
           "Compute the derivatives of the contact CoP position cost.\n\n"
           ":param data: action data\n"
-          ":param x: time-discrete state vector\n"
-          ":param u: time-discrete control input\n")
+          ":param x: state vector\n"
+          ":param u: control input\n")
       .def("createData", &CostModelContactCoPPosition::createData, bp::with_custodian_and_ward_postcall<0, 2>(),
            bp::args("self", "data"),
            "Create the contact CoP position cost data.\n\n"
@@ -47,7 +47,7 @@ void exposeCostContactCoPPosition() {
            ":return cost data.")
       .add_property("reference",
                     bp::make_function(&CostModelContactCoPPosition::get_footGeom, bp::return_internal_reference<>()),
-                    &CostModelContactCoPPosition::set_reference<FrameFootGeometry>, "reference frame friction cone");
+                    &CostModelContactCoPPosition::set_reference<FrameFootGeometry>, "reference foot geometry");
 
   bp::register_ptr_to_python<boost::shared_ptr<CostDataContactCoPPosition> >();
 

--- a/bindings/python/crocoddyl/multibody/costs/contact-cop-position.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/contact-cop-position.cpp
@@ -1,0 +1,70 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2018-2020, University of Edinburgh
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#include "python/crocoddyl/multibody/multibody.hpp"
+#include "python/crocoddyl/multibody/cost-base.hpp"
+#include "crocoddyl/multibody/costs/contact-cop-position.hpp"
+
+namespace crocoddyl {
+namespace python {
+
+void exposeCostContactCoPPosition() {
+  bp::class_<CostModelContactCoPPosition, bp::bases<CostModelAbstract> >(
+      "CostModelContactCoPPosition",
+      bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActivationModelAbstract>, FrameFootGeometry>(
+          bp::args("self", "state", "activation", "foot_geom"),
+          "Initialize the contact CoP position cost model.\n\n"
+          ":param state: state of the multibody system\n"
+          ":param activation: activation model\n"
+          ":param foot_geom: 2d geometry of the contact surface"))
+      .def<void (CostModelContactCoPPosition::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                                  const Eigen::Ref<const Eigen::VectorXd>&,
+                                                  const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &CostModelContactCoPPosition::calc, bp::args("self", "data", "x", "u"),
+          "Compute the contact CoP position cost.\n\n"
+          ":param data: cost data\n"
+          ":param x: time-discrete state vector\n"
+          ":param u: time-discrete control input")
+      .def<void (CostModelContactCoPPosition::*)(const boost::shared_ptr<CostDataAbstract>&,
+                                                  const Eigen::Ref<const Eigen::VectorXd>&,
+                                                  const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calcDiff", &CostModelContactCoPPosition::calcDiff, bp::args("self", "data", "x", "u"),
+          "Compute the derivatives of the contact CoP position cost.\n\n"
+          ":param data: action data\n"
+          ":param x: time-discrete state vector\n"
+          ":param u: time-discrete control input\n")
+      .def("createData", &CostModelContactCoPPosition::createData, bp::with_custodian_and_ward_postcall<0, 2>(),
+           bp::args("self", "data"),
+           "Create the contact CoP position cost data.\n\n"
+           "Each cost model has its own data that needs to be allocated. This function\n"
+           "returns the allocated data for a predefined cost.\n"
+           ":param data: shared data\n"
+           ":return cost data.")
+      .add_property("reference",
+                    bp::make_function(&CostModelContactCoPPosition::get_footGeom, bp::return_internal_reference<>()),
+                    &CostModelContactCoPPosition::set_reference<FrameFootGeometry>, "reference frame friction cone");
+
+  bp::register_ptr_to_python<boost::shared_ptr<CostDataContactCoPPosition> >();
+
+  bp::class_<CostDataContactCoPPosition, bp::bases<CostDataAbstract> >(
+      "CostDataContactCoPPosition", "Data for contact CoP position cost.\n\n",
+      bp::init<CostModelContactCoPPosition*, DataCollectorAbstract*>(
+          bp::args("self", "model", "data"),
+          "Create contact CoP position cost data.\n\n"
+          ":param model: contact CoP position cost model\n"
+          ":param data: shared data")[bp::with_custodian_and_ward<1, 2, bp::with_custodian_and_ward<1, 3> >()])
+      .add_property("Arr_Ru", bp::make_getter(&CostDataContactCoPPosition::Arr_Ru, bp::return_internal_reference<>()),
+                    "Intermediate product of Arr (2nd deriv of Activation) with Ru (deriv of residue)")
+      .add_property(
+          "contact",
+          bp::make_getter(&CostDataContactCoPPosition::contact, bp::return_value_policy<bp::return_by_value>()),
+          bp::make_setter(&CostDataContactCoPPosition::contact), "contact data associated with the current cost");
+}
+
+}  // namespace python
+}  // namespace crocoddyl

--- a/bindings/python/crocoddyl/multibody/costs/contact-cop-position.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/contact-cop-position.cpp
@@ -16,25 +16,26 @@ namespace python {
 void exposeCostContactCoPPosition() {
   bp::class_<CostModelContactCoPPosition, bp::bases<CostModelAbstract> >(
       "CostModelContactCoPPosition",
-      bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActivationModelAbstract>, FrameCoPSupport, 
-      int>(
-          bp::args("self", "state", "activation", "cop_support" "nu"),
+      bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActivationModelAbstract>, FrameCoPSupport, int>(
+          bp::args("self", "state", "activation",
+                   "cop_support"
+                   "nu"),
           "Initialize the contact CoP position cost model.\n\n"
           ":param state: state of the multibody system\n"
           ":param activation: activation model\n"
           ":param cop_support: contact frame ID and cop support region"
           ":param nu: dimension of control vector"))
       .def<void (CostModelContactCoPPosition::*)(const boost::shared_ptr<CostDataAbstract>&,
-                                                  const Eigen::Ref<const Eigen::VectorXd>&,
-                                                  const Eigen::Ref<const Eigen::VectorXd>&)>(
+                                                 const Eigen::Ref<const Eigen::VectorXd>&,
+                                                 const Eigen::Ref<const Eigen::VectorXd>&)>(
           "calc", &CostModelContactCoPPosition::calc, bp::args("self", "data", "x", "u"),
           "Compute the contact CoP position cost.\n\n"
           ":param data: cost data\n"
           ":param x: state vector\n"
           ":param u: control input")
       .def<void (CostModelContactCoPPosition::*)(const boost::shared_ptr<CostDataAbstract>&,
-                                                  const Eigen::Ref<const Eigen::VectorXd>&,
-                                                  const Eigen::Ref<const Eigen::VectorXd>&)>(
+                                                 const Eigen::Ref<const Eigen::VectorXd>&,
+                                                 const Eigen::Ref<const Eigen::VectorXd>&)>(
           "calcDiff", &CostModelContactCoPPosition::calcDiff, bp::args("self", "data", "x", "u"),
           "Compute the derivatives of the contact CoP position cost.\n\n"
           ":param data: action data\n"

--- a/bindings/python/crocoddyl/multibody/frames.cpp
+++ b/bindings/python/crocoddyl/multibody/frames.cpp
@@ -93,14 +93,16 @@ void exposeFrames() {
 
   bp::class_<FrameCoPSupport>("FrameCoPSupport",
                                 "Frame foot geometry.\n\n"
-                                "It defines the geometry of the contact surface for a given frame ID",
-                                bp::init<FrameIndex, Eigen::Vector2d>(bp::args("self", "frame", "support_region"),
+                                "It defines the ID of the contact frame, the geometry of the contact surface and the contact normal",
+                                bp::init<FrameIndex, Eigen::Vector2d, Eigen::Vector3d>(bp::args("self", "frame", "support_region", "normal"),
                                                                     "Initialize the frame foot geometry.\n\n"
-                                                                    ":param frame: frame ID\n"
-                                                                    ":param support_region: 2d-vector containg the length and width of the foot"))
-      .def(bp::init<>(bp::args("self"), "Default initialization of the frame friction cone."))
+                                                                    ":param frame: ID of the contact frame \n"
+                                                                    ":param support_region: dimension of the foot surface dim = (length, width)\n"
+                                                                    ":param normal: vector normal to the contact surface "))
+      .def(bp::init<>(bp::args("self"), "Default initialization of the frame CoP support."))
       .def_readwrite("frame", &FrameCoPSupport::frame, "frame ID")
-      .add_property("support_region", bp::make_getter(&FrameCoPSupport::support_region, bp::return_internal_reference<>()), "frame foot geometry")
+      .add_property("support_region", bp::make_getter(&FrameCoPSupport::support_region, bp::return_internal_reference<>()), "support region")
+      .add_property("normal", bp::make_getter(&FrameCoPSupport::normal, bp::return_internal_reference<>()), "contact normal")
       .def(PrintableVisitor<FrameCoPSupport>());
 }
 

--- a/bindings/python/crocoddyl/multibody/frames.cpp
+++ b/bindings/python/crocoddyl/multibody/frames.cpp
@@ -91,15 +91,14 @@ void exposeFrames() {
                     "frame friction cone")
       .def(PrintableVisitor<FrameFrictionCone>());
 
-  bp::class_<FrameCoPSupport>(
-      "FrameCoPSupport",
-      "Frame foot geometry.\n\n"
-      "It defines the ID of the contact frame and the geometry of the contact surface",
-      bp::init<FrameIndex, Eigen::Vector2d>(
-          bp::args("self", "frame", "support_region"),
-          "Initialize the frame foot geometry.\n\n"
-          ":param frame: ID of the contact frame \n"
-          ":param support_region: dimension of the foot surface dim = (length, width) "))
+  bp::class_<FrameCoPSupport>("FrameCoPSupport",
+                              "Frame foot geometry.\n\n"
+                              "It defines the ID of the contact frame and the geometry of the contact surface",
+                              bp::init<FrameIndex, Eigen::Vector2d>(
+                                  bp::args("self", "frame", "support_region"),
+                                  "Initialize the frame foot geometry.\n\n"
+                                  ":param frame: ID of the contact frame \n"
+                                  ":param support_region: dimension of the foot surface dim = (length, width) "))
       .def(bp::init<>(bp::args("self"), "Default initialization of the frame CoP support."))
       .def("update_A", &FrameCoPSupport::update_A, "update the matrix that defines the support region")
       .add_property("frame",

--- a/bindings/python/crocoddyl/multibody/frames.cpp
+++ b/bindings/python/crocoddyl/multibody/frames.cpp
@@ -94,13 +94,12 @@ void exposeFrames() {
   bp::class_<FrameCoPSupport>(
       "FrameCoPSupport",
       "Frame foot geometry.\n\n"
-      "It defines the ID of the contact frame, the geometry of the contact surface and the contact normal",
-      bp::init<FrameIndex, Eigen::Vector2d, Eigen::Vector3d>(
-          bp::args("self", "frame", "support_region", "normal"),
+      "It defines the ID of the contact frame and the geometry of the contact surface",
+      bp::init<FrameIndex, Eigen::Vector2d>(
+          bp::args("self", "frame", "support_region"),
           "Initialize the frame foot geometry.\n\n"
           ":param frame: ID of the contact frame \n"
-          ":param support_region: dimension of the foot surface dim = (length, width)\n"
-          ":param normal: vector normal to the contact surface "))
+          ":param support_region: dimension of the foot surface dim = (length, width) "))
       .def(bp::init<>(bp::args("self"), "Default initialization of the frame CoP support."))
       .def("update_A", &FrameCoPSupport::update_A, "update the matrix that defines the support region")
       .add_property("frame",
@@ -109,8 +108,6 @@ void exposeFrames() {
       .add_property("support_region",
                     bp::make_function(&FrameCoPSupport::get_support_region, bp::return_internal_reference<>()),
                     &FrameCoPSupport::set_support_region, "support region")
-      .add_property("normal", bp::make_function(&FrameCoPSupport::get_normal, bp::return_internal_reference<>()),
-                    &FrameCoPSupport::set_normal, "contact normal")
       .add_property("A", bp::make_function(&FrictionCone::get_A, bp::return_internal_reference<>()),
                     "inequality matrix")
       .def(PrintableVisitor<FrameCoPSupport>());

--- a/bindings/python/crocoddyl/multibody/frames.cpp
+++ b/bindings/python/crocoddyl/multibody/frames.cpp
@@ -91,18 +91,23 @@ void exposeFrames() {
                     "frame friction cone")
       .def(PrintableVisitor<FrameFrictionCone>());
 
-  bp::class_<FrameCoPSupport>("FrameCoPSupport",
-                                "Frame foot geometry.\n\n"
-                                "It defines the ID of the contact frame, the geometry of the contact surface and the contact normal",
-                                bp::init<FrameIndex, Eigen::Vector2d, Eigen::Vector3d>(bp::args("self", "frame", "support_region", "normal"),
-                                                                    "Initialize the frame foot geometry.\n\n"
-                                                                    ":param frame: ID of the contact frame \n"
-                                                                    ":param support_region: dimension of the foot surface dim = (length, width)\n"
-                                                                    ":param normal: vector normal to the contact surface "))
+  bp::class_<FrameCoPSupport>(
+      "FrameCoPSupport",
+      "Frame foot geometry.\n\n"
+      "It defines the ID of the contact frame, the geometry of the contact surface and the contact normal",
+      bp::init<FrameIndex, Eigen::Vector2d, Eigen::Vector3d>(
+          bp::args("self", "frame", "support_region", "normal"),
+          "Initialize the frame foot geometry.\n\n"
+          ":param frame: ID of the contact frame \n"
+          ":param support_region: dimension of the foot surface dim = (length, width)\n"
+          ":param normal: vector normal to the contact surface "))
       .def(bp::init<>(bp::args("self"), "Default initialization of the frame CoP support."))
       .def_readwrite("frame", &FrameCoPSupport::frame, "frame ID")
-      .add_property("support_region", bp::make_getter(&FrameCoPSupport::support_region, bp::return_internal_reference<>()), "support region")
-      .add_property("normal", bp::make_getter(&FrameCoPSupport::normal, bp::return_internal_reference<>()), "contact normal")
+      .add_property("support_region",
+                    bp::make_getter(&FrameCoPSupport::support_region, bp::return_internal_reference<>()),
+                    "support region")
+      .add_property("normal", bp::make_getter(&FrameCoPSupport::normal, bp::return_internal_reference<>()),
+                    "contact normal")
       .def(PrintableVisitor<FrameCoPSupport>());
 }
 

--- a/bindings/python/crocoddyl/multibody/frames.cpp
+++ b/bindings/python/crocoddyl/multibody/frames.cpp
@@ -90,6 +90,18 @@ void exposeFrames() {
       .add_property("oRf", bp::make_getter(&FrameFrictionCone::oRf, bp::return_internal_reference<>()),
                     "frame friction cone")
       .def(PrintableVisitor<FrameFrictionCone>());
+
+  bp::class_<FrameFootGeometry>("FrameFootGeometry",
+                                "Frame foot geometry.\n\n"
+                                "It defines the geometry of the contact surface for a given frame ID",
+                                bp::init<FrameIndex, Eigen::Vector2d>(bp::args("self", "frame", "dim"),
+                                                                    "Initialize the frame foot geometry.\n\n"
+                                                                    ":param frame: frame ID\n"
+                                                                    ":param dim: 2d-vector containg the length and width of the foot"))
+      .def(bp::init<>(bp::args("self"), "Default initialization of the frame friction cone."))
+      .def_readwrite("frame", &FrameFootGeometry::frame, "frame ID")
+      .add_property("dim", bp::make_getter(&FrameFootGeometry::dim, bp::return_internal_reference<>()), "frame foot geometry")
+      .def(PrintableVisitor<FrameFootGeometry>());
 }
 
 }  // namespace python

--- a/bindings/python/crocoddyl/multibody/frames.cpp
+++ b/bindings/python/crocoddyl/multibody/frames.cpp
@@ -102,12 +102,17 @@ void exposeFrames() {
           ":param support_region: dimension of the foot surface dim = (length, width)\n"
           ":param normal: vector normal to the contact surface "))
       .def(bp::init<>(bp::args("self"), "Default initialization of the frame CoP support."))
-      .def_readwrite("frame", &FrameCoPSupport::frame, "frame ID")
+      .def("update_A", &FrameCoPSupport::update_A, "update the matrix that defines the support region")
+      .add_property("frame",
+                    bp::make_function(&FrameCoPSupport::get_frame, bp::return_value_policy<bp::return_by_value>()),
+                    &FrameCoPSupport::set_frame, "frame ID")
       .add_property("support_region",
-                    bp::make_getter(&FrameCoPSupport::support_region, bp::return_internal_reference<>()),
-                    "support region")
-      .add_property("normal", bp::make_getter(&FrameCoPSupport::normal, bp::return_internal_reference<>()),
-                    "contact normal")
+                    bp::make_function(&FrameCoPSupport::get_support_region, bp::return_internal_reference<>()),
+                    &FrameCoPSupport::set_support_region, "support region")
+      .add_property("normal", bp::make_function(&FrameCoPSupport::get_normal, bp::return_internal_reference<>()),
+                    &FrameCoPSupport::set_normal, "contact normal")
+      .add_property("A", bp::make_function(&FrictionCone::get_A, bp::return_internal_reference<>()),
+                    "inequality matrix")
       .def(PrintableVisitor<FrameCoPSupport>());
 }
 

--- a/bindings/python/crocoddyl/multibody/frames.cpp
+++ b/bindings/python/crocoddyl/multibody/frames.cpp
@@ -91,17 +91,17 @@ void exposeFrames() {
                     "frame friction cone")
       .def(PrintableVisitor<FrameFrictionCone>());
 
-  bp::class_<FrameFootGeometry>("FrameFootGeometry",
+  bp::class_<FrameCoPSupport>("FrameCoPSupport",
                                 "Frame foot geometry.\n\n"
                                 "It defines the geometry of the contact surface for a given frame ID",
-                                bp::init<FrameIndex, Eigen::Vector2d>(bp::args("self", "frame", "dim"),
+                                bp::init<FrameIndex, Eigen::Vector2d>(bp::args("self", "frame", "support_region"),
                                                                     "Initialize the frame foot geometry.\n\n"
                                                                     ":param frame: frame ID\n"
-                                                                    ":param dim: 2d-vector containg the length and width of the foot"))
+                                                                    ":param support_region: 2d-vector containg the length and width of the foot"))
       .def(bp::init<>(bp::args("self"), "Default initialization of the frame friction cone."))
-      .def_readwrite("frame", &FrameFootGeometry::frame, "frame ID")
-      .add_property("dim", bp::make_getter(&FrameFootGeometry::dim, bp::return_internal_reference<>()), "frame foot geometry")
-      .def(PrintableVisitor<FrameFootGeometry>());
+      .def_readwrite("frame", &FrameCoPSupport::frame, "frame ID")
+      .add_property("support_region", bp::make_getter(&FrameCoPSupport::support_region, bp::return_internal_reference<>()), "frame foot geometry")
+      .def(PrintableVisitor<FrameCoPSupport>());
 }
 
 }  // namespace python

--- a/bindings/python/crocoddyl/multibody/multibody.cpp
+++ b/bindings/python/crocoddyl/multibody/multibody.cpp
@@ -40,6 +40,7 @@ void exposeMultibody() {
   exposeCostFrameVelocity();
   exposeCostContactForce();
   exposeCostContactImpulse();
+  exposeCostContactCoPPosition();
   exposeCostContactFrictionCone();
   exposeCostImpulseCoM();
   exposeCostImpulseFrictionCone();

--- a/bindings/python/crocoddyl/multibody/multibody.hpp
+++ b/bindings/python/crocoddyl/multibody/multibody.hpp
@@ -42,6 +42,7 @@ void exposeCostFrameTranslation();
 void exposeCostFrameRotation();
 void exposeCostFrameVelocity();
 void exposeCostContactForce();
+void exposeCostContactCoPPosition();
 void exposeCostContactFrictionCone();
 void exposeCostContactImpulse();
 void exposeCostImpulseFrictionCone();

--- a/include/crocoddyl/core/mathbase.hpp
+++ b/include/crocoddyl/core/mathbase.hpp
@@ -25,6 +25,7 @@ struct MathBaseTpl {
   typedef Eigen::Matrix<Scalar, 6, 1> Vector6s;
   typedef Eigen::Matrix<Scalar, 3, 3> Matrix3s;
   typedef Eigen::Matrix<Scalar, 6, 6> Matrix6s;
+  typedef Eigen::Matrix<Scalar, 4, 6> Matrix46s;
 
   typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 3> MatrixX3s;
   typedef Eigen::Matrix<Scalar, 3, Eigen::Dynamic> Matrix3xs;

--- a/include/crocoddyl/core/mathbase.hpp
+++ b/include/crocoddyl/core/mathbase.hpp
@@ -25,7 +25,6 @@ struct MathBaseTpl {
   typedef Eigen::Matrix<Scalar, 6, 1> Vector6s;
   typedef Eigen::Matrix<Scalar, 3, 3> Matrix3s;
   typedef Eigen::Matrix<Scalar, 6, 6> Matrix6s;
-  typedef Eigen::Matrix<Scalar, 4, 6> Matrix46s;
 
   typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 3> MatrixX3s;
   typedef Eigen::Matrix<Scalar, 3, Eigen::Dynamic> Matrix3xs;

--- a/include/crocoddyl/multibody/costs/contact-cop-position.hpp
+++ b/include/crocoddyl/multibody/costs/contact-cop-position.hpp
@@ -41,6 +41,7 @@ class CostModelContactCoPPositionTpl : public CostModelAbstractTpl<_Scalar> {
   typedef typename MathBase::VectorXs VectorXs;
   typedef typename MathBase::MatrixXs MatrixXs;
   typedef typename MathBase::MatrixX3s MatrixX3s;
+  typedef typename MathBaseTpl<Scalar>::Matrix46s Matrix46s;
 
   CostModelContactCoPPositionTpl(boost::shared_ptr<StateMultibody> state,
                           boost::shared_ptr<ActivationModelAbstract> activation, const FootGeometry& foot_geom, 

--- a/include/crocoddyl/multibody/costs/contact-cop-position.hpp
+++ b/include/crocoddyl/multibody/costs/contact-cop-position.hpp
@@ -26,17 +26,17 @@ namespace crocoddyl {
  * @brief Define a center of pressure cost function
  *
  * It builds a cost function that bounds the center of pressure (cop) for one contact surface to
- * lie inside a certain geometric area defined around the reference contact frame. The cost residual 
+ * lie inside a certain geometric area defined around the reference contact frame. The cost residual
  * vector is described as \mathbf{r} = \mathbf{A} \cdot \mathbf{f} \geq \mathbf{0}, where \mathbf{A}=
- * \begin{bmatrix} 0 & 0 & X/2 & 0 & -1 & 0 \\ 0 & 0 & X/2 & 0 & 1 & 0 \\ 0 & 0 & Y/2 & 1 & 0 & 0 \\ 
- * 0 & 0 & Y/2 & -1 & 0 & 0 \end{bmatrix} is the inequality matrix and \mathbf{f} is the reference spatial 
- * contact force in the frame coordinate. The constraints for the cop to lie inside the convex hull of 
+ * \begin{bmatrix} 0 & 0 & X/2 & 0 & -1 & 0 \\ 0 & 0 & X/2 & 0 & 1 & 0 \\ 0 & 0 & Y/2 & 1 & 0 & 0 \\
+ * 0 & 0 & Y/2 & -1 & 0 & 0 \end{bmatrix} is the inequality matrix and \mathbf{f} is the reference spatial
+ * contact force in the frame coordinate. The constraints for the cop to lie inside the convex hull of
  * the foot, see eq.(18-19) of https://hal.archives-ouvertes.fr/hal-02108449/document can be written as:
- * \begin{align}\begin{split}\tau^x &\leq Yf^z \\-\tau^x &\leq Yf^z \\\tau^y &\leq Yf^z \\-\tau^y &\leq Yf^z 
+ * \begin{align}\begin{split}\tau^x &\leq Yf^z \\-\tau^x &\leq Yf^z \\\tau^y &\leq Yf^z \\-\tau^y &\leq Yf^z
  * \end{split}\end{align}$`
- * The cost is computed, from the residual vector \mathbf{r}, through an user defined activation model. 
- * Additionally, the contact frame id, the desired support region for the cop and the inequality matrix 
- * are handled within FrameCoPSupportTpl. The force vector \mathbf{f} and its derivatives are computed by 
+ * The cost is computed, from the residual vector \mathbf{r}, through an user defined activation model.
+ * Additionally, the contact frame id, the desired support region for the cop and the inequality matrix
+ * are handled within FrameCoPSupportTpl. The force vector \mathbf{f} and its derivatives are computed by
  * DifferentialActionModelContactFwdDynamicsTpl. These values are stored in a shared data (i.e.
  * DataCollectorContactTpl). Note that this cost function cannot be used with other action models.
  *
@@ -79,7 +79,7 @@ class CostModelContactCoPPositionTpl : public CostModelAbstractTpl<_Scalar> {
 
   /**
    * @brief Initialize the cop cost model
-   * 
+   *
    * For this case the default nu is equal to `state->get_nv()`.
    *
    * @param[in] state        Multibody state
@@ -93,9 +93,9 @@ class CostModelContactCoPPositionTpl : public CostModelAbstractTpl<_Scalar> {
   /**
    * @brief Initialize the cop cost model
    *
-   * For this case the default activation model is quadratic barrier, i.e. 
+   * For this case the default activation model is quadratic barrier, i.e.
    * `ActivationModelQuadraticBarrierTpl(ActivationBounds(0, inf))`.
-   * 
+   *
    * @param[in] state        Multibody state
    * @param[in] cop_support  ID of contact frame and support region of the cop
    * @param[in] nu           Dimension of control vector
@@ -103,10 +103,10 @@ class CostModelContactCoPPositionTpl : public CostModelAbstractTpl<_Scalar> {
   CostModelContactCoPPositionTpl(boost::shared_ptr<StateMultibody> state, const FrameCoPSupport& cop_support,
                                  const std::size_t& nu);
 
-    /**
+  /**
    * @brief Initialize the cop cost model
-   * 
-   * For this case the default activation model is quadratic barrier, i.e. 
+   *
+   * For this case the default activation model is quadratic barrier, i.e.
    * `ActivationModelQuadraticBarrierTpl(ActivationBounds(0, inf))` and is equal to `state->get_nv().
    *
    * @param[in] state        Multibody state
@@ -118,7 +118,7 @@ class CostModelContactCoPPositionTpl : public CostModelAbstractTpl<_Scalar> {
   /**
    * @brief Compute the cop cost
    *
-   * The cop residual is computed based on the A matrix, the force vector is computed by 
+   * The cop residual is computed based on the A matrix, the force vector is computed by
    * DifferentialActionModelContactFwdDynamicsTpl and the results are stored in DataCollectorContactTpl.
    *
    * @param[in] data  cop data
@@ -131,7 +131,7 @@ class CostModelContactCoPPositionTpl : public CostModelAbstractTpl<_Scalar> {
   /**
    * @brief Compute the derivatives of the cop cost
    *
-   * The cop derivatives are based on the force derivatives computed by 
+   * The cop derivatives are based on the force derivatives computed by
    * DifferentialActionModelContactFwdDynamicsTpl and stored in DataCollectorContactTpl.
    *
    * @param[in] data  cop data
@@ -144,7 +144,7 @@ class CostModelContactCoPPositionTpl : public CostModelAbstractTpl<_Scalar> {
   /**
    * @brief Create the cop cost data
    *
-   * Each cost model has its own data that needs to be allocated. 
+   * Each cost model has its own data that needs to be allocated.
    * This function returns the allocated data for a predefined cost.
    *
    * @param[in] data  shared data (it should be of type DataCollectorContactTpl)
@@ -159,12 +159,12 @@ class CostModelContactCoPPositionTpl : public CostModelAbstractTpl<_Scalar> {
 
  protected:
   /**
-   * @brief Return the cop 
+   * @brief Return the cop
    */
   virtual void set_referenceImpl(const std::type_info& ti, const void* pv);
 
-    /**
-   * @brief Modify the cop 
+  /**
+   * @brief Modify the cop
    */
   virtual void get_referenceImpl(const std::type_info& ti, void* pv);
 

--- a/include/crocoddyl/multibody/costs/contact-cop-position.hpp
+++ b/include/crocoddyl/multibody/costs/contact-cop-position.hpp
@@ -124,10 +124,11 @@ struct CostDataContactCoPPositionTpl : public CostDataAbstractTpl<_Scalar> {
 
   pinocchio::DataTpl<Scalar>* pinocchio;
   MatrixXs Arr_Ru;
-  boost::shared_ptr<ContactDataAbstractTpl<Scalar> > contact; //spatial force expressed in world coordinates
-  pinocchio::SE3Tpl<Scalar> fiMo; //SE3 object with origin at contact point and rotation aligned with the world frame
-  pinocchio::ForceTpl<Scalar> f; //cartesian force expressed in world coordinates 
-  Vector3s cop;
+  boost::shared_ptr<ContactDataAbstractTpl<Scalar> > contact; // spatial force expressed in world coordinates
+  pinocchio::SE3Tpl<Scalar> fiMo; // SE3 object with origin at contact point and rotation aligned with the world frame
+  pinocchio::ForceTpl<Scalar> f; // cartesian force expressed in world coordinates 
+  MatrixX3s A; // inequality matrix
+  Vector3s cop; // center of pressure
   using Base::activation;
   using Base::cost;
   using Base::Lu;

--- a/include/crocoddyl/multibody/costs/contact-cop-position.hpp
+++ b/include/crocoddyl/multibody/costs/contact-cop-position.hpp
@@ -35,17 +35,17 @@ class CostModelContactCoPPositionTpl : public CostModelAbstractTpl<_Scalar> {
   typedef ActivationModelAbstractTpl<Scalar> ActivationModelAbstract;
   typedef ActivationModelQuadTpl<Scalar> ActivationModelQuad;
   typedef DataCollectorAbstractTpl<Scalar> DataCollectorAbstract;
-  typedef FrameFootGeometryTpl<Scalar> FootGeometry;
+  typedef FrameCoPSupportTpl<Scalar> CoPSupport;
   typedef typename MathBase::Vector2s Vector2s;
   typedef typename MathBase::Vector3s Vector3s;
   typedef typename MathBase::VectorXs VectorXs;
   typedef typename MathBase::MatrixXs MatrixXs;
   typedef typename MathBase::MatrixX3s MatrixX3s;
-  typedef typename MathBaseTpl<Scalar>::Matrix46s Matrix46s;
+  typedef Eigen::Matrix<Scalar, 4, 6> Matrix46;
 
   CostModelContactCoPPositionTpl(boost::shared_ptr<StateMultibody> state,
-                          boost::shared_ptr<ActivationModelAbstract> activation, const FootGeometry& foot_geom, 
-                          const Vector3s normal); //TODO: Pass as additional arg?
+                          boost::shared_ptr<ActivationModelAbstract> activation, const CoPSupport& cop_support, 
+                          const Vector3s& normal, const std::size_t& nu);
   virtual ~CostModelContactCoPPositionTpl();
 
   virtual void calc(const boost::shared_ptr<CostDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,
@@ -54,17 +54,17 @@ class CostModelContactCoPPositionTpl : public CostModelAbstractTpl<_Scalar> {
                         const Eigen::Ref<const VectorXs>& u);
   virtual boost::shared_ptr<CostDataAbstract> createData(DataCollectorAbstract* const data);
 
-  const FootGeometry& get_footGeom() const;
+  const CoPSupport& get_copSupport() const;
 
+ protected:
   using Base::activation_;
   using Base::nu_;
   using Base::state_;
   using Base::unone_;
 
   protected: 
-    FootGeometry foot_geom_; //!< frame name and geometrical dimension of the contact foot
+    CoPSupport cop_support_; //!< frame name and geometrical dimension of the contact foot
     const Vector3s normal_; //!< vector normal to the contact surface 
-    Vector3s foot_pos_; //!< position of the foot w.r.t. the ground plane
 };
 
 template <typename _Scalar>
@@ -75,7 +75,7 @@ struct CostDataContactCoPPositionTpl : public CostDataAbstractTpl<_Scalar> {
   typedef MathBaseTpl<Scalar> MathBase;
   typedef CostDataAbstractTpl<Scalar> Base;
   typedef DataCollectorAbstractTpl<Scalar> DataCollectorAbstract;
-  typedef FrameFootGeometryTpl<Scalar> FootGeometry;
+  typedef FrameCoPSupportTpl<Scalar> CoPSupport;
   typedef typename MathBase::Vector3s Vector3s;
   typedef typename MathBase::VectorXs VectorXs;
   typedef typename MathBase::MatrixXs MatrixXs;
@@ -88,8 +88,7 @@ struct CostDataContactCoPPositionTpl : public CostDataAbstractTpl<_Scalar> {
   CostDataContactCoPPositionTpl(Model<Scalar>* const model, DataCollectorAbstract* const data)
       : Base(model, data), Arr_Ru(model->get_activation()->get_nr(), model->get_state()->get_nv()) {
     Arr_Ru.setZero();
-    fiMo.translation(contact->jMf.translation());
-    
+        
     // Check that proper shared data has been passed
     DataCollectorContactTpl<Scalar>* d = dynamic_cast<DataCollectorContactTpl<Scalar>*>(shared);
     if (d == NULL) {
@@ -97,12 +96,12 @@ struct CostDataContactCoPPositionTpl : public CostDataAbstractTpl<_Scalar> {
     }
 
     // Get the active 6d contact (avoids data casting at runtime)
-    const FootGeometry& foot_geom = model->get_footGeom();
-    std::string frame_name = model->get_state()->get_pinocchio()->frames[model->get_footGeom().frame].name;
+    const CoPSupport& cop_support = model->get_copSupport();
+    std::string frame_name = model->get_state()->get_pinocchio()->frames[cop_support.frame].name;
     bool found_contact = false;
     for (typename ContactModelMultiple::ContactDataContainer::iterator it = d->contacts->contacts.begin();
          it != d->contacts->contacts.end(); ++it) {
-      if (it->second->frame == foot_geom.frame) {
+      if (it->second->frame == cop_support.frame) {
         ContactData3DTpl<Scalar>* d3d = dynamic_cast<ContactData3DTpl<Scalar>*>(it->second.get());
         if (d3d != NULL) {
           throw_pretty("Domain error: a 6d contact model is required in " +
@@ -111,10 +110,6 @@ struct CostDataContactCoPPositionTpl : public CostDataAbstractTpl<_Scalar> {
         }
         ContactData6DTpl<Scalar>* d6d = dynamic_cast<ContactData6DTpl<Scalar>*>(it->second.get());
         if (d6d != NULL) {
-          if (model->get_activation()->get_nr() != 6) {
-            throw_pretty("Domain error: nr isn't defined as 6 in the activation model for the 3d contact in " +
-                         frame_name);
-          }
           found_contact = true;
           contact = it->second;
           break;
@@ -128,10 +123,8 @@ struct CostDataContactCoPPositionTpl : public CostDataAbstractTpl<_Scalar> {
 
   pinocchio::DataTpl<Scalar>* pinocchio;
   MatrixXs Arr_Ru;
-  boost::shared_ptr<ContactDataAbstractTpl<Scalar> > contact; //!< spatial force expressed in world coordinates
-  pinocchio::SE3Tpl<Scalar> fiMo; //!< SE3 object with origin at contact point and rotation aligned with the world frame
-  pinocchio::ForceTpl<Scalar> f; //!< cartesian force expressed in world coordinates 
-  Vector3s cop; //!< center of pressure
+  boost::shared_ptr<ContactDataAbstractTpl<Scalar> > contact; //!< contact force
+  pinocchio::ForceTpl<Scalar> f; //!< transformed contact force
   using Base::activation;
   using Base::cost;
   using Base::Lu;

--- a/include/crocoddyl/multibody/costs/contact-cop-position.hpp
+++ b/include/crocoddyl/multibody/costs/contact-cop-position.hpp
@@ -40,6 +40,7 @@ class CostModelContactCoPPositionTpl : public CostModelAbstractTpl<_Scalar> {
   typedef typename MathBase::Vector3s Vector3s;
   typedef typename MathBase::VectorXs VectorXs;
   typedef typename MathBase::MatrixXs MatrixXs;
+  typedef typename MathBase::MatrixX3s MatrixX3s;
 
   CostModelContactCoPPositionTpl(boost::shared_ptr<StateMultibody> state,
                           boost::shared_ptr<ActivationModelAbstract> activation,const FootGeometry& foot_geom);

--- a/include/crocoddyl/multibody/costs/contact-cop-position.hpp
+++ b/include/crocoddyl/multibody/costs/contact-cop-position.hpp
@@ -45,7 +45,7 @@ class CostModelContactCoPPositionTpl : public CostModelAbstractTpl<_Scalar> {
 
   CostModelContactCoPPositionTpl(boost::shared_ptr<StateMultibody> state,
                           boost::shared_ptr<ActivationModelAbstract> activation, const CoPSupport& cop_support, 
-                          const Vector3s& normal, const std::size_t& nu);
+                          const std::size_t& nu);
   virtual ~CostModelContactCoPPositionTpl();
 
   virtual void calc(const boost::shared_ptr<CostDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,
@@ -64,7 +64,6 @@ class CostModelContactCoPPositionTpl : public CostModelAbstractTpl<_Scalar> {
 
  private: 
   CoPSupport cop_support_; //!< frame name and geometrical dimension of the contact foot
-  Vector3s normal_; //!< vector normal to the contact surface 
 };
 
 template <typename _Scalar>

--- a/include/crocoddyl/multibody/costs/contact-cop-position.hpp
+++ b/include/crocoddyl/multibody/costs/contact-cop-position.hpp
@@ -76,7 +76,9 @@ struct CostDataContactCoPPositionTpl : public CostDataAbstractTpl<_Scalar> {
   typedef typename MathBase::Vector3s Vector3s;
   typedef typename MathBase::VectorXs VectorXs;
   typedef typename MathBase::MatrixXs MatrixXs;
+  typedef typename MathBase::Matrix3s Matrix3s;
   typedef typename MathBase::Matrix3xs Matrix3xs;
+  typedef typename MathBase::MatrixX3s MatrixX3s;
   typedef typename MathBase::Matrix6xs Matrix6xs;
   typedef typename MathBase::Matrix6s Matrix6s;
   typedef typename MathBase::Vector6s Vector6s;

--- a/include/crocoddyl/multibody/costs/contact-cop-position.hpp
+++ b/include/crocoddyl/multibody/costs/contact-cop-position.hpp
@@ -43,7 +43,8 @@ class CostModelContactCoPPositionTpl : public CostModelAbstractTpl<_Scalar> {
   typedef typename MathBase::MatrixX3s MatrixX3s;
 
   CostModelContactCoPPositionTpl(boost::shared_ptr<StateMultibody> state,
-                          boost::shared_ptr<ActivationModelAbstract> activation,const FootGeometry& foot_geom);
+                          boost::shared_ptr<ActivationModelAbstract> activation, const FootGeometry& foot_geom, 
+                          const Vector3s normal); //TODO: Pass as additional arg?
   virtual ~CostModelContactCoPPositionTpl();
 
   virtual void calc(const boost::shared_ptr<CostDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,
@@ -61,6 +62,7 @@ class CostModelContactCoPPositionTpl : public CostModelAbstractTpl<_Scalar> {
 
   protected: 
     FootGeometry foot_geom_; //!< frame name and geometrical dimension of the contact foot
+    const Vector3s normal_; //!< vector normal to the contact surface 
     Vector3s foot_pos_; //!< position of the foot w.r.t. the ground plane
 };
 

--- a/include/crocoddyl/multibody/costs/contact-cop-position.hpp
+++ b/include/crocoddyl/multibody/costs/contact-cop-position.hpp
@@ -62,9 +62,9 @@ class CostModelContactCoPPositionTpl : public CostModelAbstractTpl<_Scalar> {
   using Base::state_;
   using Base::unone_;
 
-  protected: 
-    CoPSupport cop_support_; //!< frame name and geometrical dimension of the contact foot
-    const Vector3s normal_; //!< vector normal to the contact surface 
+ private: 
+  CoPSupport cop_support_; //!< frame name and geometrical dimension of the contact foot
+  Vector3s normal_; //!< vector normal to the contact surface 
 };
 
 template <typename _Scalar>
@@ -83,7 +83,6 @@ struct CostDataContactCoPPositionTpl : public CostDataAbstractTpl<_Scalar> {
   typedef typename MathBase::Matrix6xs Matrix6xs;
   typedef typename MathBase::Matrix6s Matrix6s;
   typedef typename MathBase::Vector6s Vector6s;
-  typedef typename MathBase::Matrix46s Matrix46s;
 
   template <template <typename Scalar> class Model>
   CostDataContactCoPPositionTpl(Model<Scalar>* const model, DataCollectorAbstract* const data)
@@ -95,17 +94,6 @@ struct CostDataContactCoPPositionTpl : public CostDataAbstractTpl<_Scalar> {
     if (d == NULL) {
       throw_pretty("Invalid argument: the shared data should be derived from DataCollectorContact");
     }
-
-    //Get model parameters
-    frame_id = model->get_frame_id();
-    cop_region = model->get_cop_region();
-    normal = model->get_normal();
-
-    //Compute the inequality matrix
-    A << 0, 0, cop_region[0] / 2, 0, -1, 0,
-        0, 0, cop_region[0] / 2, 0, 1, 0,
-        0, 0, cop_region[1] / 2, 1, 0, 0,
-        0, 0, cop_region[1] / 2, -1, 0, 0;
 
     // Get the active 6d contact (avoids data casting at runtime)
     const CoPSupport& cop_support = model->get_copSupport();

--- a/include/crocoddyl/multibody/costs/contact-cop-position.hpp
+++ b/include/crocoddyl/multibody/costs/contact-cop-position.hpp
@@ -89,9 +89,9 @@ struct CostDataContactCoPPositionTpl : public CostDataAbstractTpl<_Scalar> {
     Arr_Ru.setZero();
     
     // Check that proper shared data has been passed
-    DataCollectorMultibodyTpl<Scalar>* d = dynamic_cast<DataCollectorMultibodyTpl<Scalar>*>(shared);
+    DataCollectorContactTpl<Scalar>* d = dynamic_cast<DataCollectorContactTpl<Scalar>*>(shared);
     if (d == NULL) {
-      throw_pretty("Invalid argument: the shared data should be derived from DataCollectorMultibody");
+      throw_pretty("Invalid argument: the shared data should be derived from DataCollectorContact");
     }
 
     // Get the active 6d contact (avoids data casting at runtime)

--- a/include/crocoddyl/multibody/costs/contact-cop-position.hpp
+++ b/include/crocoddyl/multibody/costs/contact-cop-position.hpp
@@ -17,6 +17,7 @@
 #include "crocoddyl/multibody/data/contacts.hpp"
 #include "crocoddyl/multibody/frames.hpp"
 #include "crocoddyl/multibody/data/multibody.hpp"
+#include "crocoddyl/core/activations/quadratic-barrier.hpp"
 #include "crocoddyl/core/utils/exception.hpp"
 
 namespace crocoddyl {
@@ -33,7 +34,8 @@ class CostModelContactCoPPositionTpl : public CostModelAbstractTpl<_Scalar> {
   typedef StateMultibodyTpl<Scalar> StateMultibody;
   typedef CostDataAbstractTpl<Scalar> CostDataAbstract;
   typedef ActivationModelAbstractTpl<Scalar> ActivationModelAbstract;
-  typedef ActivationModelQuadTpl<Scalar> ActivationModelQuad;
+  typedef ActivationModelQuadraticBarrierTpl<Scalar> ActivationModelQuadraticBarrier;
+  typedef ActivationBoundsTpl<Scalar> ActivationBounds;
   typedef DataCollectorAbstractTpl<Scalar> DataCollectorAbstract;
   typedef FrameCoPSupportTpl<Scalar> FrameCoPSupport;
   typedef typename MathBase::Vector2s Vector2s;
@@ -46,6 +48,12 @@ class CostModelContactCoPPositionTpl : public CostModelAbstractTpl<_Scalar> {
   CostModelContactCoPPositionTpl(boost::shared_ptr<StateMultibody> state,
                                  boost::shared_ptr<ActivationModelAbstract> activation,
                                  const FrameCoPSupport& cop_support, const std::size_t& nu);
+  CostModelContactCoPPositionTpl(boost::shared_ptr<StateMultibody> state,
+                                 boost::shared_ptr<ActivationModelAbstract> activation,
+                                 const FrameCoPSupport& cop_support);
+  CostModelContactCoPPositionTpl(boost::shared_ptr<StateMultibody> state, const FrameCoPSupport& cop_support,
+                                 const std::size_t& nu);
+  CostModelContactCoPPositionTpl(boost::shared_ptr<StateMultibody> state, const FrameCoPSupport& cop_support);
   virtual ~CostModelContactCoPPositionTpl();
 
   virtual void calc(const boost::shared_ptr<CostDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,

--- a/include/crocoddyl/multibody/costs/contact-cop-position.hpp
+++ b/include/crocoddyl/multibody/costs/contact-cop-position.hpp
@@ -85,6 +85,7 @@ struct CostDataContactCoPPositionTpl : public CostDataAbstractTpl<_Scalar> {
   CostDataContactCoPPositionTpl(Model<Scalar>* const model, DataCollectorAbstract* const data)
       : Base(model, data), Arr_Ru(model->get_activation()->get_nr(), model->get_state()->get_nv()) {
     Arr_Ru.setZero();
+    fiMo.translation(contact->jMf.translation());
     
     // Check that proper shared data has been passed
     DataCollectorContactTpl<Scalar>* d = dynamic_cast<DataCollectorContactTpl<Scalar>*>(shared);

--- a/include/crocoddyl/multibody/costs/contact-cop-position.hpp
+++ b/include/crocoddyl/multibody/costs/contact-cop-position.hpp
@@ -44,8 +44,8 @@ class CostModelContactCoPPositionTpl : public CostModelAbstractTpl<_Scalar> {
   typedef Eigen::Matrix<Scalar, 4, 6> Matrix46;
 
   CostModelContactCoPPositionTpl(boost::shared_ptr<StateMultibody> state,
-                          boost::shared_ptr<ActivationModelAbstract> activation, const CoPSupport& cop_support, 
-                          const std::size_t& nu);
+                                 boost::shared_ptr<ActivationModelAbstract> activation, const CoPSupport& cop_support,
+                                 const std::size_t& nu);
   virtual ~CostModelContactCoPPositionTpl();
 
   virtual void calc(const boost::shared_ptr<CostDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,
@@ -62,8 +62,8 @@ class CostModelContactCoPPositionTpl : public CostModelAbstractTpl<_Scalar> {
   using Base::state_;
   using Base::unone_;
 
- private: 
-  CoPSupport cop_support_; //!< frame name and geometrical dimension of the contact foot
+ private:
+  CoPSupport cop_support_;  //!< frame name and geometrical dimension of the contact foot
 };
 
 template <typename _Scalar>
@@ -87,7 +87,7 @@ struct CostDataContactCoPPositionTpl : public CostDataAbstractTpl<_Scalar> {
   CostDataContactCoPPositionTpl(Model<Scalar>* const model, DataCollectorAbstract* const data)
       : Base(model, data), Arr_Ru(model->get_activation()->get_nr(), model->get_state()->get_nv()) {
     Arr_Ru.setZero();
-        
+
     // Check that proper shared data has been passed
     DataCollectorContactTpl<Scalar>* d = dynamic_cast<DataCollectorContactTpl<Scalar>*>(shared);
     if (d == NULL) {
@@ -103,8 +103,8 @@ struct CostDataContactCoPPositionTpl : public CostDataAbstractTpl<_Scalar> {
       if (it->second->frame == cop_support.frame) {
         ContactData3DTpl<Scalar>* d3d = dynamic_cast<ContactData3DTpl<Scalar>*>(it->second.get());
         if (d3d != NULL) {
-          throw_pretty("Domain error: a 6d contact model is required in " +
-                         frame_name + "in order to compute the CoP");
+          throw_pretty("Domain error: a 6d contact model is required in " + frame_name +
+                       "in order to compute the CoP");
           break;
         }
         ContactData6DTpl<Scalar>* d6d = dynamic_cast<ContactData6DTpl<Scalar>*>(it->second.get());
@@ -122,8 +122,8 @@ struct CostDataContactCoPPositionTpl : public CostDataAbstractTpl<_Scalar> {
 
   pinocchio::DataTpl<Scalar>* pinocchio;
   MatrixXs Arr_Ru;
-  boost::shared_ptr<ContactDataAbstractTpl<Scalar> > contact; //!< contact force
-  pinocchio::ForceTpl<Scalar> f; //!< transformed contact force
+  boost::shared_ptr<ContactDataAbstractTpl<Scalar> > contact;  //!< contact force
+  pinocchio::ForceTpl<Scalar> f;                               //!< transformed contact force
   using Base::activation;
   using Base::cost;
   using Base::Lu;

--- a/include/crocoddyl/multibody/costs/contact-cop-position.hpp
+++ b/include/crocoddyl/multibody/costs/contact-cop-position.hpp
@@ -53,7 +53,6 @@ class CostModelContactCoPPositionTpl : public CostModelAbstractTpl<_Scalar> {
   virtual boost::shared_ptr<CostDataAbstract> createData(DataCollectorAbstract* const data);
 
   const FootGeometry& get_footGeom() const;
-  // TODO: Other getter/setter methods required?
 
   using Base::activation_;
   using Base::nu_;
@@ -61,8 +60,8 @@ class CostModelContactCoPPositionTpl : public CostModelAbstractTpl<_Scalar> {
   using Base::unone_;
 
   protected: 
-    FootGeometry foot_geom_; // frame name and geometrical dimension of the contact foot
-    Vector3s foot_pos_; // position of the foot w.r.t. the ground plane
+    FootGeometry foot_geom_; //!< frame name and geometrical dimension of the contact foot
+    Vector3s foot_pos_; //!< position of the foot w.r.t. the ground plane
 };
 
 template <typename _Scalar>
@@ -78,8 +77,6 @@ struct CostDataContactCoPPositionTpl : public CostDataAbstractTpl<_Scalar> {
   typedef typename MathBase::VectorXs VectorXs;
   typedef typename MathBase::MatrixXs MatrixXs;
   typedef typename MathBase::Matrix3s Matrix3s;
-  typedef typename MathBase::Matrix3xs Matrix3xs;
-  typedef typename MathBase::MatrixX3s MatrixX3s;
   typedef typename MathBase::Matrix6xs Matrix6xs;
   typedef typename MathBase::Matrix6s Matrix6s;
   typedef typename MathBase::Vector6s Vector6s;
@@ -127,11 +124,10 @@ struct CostDataContactCoPPositionTpl : public CostDataAbstractTpl<_Scalar> {
 
   pinocchio::DataTpl<Scalar>* pinocchio;
   MatrixXs Arr_Ru;
-  boost::shared_ptr<ContactDataAbstractTpl<Scalar> > contact; // spatial force expressed in world coordinates
-  pinocchio::SE3Tpl<Scalar> fiMo; // SE3 object with origin at contact point and rotation aligned with the world frame
-  pinocchio::ForceTpl<Scalar> f; // cartesian force expressed in world coordinates 
-  MatrixX3s A; // inequality matrix
-  Vector3s cop; // center of pressure
+  boost::shared_ptr<ContactDataAbstractTpl<Scalar> > contact; //!< spatial force expressed in world coordinates
+  pinocchio::SE3Tpl<Scalar> fiMo; //!< SE3 object with origin at contact point and rotation aligned with the world frame
+  pinocchio::ForceTpl<Scalar> f; //!< cartesian force expressed in world coordinates 
+  Vector3s cop; //!< center of pressure
   using Base::activation;
   using Base::cost;
   using Base::Lu;

--- a/include/crocoddyl/multibody/costs/contact-cop-position.hpp
+++ b/include/crocoddyl/multibody/costs/contact-cop-position.hpp
@@ -56,7 +56,6 @@ class CostModelContactCoPPositionTpl : public CostModelAbstractTpl<_Scalar> {
 
   const CoPSupport& get_copSupport() const;
 
- protected:
   using Base::activation_;
   using Base::nu_;
   using Base::state_;
@@ -88,7 +87,8 @@ struct CostDataContactCoPPositionTpl : public CostDataAbstractTpl<_Scalar> {
   CostDataContactCoPPositionTpl(Model<Scalar>* const model, DataCollectorAbstract* const data)
       : Base(model, data), Arr_Ru(model->get_activation()->get_nr(), model->get_state()->get_nv()) {
     Arr_Ru.setZero();
-        
+    fiMo.translation(contact->jMf.translation());
+    
     // Check that proper shared data has been passed
     DataCollectorContactTpl<Scalar>* d = dynamic_cast<DataCollectorContactTpl<Scalar>*>(shared);
     if (d == NULL) {
@@ -110,6 +110,10 @@ struct CostDataContactCoPPositionTpl : public CostDataAbstractTpl<_Scalar> {
         }
         ContactData6DTpl<Scalar>* d6d = dynamic_cast<ContactData6DTpl<Scalar>*>(it->second.get());
         if (d6d != NULL) {
+          if (model->get_activation()->get_nr() != 6) {
+            throw_pretty("Domain error: nr isn't defined as 6 in the activation model for the 3d contact in " +
+                         frame_name);
+          }
           found_contact = true;
           contact = it->second;
           break;

--- a/include/crocoddyl/multibody/costs/contact-cop-position.hpp
+++ b/include/crocoddyl/multibody/costs/contact-cop-position.hpp
@@ -57,6 +57,9 @@ class CostModelContactCoPPositionTpl : public CostModelAbstractTpl<_Scalar> {
   const FrameCoPSupport& get_copSupport() const;
 
  protected:
+  virtual void set_referenceImpl(const std::type_info& ti, const void* pv);
+  virtual void get_referenceImpl(const std::type_info& ti, void* pv);
+
   using Base::activation_;
   using Base::nu_;
   using Base::state_;
@@ -95,7 +98,8 @@ struct CostDataContactCoPPositionTpl : public CostDataAbstractTpl<_Scalar> {
     }
 
     // Get the active 6d contact (avoids data casting at runtime)
-    const FrameCoPSupport& cop_support = model->get_copSupport();
+    FrameCoPSupport cop_support;
+    model->get_reference(cop_support);
     std::string frame_name = model->get_state()->get_pinocchio()->frames[cop_support.get_frame()].name;
     bool found_contact = false;
     for (typename ContactModelMultiple::ContactDataContainer::iterator it = d->contacts->contacts.begin();

--- a/include/crocoddyl/multibody/costs/contact-cop-position.hpp
+++ b/include/crocoddyl/multibody/costs/contact-cop-position.hpp
@@ -1,0 +1,151 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2020, University of Duisburg-Essen, University of Edinburgh
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef CROCODDYL_MULTIBODY_COSTS_CONTACT_COP_POSITION_HPP_
+#define CROCODDYL_MULTIBODY_COSTS_CONTACT_COP_POSITION_HPP_
+
+#include "crocoddyl/multibody/fwd.hpp"
+#include "crocoddyl/multibody/cost-base.hpp"
+#include "crocoddyl/multibody/contact-base.hpp"
+#include "crocoddyl/multibody/contacts/contact-3d.hpp"
+#include "crocoddyl/multibody/contacts/contact-6d.hpp"
+#include "crocoddyl/multibody/data/contacts.hpp"
+#include "crocoddyl/multibody/frames.hpp"
+#include "crocoddyl/multibody/data/multibody.hpp"
+#include "crocoddyl/core/utils/exception.hpp"
+
+namespace crocoddyl {
+
+template <typename _Scalar>
+class CostModelContactCoPPositionTpl : public CostModelAbstractTpl<_Scalar> {
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  typedef _Scalar Scalar;
+  typedef MathBaseTpl<Scalar> MathBase;
+  typedef CostModelAbstractTpl<Scalar> Base;
+  typedef CostDataContactCoPPositionTpl<Scalar> Data;
+  typedef StateMultibodyTpl<Scalar> StateMultibody;
+  typedef CostDataAbstractTpl<Scalar> CostDataAbstract;
+  typedef ActivationModelAbstractTpl<Scalar> ActivationModelAbstract;
+  typedef ActivationModelQuadTpl<Scalar> ActivationModelQuad;
+  typedef DataCollectorAbstractTpl<Scalar> DataCollectorAbstract;
+  typedef FrameFootGeometryTpl<Scalar> FootGeometry;
+  typedef typename MathBase::Vector2s Vector2s;
+  typedef typename MathBase::Vector3s Vector3s;
+  typedef typename MathBase::VectorXs VectorXs;
+  typedef typename MathBase::MatrixXs MatrixXs;
+
+  CostModelContactCoPPositionTpl(boost::shared_ptr<StateMultibody> state,
+                          boost::shared_ptr<ActivationModelAbstract> activation,const FootGeometry& foot_geom);
+  virtual ~CostModelContactCoPPositionTpl();
+
+  virtual void calc(const boost::shared_ptr<CostDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,
+                    const Eigen::Ref<const VectorXs>& u);
+  virtual void calcDiff(const boost::shared_ptr<CostDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,
+                        const Eigen::Ref<const VectorXs>& u);
+  virtual boost::shared_ptr<CostDataAbstract> createData(DataCollectorAbstract* const data);
+
+  const FootGeometry& get_footGeom() const;
+  // TODO: Other getter/setter methods required?
+
+  using Base::activation_;
+  using Base::nu_;
+  using Base::state_;
+  using Base::unone_;
+
+  protected: 
+    FootGeometry foot_geom_; // frame name and geometrical dimension of the contact foot
+    Vector3s foot_pos_; // position of the foot w.r.t. the ground plane
+};
+
+template <typename _Scalar>
+struct CostDataContactCoPPositionTpl : public CostDataAbstractTpl<_Scalar> {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  typedef _Scalar Scalar;
+  typedef MathBaseTpl<Scalar> MathBase;
+  typedef CostDataAbstractTpl<Scalar> Base;
+  typedef DataCollectorAbstractTpl<Scalar> DataCollectorAbstract;
+  typedef FrameFootGeometryTpl<Scalar> FootGeometry;
+  typedef typename MathBase::Vector3s Vector3s;
+  typedef typename MathBase::VectorXs VectorXs;
+  typedef typename MathBase::MatrixXs MatrixXs;
+  typedef typename MathBase::Matrix3xs Matrix3xs;
+  typedef typename MathBase::Matrix6xs Matrix6xs;
+  typedef typename MathBase::Matrix6s Matrix6s;
+  typedef typename MathBase::Vector6s Vector6s;
+
+  template <template <typename Scalar> class Model>
+  CostDataContactCoPPositionTpl(Model<Scalar>* const model, DataCollectorAbstract* const data)
+      : Base(model, data), Arr_Ru(model->get_activation()->get_nr(), model->get_state()->get_nv()) {
+    Arr_Ru.setZero();
+    
+    // Check that proper shared data has been passed
+    DataCollectorMultibodyTpl<Scalar>* d = dynamic_cast<DataCollectorMultibodyTpl<Scalar>*>(shared);
+    if (d == NULL) {
+      throw_pretty("Invalid argument: the shared data should be derived from DataCollectorMultibody");
+    }
+
+    // Get the active 6d contact (avoids data casting at runtime)
+    const FootGeometry& foot_geom = model->get_footGeom();
+    std::string frame_name = model->get_state()->get_pinocchio()->frames[model->get_footGeom().frame].name;
+    bool found_contact = false;
+    for (typename ContactModelMultiple::ContactDataContainer::iterator it = d->contacts->contacts.begin();
+         it != d->contacts->contacts.end(); ++it) {
+      if (it->second->frame == foot_geom.frame) {
+        ContactData3DTpl<Scalar>* d3d = dynamic_cast<ContactData3DTpl<Scalar>*>(it->second.get());
+        if (d3d != NULL) {
+          throw_pretty("Domain error: a 6d contact model is required in " +
+                         frame_name + "in order to compute the CoP");
+          break;
+        }
+        ContactData6DTpl<Scalar>* d6d = dynamic_cast<ContactData6DTpl<Scalar>*>(it->second.get());
+        if (d6d != NULL) {
+          if (model->get_activation()->get_nr() != 6) {
+            throw_pretty("Domain error: nr isn't defined as 6 in the activation model for the 3d contact in " +
+                         frame_name);
+          }
+          found_contact = true;
+          contact = it->second;
+          break;
+        }
+      }
+    }
+    if (!found_contact) {
+      throw_pretty("Domain error: there isn't defined contact data for " + frame_name);
+    }
+  }
+
+  pinocchio::DataTpl<Scalar>* pinocchio;
+  MatrixXs Arr_Ru;
+  boost::shared_ptr<ContactDataAbstractTpl<Scalar> > contact; //spatial force expressed in world coordinates
+  pinocchio::SE3Tpl<Scalar> fiMo; //SE3 object with origin at contact point and rotation aligned with the world frame
+  pinocchio::ForceTpl<Scalar> f; //cartesian force expressed in world coordinates 
+  Vector3s cop;
+  using Base::activation;
+  using Base::cost;
+  using Base::Lu;
+  using Base::Luu;
+  using Base::Lx;
+  using Base::Lxu;
+  using Base::Lxx;
+  using Base::r;
+  using Base::Ru;
+  using Base::Rx;
+  using Base::shared;
+};
+
+}  // namespace crocoddyl
+
+/* --- Details -------------------------------------------------------------- */
+/* --- Details -------------------------------------------------------------- */
+/* --- Details -------------------------------------------------------------- */
+#include "crocoddyl/multibody/costs/contact-cop-position.hxx"
+
+#endif  // CROCODDYL_MULTIBODY_COSTS_CONTACT_COP_POSITION_HPP_

--- a/include/crocoddyl/multibody/costs/contact-cop-position.hxx
+++ b/include/crocoddyl/multibody/costs/contact-cop-position.hxx
@@ -75,4 +75,23 @@ const FrameCoPSupportTpl<Scalar>& CostModelContactCoPPositionTpl<Scalar>::get_co
   return cop_support_;
 }
 
+template <typename Scalar>
+void CostModelContactCoPPositionTpl<Scalar>::set_referenceImpl(const std::type_info& ti, const void* pv) {
+  if (ti == typeid(FrameCoPSupport)) {
+    cop_support_ = *static_cast<const FrameCoPSupport*>(pv);
+  } else {
+    throw_pretty("Invalid argument: incorrect type (it should be FrameCoPSupport)");
+  }
+}
+
+template <typename Scalar>
+void CostModelContactCoPPositionTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) {
+  if (ti == typeid(FrameCoPSupport)) {
+    FrameCoPSupport& ref_map = *static_cast<FrameCoPSupport*>(pv);
+    ref_map = cop_support_;
+  } else {
+    throw_pretty("Invalid argument: incorrect type (it should be FrameCoPSupport)");
+  }
+}
+
 }  // namespace crocoddyl

--- a/include/crocoddyl/multibody/costs/contact-cop-position.hxx
+++ b/include/crocoddyl/multibody/costs/contact-cop-position.hxx
@@ -14,8 +14,8 @@ namespace crocoddyl {
 template<typename _Scalar>
 CostModelContactCoPPositionTpl<_Scalar>::CostModelContactCoPPositionTpl(boost::shared_ptr<StateMultibody> state,
                                           boost::shared_ptr<ActivationModelAbstract> activation,
-                                          const CoPSupport& cop_support, const Vector3s& normal, const std::size_t& nu)
-    : Base(state, activation, nu), cop_support_(cop_support), normal_(normal) {
+                                          const CoPSupport& cop_support, const std::size_t& nu)
+    : Base(state, activation, nu), cop_support_(cop_support) {
       cop_support_.update_A();
     }
 

--- a/include/crocoddyl/multibody/costs/contact-cop-position.hxx
+++ b/include/crocoddyl/multibody/costs/contact-cop-position.hxx
@@ -14,10 +14,8 @@ namespace crocoddyl {
 template <typename _Scalar>
 CostModelContactCoPPositionTpl<_Scalar>::CostModelContactCoPPositionTpl(
     boost::shared_ptr<StateMultibody> state, boost::shared_ptr<ActivationModelAbstract> activation,
-    const CoPSupport& cop_support, const std::size_t& nu)
-    : Base(state, activation, nu), cop_support_(cop_support) {
-  cop_support_.update_A();
-}
+    const FrameCoPSupport& cop_support, const std::size_t& nu)
+    : Base(state, activation, nu), cop_support_(cop_support) {}
 
 template <typename Scalar>
 CostModelContactCoPPositionTpl<Scalar>::~CostModelContactCoPPositionTpl() {}
@@ -28,11 +26,8 @@ void CostModelContactCoPPositionTpl<Scalar>::calc(const boost::shared_ptr<CostDa
                                                   const Eigen::Ref<const VectorXs>&) {
   Data* d = static_cast<Data*>(data.get());
 
-  // Transform the contact force
-  d->f = d->contact->jMf.actInv(d->contact->f);
-
   // Compute the cost residual respecting A * f
-  data->r.noalias() = cop_support_.get_A() * d->f.toVector();
+  data->r.noalias() = cop_support_.get_A() * d->contact->jMf.actInv(d->contact->f).toVector();
 
   // Compute the cost
   activation_->calc(data->activation, data->r);

--- a/include/crocoddyl/multibody/costs/contact-cop-position.hxx
+++ b/include/crocoddyl/multibody/costs/contact-cop-position.hxx
@@ -11,20 +11,21 @@
 
 namespace crocoddyl {
 
-template<typename _Scalar>
-CostModelContactCoPPositionTpl<_Scalar>::CostModelContactCoPPositionTpl(boost::shared_ptr<StateMultibody> state,
-                                          boost::shared_ptr<ActivationModelAbstract> activation,
-                                          const CoPSupport& cop_support, const std::size_t& nu)
+template <typename _Scalar>
+CostModelContactCoPPositionTpl<_Scalar>::CostModelContactCoPPositionTpl(
+    boost::shared_ptr<StateMultibody> state, boost::shared_ptr<ActivationModelAbstract> activation,
+    const CoPSupport& cop_support, const std::size_t& nu)
     : Base(state, activation, nu), cop_support_(cop_support) {
-      cop_support_.update_A();
-    }
+  cop_support_.update_A();
+}
 
 template <typename Scalar>
 CostModelContactCoPPositionTpl<Scalar>::~CostModelContactCoPPositionTpl() {}
 
 template <typename Scalar>
 void CostModelContactCoPPositionTpl<Scalar>::calc(const boost::shared_ptr<CostDataAbstract>& data,
-                                           const Eigen::Ref<const VectorXs>&, const Eigen::Ref<const VectorXs>&) {
+                                                  const Eigen::Ref<const VectorXs>&,
+                                                  const Eigen::Ref<const VectorXs>&) {
   Data* d = static_cast<Data*>(data.get());
 
   // Transform the contact force
@@ -40,7 +41,7 @@ void CostModelContactCoPPositionTpl<Scalar>::calc(const boost::shared_ptr<CostDa
 
 template <typename Scalar>
 void CostModelContactCoPPositionTpl<Scalar>::calcDiff(const boost::shared_ptr<CostDataAbstract>& data,
-                                                      const Eigen::Ref<const VectorXs>&, 
+                                                      const Eigen::Ref<const VectorXs>&,
                                                       const Eigen::Ref<const VectorXs>&) {
   // Update all data
   Data* d = static_cast<Data*>(data.get());
@@ -50,19 +51,19 @@ void CostModelContactCoPPositionTpl<Scalar>::calcDiff(const boost::shared_ptr<Co
   const MatrixXs& df_du = d->contact->df_du;
   const Matrix46& A = cop_support_.get_A();
 
-  //Compute the derivatives of the activation function
+  // Compute the derivatives of the activation function
   activation_->calcDiff(data->activation, data->r);
 
-  //Compute the derivatives of the cost residual
+  // Compute the derivatives of the cost residual
   data->Rx.noalias() = A * df_dx;
   data->Ru.noalias() = A * df_du;
   d->Arr_Ru.noalias() = data->activation->Arr * data->Ru;
 
-  //Compute the first order derivatives of the cost function
+  // Compute the first order derivatives of the cost function
   data->Lx.noalias() = data->Rx.transpose() * data->activation->Ar;
   data->Lu.noalias() = data->Ru.transpose() * data->activation->Ar;
 
-  //Compute the second order derivatives of the cost function
+  // Compute the second order derivatives of the cost function
   data->Lxx.noalias() = data->Rx.transpose() * data->activation->Arr * data->Rx;
   data->Lxu.noalias() = data->Rx.transpose() * d->Arr_Ru;
   data->Luu.noalias() = data->Ru.transpose() * d->Arr_Ru;
@@ -74,7 +75,7 @@ boost::shared_ptr<CostDataAbstractTpl<Scalar> > CostModelContactCoPPositionTpl<S
   return boost::allocate_shared<Data>(Eigen::aligned_allocator<Data>(), this, data);
 }
 
-template<typename Scalar>
+template <typename Scalar>
 const FrameCoPSupportTpl<Scalar>& CostModelContactCoPPositionTpl<Scalar>::get_copSupport() const {
   return cop_support_;
 }

--- a/include/crocoddyl/multibody/costs/contact-cop-position.hxx
+++ b/include/crocoddyl/multibody/costs/contact-cop-position.hxx
@@ -28,7 +28,7 @@ void CostModelContactCoPPositionTpl<Scalar>::calc(const boost::shared_ptr<CostDa
   Data* d = static_cast<Data*>(data.get());
 
   // Transform the spatial force to a cartesian force expressed in world coordinates  
-  d->fiMo = d->pinocchio.SE3(d->pinocchio->oMi[d->contact->joint].rotation(), d->contact->jMf.translation()); //TODO: Debug error: request for member ‘SE3’
+  d->fiMo.rotation(d->pinocchio->oMi[d->contact->joint].rotation());
   d->f = d->fiMo.actInv(d->contact->f);
   
   // Compute the CoP (for evaluation)
@@ -54,6 +54,8 @@ void CostModelContactCoPPositionTpl<Scalar>::calcDiff(const boost::shared_ptr<Co
   Data* d = static_cast<Data*>(data.get());
 
   // Get the derivatives of the contact wrench
+  const MatrixXs& df_dx = d->contact->df_dx;
+  const MatrixXs& df_du = d->contact->df_du;
   const MatrixX3s& A = foot_geom_.get_A();
 
   //Compute the derivatives of the activation function

--- a/include/crocoddyl/multibody/costs/contact-cop-position.hxx
+++ b/include/crocoddyl/multibody/costs/contact-cop-position.hxx
@@ -47,7 +47,7 @@ void CostModelContactCoPPositionTpl<Scalar>::calc(const boost::shared_ptr<CostDa
 }
 
 template <typename Scalar>
-void CostModelContactCoPPositionTpl<Scalar>::calcDiff(const boost::shared_ptr<CostDataAbstract>& data, //TODO: Correct assignment of the derivatives?
+void CostModelContactCoPPositionTpl<Scalar>::calcDiff(const boost::shared_ptr<CostDataAbstract>& data,
                                                       const Eigen::Ref<const VectorXs>&, 
                                                       const Eigen::Ref<const VectorXs>&) {
   // Update all data

--- a/include/crocoddyl/multibody/costs/contact-cop-position.hxx
+++ b/include/crocoddyl/multibody/costs/contact-cop-position.hxx
@@ -17,6 +17,29 @@ CostModelContactCoPPositionTpl<_Scalar>::CostModelContactCoPPositionTpl(
     const FrameCoPSupport& cop_support, const std::size_t& nu)
     : Base(state, activation, nu), cop_support_(cop_support) {}
 
+template <typename _Scalar>
+CostModelContactCoPPositionTpl<_Scalar>::CostModelContactCoPPositionTpl(
+    boost::shared_ptr<StateMultibody> state, boost::shared_ptr<ActivationModelAbstract> activation,
+    const FrameCoPSupport& cop_support)
+    : Base(state, activation), cop_support_(cop_support) {}
+
+template <typename _Scalar>
+CostModelContactCoPPositionTpl<_Scalar>::CostModelContactCoPPositionTpl(boost::shared_ptr<StateMultibody> state,
+                                                                        const FrameCoPSupport& cop_support,
+                                                                        const std::size_t& nu)
+    : Base(state,
+           boost::make_shared<ActivationModelQuadraticBarrier>(
+               ActivationBounds(VectorXs::Zero(4), std::numeric_limits<_Scalar>::max() * VectorXs::Ones(4))),
+           nu),
+      cop_support_(cop_support) {}
+
+template <typename _Scalar>
+CostModelContactCoPPositionTpl<_Scalar>::CostModelContactCoPPositionTpl(boost::shared_ptr<StateMultibody> state,
+                                                                        const FrameCoPSupport& cop_support)
+    : Base(state, boost::make_shared<ActivationModelQuadraticBarrier>(
+                      ActivationBounds(VectorXs::Zero(4), std::numeric_limits<_Scalar>::max() * VectorXs::Ones(4)))),
+      cop_support_(cop_support) {}
+
 template <typename Scalar>
 CostModelContactCoPPositionTpl<Scalar>::~CostModelContactCoPPositionTpl() {}
 

--- a/include/crocoddyl/multibody/costs/contact-cop-position.hxx
+++ b/include/crocoddyl/multibody/costs/contact-cop-position.hxx
@@ -79,14 +79,4 @@ const FrameCoPSupportTpl<Scalar>& CostModelContactCoPPositionTpl<Scalar>::get_co
   return cop_support_;
 }
 
-template<typename Scalar>
-const typename MathBaseTpl<Scalar>::Vector2s& CostModelContactCoPPositionTpl<Scalar>::get_cop_region() const {
-  return cop_region_;
-}
-
-template<typename Scalar>
-const typename MathBaseTpl<Scalar>::Vector3s& CostModelContactCoPPositionTpl<Scalar>::get_normal() const {
-  return normal_;
-}
-
 }  // namespace crocoddyl

--- a/include/crocoddyl/multibody/costs/contact-cop-position.hxx
+++ b/include/crocoddyl/multibody/costs/contact-cop-position.hxx
@@ -31,7 +31,7 @@ void CostModelContactCoPPositionTpl<Scalar>::calc(const boost::shared_ptr<CostDa
   d->fiMo.rotation(d->pinocchio->oMi[d->contact->joint].rotation());
   d->f = d->fiMo.actInv(d->contact->f);
   
-  // Compute the CoP (for evaluation)
+  // Compute the CoP (TODO: Remove after evaluation)
   // OC = (tau_0^p x n) / (n * f^p) compare eq.(13) in https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.138.8014&rep=rep1&type=pdf
   d->cop << normal_[1] * d->f.angular()[2] - normal_[2] * d->f.angular()[1], 
             normal_[2] * d->f.angular()[0] - normal_[0] * d->f.angular()[2],
@@ -56,9 +56,9 @@ void CostModelContactCoPPositionTpl<Scalar>::calcDiff(const boost::shared_ptr<Co
   Data* d = static_cast<Data*>(data.get());
 
   // Get the derivatives of the contact wrench
-  const MatrixXs& df_dx = d->contact->df_dx;
+  const MatrixXs& df_dx = d->contact->df_dx; // TODO: Evantually transform derivative to Caron frame
   const MatrixXs& df_du = d->contact->df_du;
-  const MatrixX3s& A = foot_geom_.get_A();
+  const Matrix46s& A = foot_geom_.get_A();
 
   //Compute the derivatives of the activation function
   activation_->calcDiff(data->activation, data->r);

--- a/include/crocoddyl/multibody/costs/contact-cop-position.hxx
+++ b/include/crocoddyl/multibody/costs/contact-cop-position.hxx
@@ -1,0 +1,77 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2020, University of Duisburg-Essen, University of Edinburgh
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#include "crocoddyl/core/utils/exception.hpp"
+#include "crocoddyl/multibody/costs/contact-cop-position.hpp"
+
+namespace crocoddyl {
+
+template<typename _Scalar>
+CostModelContactCoPPositionTpl<_Scalar>::CostModelContactCoPPositionTpl(boost::shared_ptr<StateMultibody> state,
+                                          boost::shared_ptr<ActivationModelAbstract> activation,
+                                          const FootGeometry& foot_geom)
+    : Base(state, activation), foot_geom_(foot_geom) {}
+
+template <typename Scalar>
+CostModelContactCoPPositionTpl<Scalar>::~CostModelContactCoPPositionTpl() {}
+
+template <typename Scalar>
+void CostModelContactCoPPositionTpl<Scalar>::calc(const boost::shared_ptr<CostDataAbstract>& data,
+                                           const Eigen::Ref<const VectorXs>&, const Eigen::Ref<const VectorXs>&) {
+  Data* d = static_cast<Data*>(data.get());
+
+  // Transform the spatial force to a cartesian force expressed in world coordinates  
+  data->fiMo = d->pinnochio.SE3(d->pinocchio->oMi[d->contact->joint].rotation().T, d->contact->jMf.translation());
+  data->f = data->fiMo.actInv(d->contact->f);
+  
+  // Compute the CoP
+  // OC = (tau_0^p x n) / (n * f^p) compare eq.(13) in https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.138.8014&rep=rep1&type=pdf
+  data->cop(-data->f.angular().at(1) / data->f.linear().at(2), data->f.angular().at(0) / data->f.linear().at(2), 0.0);
+
+  // Get foot position
+  foot_pos_ = d->pinocchio->oMf[d->contact->frame].translation();
+
+  // Compute the cost residual 
+  // Preliminarily: Simply take the difference between the computed CoP and the foot frame center position
+  // TODO: Impose inequality constraint A*r <= 0 (cmp. contact-friction-cone.hxx ) to penalize if CoP is not inside the contact area defined by 
+  data->r = foot_pos_ - data->cop;                             
+                            //      dx = max(abs(px - x) - width / 2, 0);
+                            //      dy = max(abs(py - y) - height / 2, 0);
+                            //      d =  dx * dx + dy * dy;
+  // Compute the cost
+  activation_->calc(data->activation, data->r);
+  data->cost = data->activation->a_value;
+}
+
+template <typename Scalar> //TODO: Develop calcDiff() following contact-friction-cone.hxx + CoP derivation
+void CostModelContactCoPPositionTpl<Scalar>::calcDiff(const boost::shared_ptr<CostDataAbstract>& data,
+                                                      const Eigen::Ref<const VectorXs>&, 
+                                                      const Eigen::Ref<const VectorXs>&) {
+  // Update all data
+  Data* d = static_cast<Data*>(data.get());
+
+  // TODO: Compute derivatives of CoP (dCoP_dx, dCoP_du)
+
+  // TODO: Compute derivatives of the cost residual (data->Rx = A * dCoP_dx, 
+                                                   //data->Ru = A * dCoP_du)
+
+  // TODO: Compute the derivatives of the cost function
+}
+
+template <typename Scalar>
+boost::shared_ptr<CostDataAbstractTpl<Scalar> > CostModelContactCoPPositionTpl<Scalar>::createData(
+    DataCollectorAbstract* const data) {
+  return boost::allocate_shared<Data>(Eigen::aligned_allocator<Data>(), this, data);
+}
+
+template<typename Scalar>
+const FrameFootGeometryTpl<Scalar>& CostModelContactCoPPositionTpl<Scalar>::get_footGeom() const {
+  return foot_geom_;
+}
+
+}  // namespace crocoddyl

--- a/include/crocoddyl/multibody/costs/contact-cop-position.hxx
+++ b/include/crocoddyl/multibody/costs/contact-cop-position.hxx
@@ -49,7 +49,7 @@ void CostModelContactCoPPositionTpl<Scalar>::calc(const boost::shared_ptr<CostDa
                                                   const Eigen::Ref<const VectorXs>&) {
   Data* d = static_cast<Data*>(data.get());
 
-  // Compute the cost residual respecting A * f
+  // Compute the cost residual r =  A * f
   data->r.noalias() = cop_support_.get_A() * d->contact->jMf.actInv(d->contact->f).toVector();
 
   // Compute the cost
@@ -64,7 +64,7 @@ void CostModelContactCoPPositionTpl<Scalar>::calcDiff(const boost::shared_ptr<Co
   // Update all data
   Data* d = static_cast<Data*>(data.get());
 
-  // Get the derivatives of the contact wrench
+  // Get the derivatives of the local contact wrench
   const MatrixXs& df_dx = d->contact->df_dx;
   const MatrixXs& df_du = d->contact->df_du;
   const Matrix46& A = cop_support_.get_A();

--- a/include/crocoddyl/multibody/costs/contact-cop-position.hxx
+++ b/include/crocoddyl/multibody/costs/contact-cop-position.hxx
@@ -27,8 +27,18 @@ void CostModelContactCoPPositionTpl<Scalar>::calc(const boost::shared_ptr<CostDa
                                            const Eigen::Ref<const VectorXs>&, const Eigen::Ref<const VectorXs>&) {
   Data* d = static_cast<Data*>(data.get());
 
-  // Transform the contact force
-  d->f = d->contact->jMf.actInv(d->contact->f);
+  // Transform the spatial force to a cartesian force expressed in world coordinates  
+  d->fiMo.rotation(d->pinocchio->oMi[d->contact->joint].rotation());
+  d->f = d->fiMo.actInv(d->contact->f);
+  
+  // Compute the CoP (TODO: Remove after evaluation)
+  // OC = (tau_0^p x n) / (n * f^p) compare eq.(13) in https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.138.8014&rep=rep1&type=pdf
+  d->cop << normal_[1] * d->f.angular()[2] - normal_[2] * d->f.angular()[1], 
+            normal_[2] * d->f.angular()[0] - normal_[0] * d->f.angular()[2],
+            normal_[0] * d->f.angular()[1] - normal_[1] * d->f.angular()[0]; 
+  d->cop *= 1 / (normal_[0] * d->f.linear()[0] + normal_[1] * d->f.linear()[1] + normal_[2] * d->f.linear()[2]);
+  // Get foot position (for evaluation)
+  // foot_pos_ = d->pinocchio->oMf[d->contact->frame].translation();   
 
   // Compute the cost residual respecting A * f
   data->r.noalias() = cop_support_.get_A() * d->f.toVector();
@@ -46,7 +56,7 @@ void CostModelContactCoPPositionTpl<Scalar>::calcDiff(const boost::shared_ptr<Co
   Data* d = static_cast<Data*>(data.get());
 
   // Get the derivatives of the contact wrench
-  const MatrixXs& df_dx = d->contact->df_dx;
+  const MatrixXs& df_dx = d->contact->df_dx; // TODO: Evantually transform derivative to Caron frame
   const MatrixXs& df_du = d->contact->df_du;
   const Matrix46& A = cop_support_.get_A();
 

--- a/include/crocoddyl/multibody/costs/contact-cop-position.hxx
+++ b/include/crocoddyl/multibody/costs/contact-cop-position.hxx
@@ -15,7 +15,7 @@ template<typename _Scalar>
 CostModelContactCoPPositionTpl<_Scalar>::CostModelContactCoPPositionTpl(boost::shared_ptr<StateMultibody> state,
                                           boost::shared_ptr<ActivationModelAbstract> activation,
                                           const FootGeometry& foot_geom, const Vector3s normal)
-    : Base(state, activation), foot_geom_(foot_geom) {
+    : Base(state, activation), foot_geom_(foot_geom), normal_(normal) {
       foot_geom_.update_A(); //TODO: Call here?
     }
 
@@ -33,8 +33,10 @@ void CostModelContactCoPPositionTpl<Scalar>::calc(const boost::shared_ptr<CostDa
   
   // Compute the CoP (for evaluation)
   // OC = (tau_0^p x n) / (n * f^p) compare eq.(13) in https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.138.8014&rep=rep1&type=pdf
-  d->cop << -d->f.angular()[1] / d->f.linear()[2], d->f.angular()[0] / d->f.linear()[2], 0.0;
-
+  d->cop << normal_[1] * d->f.angular()[2] - normal_[2] * d->f.angular()[1], 
+            normal_[2] * d->f.angular()[0] - normal_[0] * d->f.angular()[2],
+            normal_[0] * d->f.angular()[1] - normal_[1] * d->f.angular()[0]; 
+  d->cop *= 1 / (normal_[0] * d->f.linear()[0] + normal_[1] * d->f.linear()[1] + normal_[2] * d->f.linear()[2]);
   // Get foot position (for evaluation)
   // foot_pos_ = d->pinocchio->oMf[d->contact->frame].translation();   
 

--- a/include/crocoddyl/multibody/frames.hpp
+++ b/include/crocoddyl/multibody/frames.hpp
@@ -164,10 +164,8 @@ class FrameCoPSupportTpl {
     return os;
   }
 
-  // Define the inequality matrix A to implement A * f <= 0 compare eq.(18-19) in
+  // Define the inequality matrix A to implement A * f >= 0. Compare eq.(18-19) in
   // https://hal.archives-ouvertes.fr/hal-02108449/document
-  // Matrix3s c_R_o = Quaternions::FromTwoVectors(nsurf_, Vector3s::UnitZ()).toRotationMatrix(); TODO: Rotation
-  // necessary for each row of A?
   void update_A() {
     A_ << Scalar(0), Scalar(0), support_region_[0] / Scalar(2), Scalar(0), Scalar(-1), Scalar(0), Scalar(0), Scalar(0),
         support_region_[0] / Scalar(2), Scalar(0), Scalar(1), Scalar(0), Scalar(0), Scalar(0),
@@ -186,8 +184,8 @@ class FrameCoPSupportTpl {
   const Matrix46& get_A() const { return A_; }
 
  private:
-  FrameIndex frame_;         //!< ID of the contact frame
-  Vector2s support_region_;  //!< dimension of the foot surface dim = (length, width)
+  FrameIndex frame_;         //!< contact frame ID
+  Vector2s support_region_;  //!< cop support region = (length, width)
   Matrix46 A_;               //!< inequality matrix
 };
 

--- a/include/crocoddyl/multibody/frames.hpp
+++ b/include/crocoddyl/multibody/frames.hpp
@@ -155,10 +155,10 @@ struct FrameCoPSupportTpl {
   // Define the inequality matrix A to implement A * f <= 0 compare eq.(18-19) in https://hal.archives-ouvertes.fr/hal-02108449/document
   //Matrix3s c_R_o = Quaternions::FromTwoVectors(nsurf_, Vector3s::UnitZ()).toRotationMatrix(); TODO: Rotation necessary for each row of A?
   void update_A() {
-  A_ << 0, 0, support_region[0] / 2, 0, -1, 0,
-        0, 0, support_region[0] / 2, 0, 1, 0,
-        0, 0, support_region[1] / 2, 1, 0, 0,
-        0, 0, support_region[1] / 2, -1, 0, 0;
+  A_ << Scalar(0), Scalar(0), support_region[0] / Scalar(2), Scalar(0), Scalar(-1), Scalar(0),
+        Scalar(0), Scalar(0), support_region[0] / Scalar(2), Scalar(0), Scalar(1), Scalar(0),
+        Scalar(0), Scalar(0), support_region[1] / Scalar(2), Scalar(1), Scalar(0), Scalar(0),
+        Scalar(0), Scalar(0), support_region[1] / Scalar(2), Scalar(-1), Scalar(0), Scalar(0);
   }
 
   const Matrix46& get_A() const {

--- a/include/crocoddyl/multibody/frames.hpp
+++ b/include/crocoddyl/multibody/frames.hpp
@@ -146,30 +146,36 @@ struct FrameCoPSupportTpl {
   typedef Eigen::Matrix<Scalar, 4, 6> Matrix46;
 
   explicit FrameCoPSupportTpl() : frame(0), support_region(Vector2s::Zero()), normal(Vector3s::Zero()) {}
-  FrameCoPSupportTpl(const FrameCoPSupportTpl<Scalar>& value) : frame(value.frame), support_region(value.support_region), normal(value.normal) {}
-  FrameCoPSupportTpl(const FrameIndex& frame, const Vector2s& support_region, const Vector3s& normal) : frame(frame), support_region(support_region), normal(normal) {}
+  FrameCoPSupportTpl(const FrameCoPSupportTpl<Scalar>& value)
+      : frame(value.frame), support_region(value.support_region), normal(value.normal) {}
+  FrameCoPSupportTpl(const FrameIndex& frame, const Vector2s& support_region, const Vector3s& normal)
+      : frame(frame), support_region(support_region), normal(normal) {}
   friend std::ostream& operator<<(std::ostream& os, const FrameCoPSupportTpl<Scalar>& X) {
-    os << "      frame: " << X.frame << std::endl << "foot dimensions: " << std::endl << X.support_region << std::endl << "contact normal: " << std::endl << X.normal << std::endl;
+    os << "      frame: " << X.frame << std::endl
+       << "foot dimensions: " << std::endl
+       << X.support_region << std::endl
+       << "contact normal: " << std::endl
+       << X.normal << std::endl;
     return os;
   }
 
-  // Define the inequality matrix A to implement A * f <= 0 compare eq.(18-19) in https://hal.archives-ouvertes.fr/hal-02108449/document
-  //Matrix3s c_R_o = Quaternions::FromTwoVectors(nsurf_, Vector3s::UnitZ()).toRotationMatrix(); TODO: Rotation necessary for each row of A?
+  // Define the inequality matrix A to implement A * f <= 0 compare eq.(18-19) in
+  // https://hal.archives-ouvertes.fr/hal-02108449/document
+  // Matrix3s c_R_o = Quaternions::FromTwoVectors(nsurf_, Vector3s::UnitZ()).toRotationMatrix(); TODO: Rotation
+  // necessary for each row of A?
   void update_A() {
-  A << Scalar(0), Scalar(0), support_region[0] / Scalar(2), Scalar(0), Scalar(-1), Scalar(0),
-        Scalar(0), Scalar(0), support_region[0] / Scalar(2), Scalar(0), Scalar(1), Scalar(0),
-        Scalar(0), Scalar(0), support_region[1] / Scalar(2), Scalar(1), Scalar(0), Scalar(0),
-        Scalar(0), Scalar(0), support_region[1] / Scalar(2), Scalar(-1), Scalar(0), Scalar(0);
+    A << Scalar(0), Scalar(0), support_region[0] / Scalar(2), Scalar(0), Scalar(-1), Scalar(0), Scalar(0), Scalar(0),
+        support_region[0] / Scalar(2), Scalar(0), Scalar(1), Scalar(0), Scalar(0), Scalar(0),
+        support_region[1] / Scalar(2), Scalar(1), Scalar(0), Scalar(0), Scalar(0), Scalar(0),
+        support_region[1] / Scalar(2), Scalar(-1), Scalar(0), Scalar(0);
   }
 
-  const Matrix46& get_A() const {
-    return A;
-}
+  const Matrix46& get_A() const { return A; }
 
-  FrameIndex frame; //!< ID of the contact frame 
-  Vector2s support_region; //!< dimension of the foot surface dim = (length, width)
-  Vector3s normal; //!< vector normal to the contact surface 
-  Matrix46 A; //!< inequality matrix
+  FrameIndex frame;         //!< ID of the contact frame
+  Vector2s support_region;  //!< dimension of the foot surface dim = (length, width)
+  Vector3s normal;          //!< vector normal to the contact surface
+  Matrix46 A;               //!< inequality matrix
 };
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/multibody/frames.hpp
+++ b/include/crocoddyl/multibody/frames.hpp
@@ -146,13 +146,9 @@ class FrameCoPSupportTpl {
   typedef Eigen::Matrix<Scalar, 4, 6> Matrix46;
 
  public:
-  explicit FrameCoPSupportTpl() : frame_(0), support_region_(Vector2s::Zero()) {
-    update_A();
-  }
+  explicit FrameCoPSupportTpl() : frame_(0), support_region_(Vector2s::Zero()) { update_A(); }
   FrameCoPSupportTpl(const FrameCoPSupportTpl<Scalar>& value)
-      : frame_(value.get_frame()),
-        support_region_(value.get_support_region()),
-        A_(value.get_A()) {}
+      : frame_(value.get_frame()), support_region_(value.get_support_region()), A_(value.get_A()) {}
   FrameCoPSupportTpl(const FrameIndex& frame, const Vector2s& support_region)
       : frame_(frame), support_region_(support_region) {
     update_A();

--- a/include/crocoddyl/multibody/frames.hpp
+++ b/include/crocoddyl/multibody/frames.hpp
@@ -142,32 +142,34 @@ struct FrameCoPSupportTpl {
 
   typedef _Scalar Scalar;
   typedef typename MathBaseTpl<Scalar>::Vector2s Vector2s;
+  typedef typename MathBaseTpl<Scalar>::Vector3s Vector3s;
   typedef Eigen::Matrix<Scalar, 4, 6> Matrix46;
 
-  explicit FrameCoPSupportTpl() : frame(0), support_region(Vector2s::Zero()) {}
-  FrameCoPSupportTpl(const FrameCoPSupportTpl<Scalar>& value) : frame(value.frame), support_region(value.support_region) {}
-  FrameCoPSupportTpl(const FrameIndex& frame, const Vector2s& support_region) : frame(frame), support_region(support_region) {}
+  explicit FrameCoPSupportTpl() : frame(0), support_region(Vector2s::Zero()), normal(Vector3s::Zero()) {}
+  FrameCoPSupportTpl(const FrameCoPSupportTpl<Scalar>& value) : frame(value.frame), support_region(value.support_region), normal(value.normal) {}
+  FrameCoPSupportTpl(const FrameIndex& frame, const Vector2s& support_region, const Vector3s& normal) : frame(frame), support_region(support_region), normal(normal) {}
   friend std::ostream& operator<<(std::ostream& os, const FrameCoPSupportTpl<Scalar>& X) {
-    os << "      frame: " << X.frame << std::endl << "foot dimensions: " << std::endl << X.support_region << std::endl;
+    os << "      frame: " << X.frame << std::endl << "foot dimensions: " << std::endl << X.support_region << std::endl << "contact normal: " << std::endl << X.normal << std::endl;
     return os;
   }
 
   // Define the inequality matrix A to implement A * f <= 0 compare eq.(18-19) in https://hal.archives-ouvertes.fr/hal-02108449/document
   //Matrix3s c_R_o = Quaternions::FromTwoVectors(nsurf_, Vector3s::UnitZ()).toRotationMatrix(); TODO: Rotation necessary for each row of A?
   void update_A() {
-  A_ << Scalar(0), Scalar(0), support_region[0] / Scalar(2), Scalar(0), Scalar(-1), Scalar(0),
+  A << Scalar(0), Scalar(0), support_region[0] / Scalar(2), Scalar(0), Scalar(-1), Scalar(0),
         Scalar(0), Scalar(0), support_region[0] / Scalar(2), Scalar(0), Scalar(1), Scalar(0),
         Scalar(0), Scalar(0), support_region[1] / Scalar(2), Scalar(1), Scalar(0), Scalar(0),
         Scalar(0), Scalar(0), support_region[1] / Scalar(2), Scalar(-1), Scalar(0), Scalar(0);
   }
 
   const Matrix46& get_A() const {
-    return A_;
+    return A;
 }
 
-  FrameIndex frame; //!< name of the contact frame 
+  FrameIndex frame; //!< ID of the contact frame 
   Vector2s support_region; //!< dimension of the foot surface dim = (length, width)
-  Matrix46 A_; //!< inequality matrix
+  Vector3s normal; //!< vector normal to the contact surface 
+  Matrix46 A; //!< inequality matrix
 };
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/multibody/frames.hpp
+++ b/include/crocoddyl/multibody/frames.hpp
@@ -142,7 +142,7 @@ struct FrameFootGeometryTpl {
 
   typedef _Scalar Scalar;
   typedef typename MathBaseTpl<Scalar>::Vector2s Vector2s;
-  typedef typename MathBaseTpl<Scalar>::MatrixX3s MatrixX3s;
+  typedef typename MathBaseTpl<Scalar>::Matrix46s Matrix46s;
 
   explicit FrameFootGeometryTpl() : frame(0), dim(Vector2s::Zero()) {}
   FrameFootGeometryTpl(const FrameFootGeometryTpl<Scalar>& value) : frame(value.frame), dim(value.dim) {}
@@ -161,13 +161,13 @@ struct FrameFootGeometryTpl {
         0, 0, -dim[0] / 2, 0, -1, 0;
   }
 
-  const MatrixX3s& get_A() const {
+  const Matrix46s& get_A() const {
     return A_;
 }
 
   FrameIndex frame; //!< name of the contact frame 
   Vector2s dim; //!< dimension of the foot surface dim = (length, width)
-  MatrixX3s A_; //!< inequality matrix
+  Matrix46s A_; //!< inequality matrix
 };
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/multibody/frames.hpp
+++ b/include/crocoddyl/multibody/frames.hpp
@@ -147,7 +147,7 @@ struct FrameFootGeometryTpl {
   explicit FrameFootGeometryTpl() : frame(0), dim(Vector2s::Zero()) {}
   FrameFootGeometryTpl(const FrameFootGeometryTpl<Scalar>& value) : frame(value.frame), dim(value.dim) {}
   FrameFootGeometryTpl(const FrameIndex& frame, const Vector2s& dim) : frame(frame), dim(dim) {}
-  friend std::ostream& operator<<(std::ostream& os, const FrameTranslationTpl<Scalar>& X) {
+  friend std::ostream& operator<<(std::ostream& os, const FrameFootGeometryTpl<Scalar>& X) {
     os << "      frame: " << X.frame << std::endl << "foot dimensions: " << std::endl << X.dim << std::endl;
     return os;
   }

--- a/include/crocoddyl/multibody/frames.hpp
+++ b/include/crocoddyl/multibody/frames.hpp
@@ -137,37 +137,37 @@ struct FrameFrictionConeTpl {
 };
 
 template <typename _Scalar>
-struct FrameFootGeometryTpl {
+struct FrameCoPSupportTpl {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   typedef _Scalar Scalar;
   typedef typename MathBaseTpl<Scalar>::Vector2s Vector2s;
-  typedef typename MathBaseTpl<Scalar>::Matrix46s Matrix46s;
+  typedef Eigen::Matrix<Scalar, 4, 6> Matrix46;
 
-  explicit FrameFootGeometryTpl() : frame(0), dim(Vector2s::Zero()) {}
-  FrameFootGeometryTpl(const FrameFootGeometryTpl<Scalar>& value) : frame(value.frame), dim(value.dim) {}
-  FrameFootGeometryTpl(const FrameIndex& frame, const Vector2s& dim) : frame(frame), dim(dim) {}
-  friend std::ostream& operator<<(std::ostream& os, const FrameFootGeometryTpl<Scalar>& X) {
-    os << "      frame: " << X.frame << std::endl << "foot dimensions: " << std::endl << X.dim << std::endl;
+  explicit FrameCoPSupportTpl() : frame(0), support_region(Vector2s::Zero()) {}
+  FrameCoPSupportTpl(const FrameCoPSupportTpl<Scalar>& value) : frame(value.frame), support_region(value.support_region) {}
+  FrameCoPSupportTpl(const FrameIndex& frame, const Vector2s& support_region) : frame(frame), support_region(support_region) {}
+  friend std::ostream& operator<<(std::ostream& os, const FrameCoPSupportTpl<Scalar>& X) {
+    os << "      frame: " << X.frame << std::endl << "foot dimensions: " << std::endl << X.support_region << std::endl;
     return os;
   }
 
   // Define the inequality matrix A to implement A * f <= 0 compare eq.(18-19) in https://hal.archives-ouvertes.fr/hal-02108449/document
   //Matrix3s c_R_o = Quaternions::FromTwoVectors(nsurf_, Vector3s::UnitZ()).toRotationMatrix(); TODO: Rotation necessary for each row of A?
   void update_A() {
-    A_ << 0, 0, -dim[1] / 2, 1, 0, 0,
-        0, 0, -dim[1] / 2, -1, 0, 0,
-        0, 0, -dim[0] / 2, 0, 1, 0,
-        0, 0, -dim[0] / 2, 0, -1, 0;
+  A_ << 0, 0, support_region[0] / 2, 0, -1, 0,
+        0, 0, support_region[0] / 2, 0, 1, 0,
+        0, 0, support_region[1] / 2, 1, 0, 0,
+        0, 0, support_region[1] / 2, -1, 0, 0;
   }
 
-  const Matrix46s& get_A() const {
+  const Matrix46& get_A() const {
     return A_;
 }
 
   FrameIndex frame; //!< name of the contact frame 
-  Vector2s dim; //!< dimension of the foot surface dim = (length, width)
-  Matrix46s A_; //!< inequality matrix
+  Vector2s support_region; //!< dimension of the foot surface dim = (length, width)
+  Matrix46 A_; //!< inequality matrix
 };
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/multibody/frames.hpp
+++ b/include/crocoddyl/multibody/frames.hpp
@@ -142,6 +142,7 @@ struct FrameFootGeometryTpl {
 
   typedef _Scalar Scalar;
   typedef typename MathBaseTpl<Scalar>::Vector2s Vector2s;
+  typedef typename MathBaseTpl<Scalar>::MatrixX3s MatrixX3s;
 
   explicit FrameFootGeometryTpl() : frame(0), dim(Vector2s::Zero()) {}
   FrameFootGeometryTpl(const FrameFootGeometryTpl<Scalar>& value) : frame(value.frame), dim(value.dim) {}
@@ -151,8 +152,22 @@ struct FrameFootGeometryTpl {
     return os;
   }
 
-  FrameIndex frame; // name of the contact frame 
-  Vector2s dim; // dimension of the foot surface dim = (length, width)
+  // Define the inequality matrix A to implement A * f <= 0 compare eq.(18-19) in https://hal.archives-ouvertes.fr/hal-02108449/document
+  //Matrix3s c_R_o = Quaternions::FromTwoVectors(nsurf_, Vector3s::UnitZ()).toRotationMatrix(); TODO: Rotation necessary for each row of A?
+  void update_A() {
+    A_ << 0, 0, -dim[1] / 2, 1, 0, 0,
+        0, 0, -dim[1] / 2, -1, 0, 0,
+        0, 0, -dim[0] / 2, 0, 1, 0,
+        0, 0, -dim[0] / 2, 0, -1, 0;
+  }
+
+  const MatrixX3s& get_A() const {
+    return A_;
+}
+
+  FrameIndex frame; //!< name of the contact frame 
+  Vector2s dim; //!< dimension of the foot surface dim = (length, width)
+  MatrixX3s A_; //!< inequality matrix
 };
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/multibody/frames.hpp
+++ b/include/crocoddyl/multibody/frames.hpp
@@ -146,24 +146,21 @@ class FrameCoPSupportTpl {
   typedef Eigen::Matrix<Scalar, 4, 6> Matrix46;
 
  public:
-  explicit FrameCoPSupportTpl() : frame_(0), support_region_(Vector2s::Zero()), normal_(Vector3s::Zero()) {
+  explicit FrameCoPSupportTpl() : frame_(0), support_region_(Vector2s::Zero()) {
     update_A();
   }
   FrameCoPSupportTpl(const FrameCoPSupportTpl<Scalar>& value)
       : frame_(value.get_frame()),
         support_region_(value.get_support_region()),
-        normal_(value.get_normal()),
         A_(value.get_A()) {}
-  FrameCoPSupportTpl(const FrameIndex& frame, const Vector2s& support_region, const Vector3s& normal)
-      : frame_(frame), support_region_(support_region), normal_(normal) {
+  FrameCoPSupportTpl(const FrameIndex& frame, const Vector2s& support_region)
+      : frame_(frame), support_region_(support_region) {
     update_A();
   }
   friend std::ostream& operator<<(std::ostream& os, const FrameCoPSupportTpl<Scalar>& X) {
     os << "          frame: " << X.get_frame() << std::endl
        << "foot dimensions: " << std::endl
-       << X.get_support_region() << std::endl
-       << " contact normal: " << std::endl
-       << X.get_normal() << std::endl;
+       << X.get_support_region() << std::endl;
     return os;
   }
 
@@ -183,17 +180,14 @@ class FrameCoPSupportTpl {
     support_region_ = support_region;
     update_A();
   }
-  void set_normal(const Vector3s& normal) { normal_ = normal; }
 
   const FrameIndex& get_frame() const { return frame_; }
   const Vector2s& get_support_region() const { return support_region_; }
-  const Vector3s& get_normal() const { return normal_; }
   const Matrix46& get_A() const { return A_; }
 
  private:
   FrameIndex frame_;         //!< ID of the contact frame
   Vector2s support_region_;  //!< dimension of the foot surface dim = (length, width)
-  Vector3s normal_;          //!< vector normal to the contact surface
   Matrix46 A_;               //!< inequality matrix
 };
 

--- a/include/crocoddyl/multibody/frames.hpp
+++ b/include/crocoddyl/multibody/frames.hpp
@@ -136,6 +136,25 @@ struct FrameFrictionConeTpl {
   FrictionCone oRf;
 };
 
+template <typename _Scalar>
+struct FrameFootGeometryTpl {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  typedef _Scalar Scalar;
+  typedef typename MathBaseTpl<Scalar>::Vector2s Vector2s;
+
+  explicit FrameFootGeometryTpl() : frame(0), dim(Vector2s::Zero()) {}
+  FrameFootGeometryTpl(const FrameFootGeometryTpl<Scalar>& value) : frame(value.frame), dim(value.dim) {}
+  FrameFootGeometryTpl(const FrameIndex& frame, const Vector2s& dim) : frame(frame), dim(dim) {}
+  friend std::ostream& operator<<(std::ostream& os, const FrameTranslationTpl<Scalar>& X) {
+    os << "      frame: " << X.frame << std::endl << "foot dimensions: " << std::endl << X.dim << std::endl;
+    return os;
+  }
+
+  FrameIndex frame; // name of the contact frame 
+  Vector2s dim; // dimension of the foot surface dim = (length, width)
+};
+
 }  // namespace crocoddyl
 
 #endif  // CROCODDYL_MULTIBODY_FRAMES_HPP_

--- a/include/crocoddyl/multibody/fwd.hpp
+++ b/include/crocoddyl/multibody/fwd.hpp
@@ -150,6 +150,11 @@ class CostModelImpulseFrictionConeTpl;
 template <typename Scalar>
 struct CostDataImpulseFrictionConeTpl;
 
+template <typename Scalar>
+class CostModelContactCoPPositionTpl;
+template <typename Scalar>
+struct CostDataContactCoPPositionTpl;
+
 // impulse
 template <typename Scalar>
 class ImpulseModelAbstractTpl;

--- a/include/crocoddyl/multibody/fwd.hpp
+++ b/include/crocoddyl/multibody/fwd.hpp
@@ -74,6 +74,9 @@ struct FrameForceTpl;
 template <typename Scalar>
 struct FrameFrictionConeTpl;
 
+template <typename Scalar>
+struct FrameFootGeometryTpl;
+
 // cost
 template <typename Scalar>
 class CostModelAbstractTpl;
@@ -257,6 +260,7 @@ typedef FramePlacementTpl<double> FramePlacement;
 typedef FrameMotionTpl<double> FrameMotion;
 typedef FrameForceTpl<double> FrameForce;
 typedef FrameFrictionConeTpl<double> FrameFrictionCone;
+typedef FrameFootGeometryTpl<double> FrameFootGeometry;
 
 typedef CostModelAbstractTpl<double> CostModelAbstract;
 typedef CostDataAbstractTpl<double> CostDataAbstract;
@@ -277,6 +281,8 @@ typedef CostModelStateTpl<double> CostModelState;
 typedef CostDataStateTpl<double> CostDataState;
 typedef CostModelFrameVelocityTpl<double> CostModelFrameVelocity;
 typedef CostDataFrameVelocityTpl<double> CostDataFrameVelocity;
+typedef CostModelContactCoPPositionTpl<double> CostModelContactCoPPosition;
+typedef CostDataContactCoPPositionTpl<double> CostDataContactCoPPosition;
 typedef CostModelContactFrictionConeTpl<double> CostModelContactFrictionCone;
 typedef CostDataContactFrictionConeTpl<double> CostDataContactFrictionCone;
 typedef CostModelContactForceTpl<double> CostModelContactForce;

--- a/include/crocoddyl/multibody/fwd.hpp
+++ b/include/crocoddyl/multibody/fwd.hpp
@@ -75,7 +75,7 @@ template <typename Scalar>
 struct FrameFrictionConeTpl;
 
 template <typename Scalar>
-struct FrameFootGeometryTpl;
+struct FrameCoPSupportTpl;
 
 // cost
 template <typename Scalar>
@@ -260,7 +260,7 @@ typedef FramePlacementTpl<double> FramePlacement;
 typedef FrameMotionTpl<double> FrameMotion;
 typedef FrameForceTpl<double> FrameForce;
 typedef FrameFrictionConeTpl<double> FrameFrictionCone;
-typedef FrameFootGeometryTpl<double> FrameFootGeometry;
+typedef FrameCoPSupportTpl<double> FrameCoPSupport;
 
 typedef CostModelAbstractTpl<double> CostModelAbstract;
 typedef CostDataAbstractTpl<double> CostDataAbstract;

--- a/src/multibody/costs/contact-cop-position.cpp
+++ b/src/multibody/costs/contact-cop-position.cpp
@@ -1,0 +1,9 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2020, University of Duisburg-Essen, University of Edinburgh
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#include "crocoddyl/multibody/costs/contact-cop-position.hpp"

--- a/unittest/bindings/CMakeLists.txt
+++ b/unittest/bindings/CMakeLists.txt
@@ -12,7 +12,6 @@ SET(${PROJECT_NAME}_PYTHON_BINDINGS_TESTS
   momemtum_cost
   impulse_com_cost
   squashing
-  cop_cost
   )
 
 FOREACH(TEST ${${PROJECT_NAME}_PYTHON_BINDINGS_TESTS})

--- a/unittest/bindings/CMakeLists.txt
+++ b/unittest/bindings/CMakeLists.txt
@@ -12,6 +12,7 @@ SET(${PROJECT_NAME}_PYTHON_BINDINGS_TESTS
   momemtum_cost
   impulse_com_cost
   squashing
+  cop_cost
   )
 
 FOREACH(TEST ${${PROJECT_NAME}_PYTHON_BINDINGS_TESTS})

--- a/unittest/bindings/test_cop_cost.py
+++ b/unittest/bindings/test_cop_cost.py
@@ -25,11 +25,11 @@ COSTS = crocoddyl.CostModelSum(ROBOT_STATE, ACTUATION.nu)
 COSTS.addCost(
     "r_sole_cop",
     crocoddyl.CostModelContactCoPPosition(ROBOT_STATE, crocoddyl.ActivationModelQuad(4), # TODO: Hard coded dim?
-    crocoddyl.FrameFootGeometry(ROBOT_MODEL.getFrameId('r_sole'), (20, 8)), 1.))
+    crocoddyl.FrameFootGeometry(ROBOT_MODEL.getFrameId('r_sole'), (20, 8)), 1.), [0, 0, 1])
 COSTS.addCost(
     "l_sole_cop",
     crocoddyl.CostModelContactCoPPosition(ROBOT_STATE, crocoddyl.ActivationModelQuad(4), 
-    crocoddyl.FrameFootGeometry(ROBOT_MODEL.getFrameId('l_sole'), (20, 8)), 1.))
+    crocoddyl.FrameFootGeometry(ROBOT_MODEL.getFrameId('l_sole'), (20, 8)), 1.), [0, 0, 1])
 MODEL = crocoddyl.DifferentialActionModelContactFwdDynamics(ROBOT_STATE, ACTUATION, CONTACTS, COSTS, 0., True)
 DATA = MODEL.createData()
 

--- a/unittest/bindings/test_cop_cost.py
+++ b/unittest/bindings/test_cop_cost.py
@@ -11,11 +11,7 @@ ROBOT_DATA = ROBOT_MODEL.createData()
 ROBOT_STATE = crocoddyl.StateMultibody(ROBOT_MODEL)
 ACTUATION = crocoddyl.ActuationModelFloatingBase(ROBOT_STATE)
 
-# Create friction cone and its activation
-frictionCone = crocoddyl.FrictionCone(np.matrix([0., 0., 1.]).T, 0.7, 4, False)
-activation = crocoddyl.ActivationModelQuadraticBarrier(crocoddyl.ActivationBounds(frictionCone.lb, frictionCone.ub))
-
-# Contact friction-cone cost unittest
+# Contact CoP position cost unittest
 CONTACTS = crocoddyl.ContactModelMultiple(ROBOT_STATE, ACTUATION.nu)
 CONTACT_6D_RF = crocoddyl.ContactModel6D(
     ROBOT_STATE, crocoddyl.FramePlacement(ROBOT_MODEL.getFrameId('r_sole'), pinocchio.SE3.Random()), ACTUATION.nu,
@@ -28,10 +24,12 @@ CONTACTS.addContact("l_sole_contact", CONTACT_6D_LF)
 COSTS = crocoddyl.CostModelSum(ROBOT_STATE, ACTUATION.nu)
 COSTS.addCost(
     "r_sole_cop",
-    crocoddyl.CostModelContactCoPPosition(ROBOT_STATE, activation, crocoddyl.FrameFootGeometry(ROBOT_MODEL.getFrameId('r_sole'), (20, 8)), 1.))
+    crocoddyl.CostModelContactCoPPosition(ROBOT_STATE, crocoddyl.ActivationModelQuad(4), # TODO: Hard coded dim?
+    crocoddyl.FrameFootGeometry(ROBOT_MODEL.getFrameId('r_sole'), (20, 8)), 1.))
 COSTS.addCost(
     "l_sole_cop",
-    crocoddyl.CostModelContactCoPPosition(ROBOT_STATE, activation, crocoddyl.FrameFootGeometry(ROBOT_MODEL.getFrameId('l_sole'), (20, 8)), 1.))
+    crocoddyl.CostModelContactCoPPosition(ROBOT_STATE, crocoddyl.ActivationModelQuad(4), 
+    crocoddyl.FrameFootGeometry(ROBOT_MODEL.getFrameId('l_sole'), (20, 8)), 1.))
 MODEL = crocoddyl.DifferentialActionModelContactFwdDynamics(ROBOT_STATE, ACTUATION, CONTACTS, COSTS, 0., True)
 DATA = MODEL.createData()
 

--- a/unittest/bindings/test_cop_cost.py
+++ b/unittest/bindings/test_cop_cost.py
@@ -11,10 +11,6 @@ ROBOT_DATA = ROBOT_MODEL.createData()
 ROBOT_STATE = crocoddyl.StateMultibody(ROBOT_MODEL)
 ACTUATION = crocoddyl.ActuationModelFloatingBase(ROBOT_STATE)
 
-# Create friction cone and its activation
-activation = crocoddyl.ActivationModelQuadraticBarrier(crocoddyl.ActivationBounds(
-                np.array([0] * 4), np.array([np.inf] * 4)))
-
 # Contact CoP position cost unittest
 CONTACTS = crocoddyl.ContactModelMultiple(ROBOT_STATE, ACTUATION.nu)
 CONTACT_6D_RF = crocoddyl.ContactModel6D(

--- a/unittest/bindings/test_cop_cost.py
+++ b/unittest/bindings/test_cop_cost.py
@@ -1,0 +1,55 @@
+import crocoddyl
+import pinocchio
+import example_robot_data
+import numpy as np
+
+from test_utils import NUMDIFF_MODIFIER, assertNumDiff
+
+# Create robot model, data, state and actuation
+ROBOT_MODEL = example_robot_data.loadICub().model
+ROBOT_DATA = ROBOT_MODEL.createData()
+ROBOT_STATE = crocoddyl.StateMultibody(ROBOT_MODEL)
+ACTUATION = crocoddyl.ActuationModelFloatingBase(ROBOT_STATE)
+
+# Create friction cone and its activation
+frictionCone = crocoddyl.FrictionCone(np.matrix([0., 0., 1.]).T, 0.7, 4, False)
+activation = crocoddyl.ActivationModelQuadraticBarrier(crocoddyl.ActivationBounds(frictionCone.lb, frictionCone.ub))
+
+# Contact friction-cone cost unittest
+CONTACTS = crocoddyl.ContactModelMultiple(ROBOT_STATE, ACTUATION.nu)
+CONTACT_6D_RF = crocoddyl.ContactModel6D(
+    ROBOT_STATE, crocoddyl.FramePlacement(ROBOT_MODEL.getFrameId('r_sole'), pinocchio.SE3.Random()), ACTUATION.nu,
+    pinocchio.utils.rand(2))
+CONTACT_6D_LF = crocoddyl.ContactModel6D(
+    ROBOT_STATE, crocoddyl.FramePlacement(ROBOT_MODEL.getFrameId('l_sole'), pinocchio.SE3.Random()), ACTUATION.nu,
+    pinocchio.utils.rand(2))
+CONTACTS.addContact("r_sole_contact", CONTACT_6D_RF)
+CONTACTS.addContact("l_sole_contact", CONTACT_6D_LF)
+COSTS = crocoddyl.CostModelSum(ROBOT_STATE, ACTUATION.nu)
+COSTS.addCost(
+    "r_sole_cop",
+    crocoddyl.CostModelContactCoPPosition(ROBOT_STATE, activation, crocoddyl.FrameFootGeometry(ROBOT_MODEL.getFrameId('r_sole'), (20, 8)), 1.))
+COSTS.addCost(
+    "l_sole_cop",
+    crocoddyl.CostModelContactCoPPosition(ROBOT_STATE, activation, crocoddyl.FrameFootGeometry(ROBOT_MODEL.getFrameId('l_sole'), (20, 8)), 1.))
+MODEL = crocoddyl.DifferentialActionModelContactFwdDynamics(ROBOT_STATE, ACTUATION, CONTACTS, COSTS, 0., True)
+DATA = MODEL.createData()
+
+MODEL_ND = crocoddyl.DifferentialActionModelNumDiff(MODEL)
+MODEL_ND.disturbance *= 10
+dnum = MODEL_ND.createData()
+
+x = ROBOT_STATE.rand()
+u = pinocchio.utils.rand(ACTUATION.nu)
+MODEL.calc(DATA, x, u)
+MODEL.calcDiff(DATA, x, u)
+MODEL_ND.calc(dnum, x, u)
+MODEL_ND.calcDiff(dnum, x, u)
+assertNumDiff(DATA.Fx, dnum.Fx, NUMDIFF_MODIFIER *
+              MODEL_ND.disturbance)  # threshold was 2.7e-2, is now 2.11e-4 (see assertNumDiff.__doc__)
+assertNumDiff(DATA.Fu, dnum.Fu, NUMDIFF_MODIFIER *
+              MODEL_ND.disturbance)  # threshold was 2.7e-2, is now 2.11e-4 (see assertNumDiff.__doc__)
+assertNumDiff(DATA.Lx, dnum.Lx, NUMDIFF_MODIFIER *
+              MODEL_ND.disturbance)  # threshold was 2.7e-2, is now 2.11e-4 (see assertNumDiff.__doc__)
+assertNumDiff(DATA.Lu, dnum.Lu, NUMDIFF_MODIFIER *
+              MODEL_ND.disturbance)  # threshold was 2.7e-2, is now 2.11e-4 (see assertNumDiff.__doc__)

--- a/unittest/bindings/test_cop_cost.py
+++ b/unittest/bindings/test_cop_cost.py
@@ -12,8 +12,8 @@ ROBOT_STATE = crocoddyl.StateMultibody(ROBOT_MODEL)
 ACTUATION = crocoddyl.ActuationModelFloatingBase(ROBOT_STATE)
 
 # Create friction cone and its activation
-activation = crocoddyl.ActivationModelQuadraticBarrier(crocoddyl.ActivationBounds(
-                np.array([0] * 4), np.array([np.inf] * 4)))
+activation = crocoddyl.ActivationModelQuadraticBarrier(
+    crocoddyl.ActivationBounds(np.array([0] * 4), np.array([np.inf] * 4)))
 
 # Contact CoP position cost unittest
 CONTACTS = crocoddyl.ContactModelMultiple(ROBOT_STATE, ACTUATION.nu)
@@ -27,11 +27,11 @@ CONTACTS.addContact("r_sole_contact", CONTACT_6D_RF)
 CONTACTS.addContact("l_sole_contact", CONTACT_6D_LF)
 COSTS = crocoddyl.CostModelSum(ROBOT_STATE, ACTUATION.nu)
 CoPCostRF = crocoddyl.CostModelContactCoPPosition(
-    ROBOT_STATE, activation, 
+    ROBOT_STATE, activation,
     crocoddyl.FrameCoPSupport(ROBOT_MODEL.getFrameId('r_sole'), np.array([0.01, 0.01]), np.array([0, 0, 1])),
     ACTUATION.nu)
 CoPCostLF = crocoddyl.CostModelContactCoPPosition(
-    ROBOT_STATE, activation, 
+    ROBOT_STATE, activation,
     crocoddyl.FrameCoPSupport(ROBOT_MODEL.getFrameId('l_sole'), np.array([0.01, 0.01]), np.array([0, 0, 1])),
     ACTUATION.nu)
 COSTS.addCost("r_sole_cop", CoPCostRF, 1)

--- a/unittest/bindings/test_cop_cost.py
+++ b/unittest/bindings/test_cop_cost.py
@@ -28,12 +28,10 @@ CONTACTS.addContact("l_sole_contact", CONTACT_6D_LF)
 COSTS = crocoddyl.CostModelSum(ROBOT_STATE, ACTUATION.nu)
 CoPCostRF = crocoddyl.CostModelContactCoPPosition(
     ROBOT_STATE, activation,
-    crocoddyl.FrameCoPSupport(ROBOT_MODEL.getFrameId('r_sole'), np.array([0.01, 0.01]), np.array([0, 0, 1])),
-    ACTUATION.nu)
+    crocoddyl.FrameCoPSupport(ROBOT_MODEL.getFrameId('r_sole'), np.array([0.01, 0.01])), ACTUATION.nu)
 CoPCostLF = crocoddyl.CostModelContactCoPPosition(
     ROBOT_STATE, activation,
-    crocoddyl.FrameCoPSupport(ROBOT_MODEL.getFrameId('l_sole'), np.array([0.01, 0.01]), np.array([0, 0, 1])),
-    ACTUATION.nu)
+    crocoddyl.FrameCoPSupport(ROBOT_MODEL.getFrameId('l_sole'), np.array([0.01, 0.01])), ACTUATION.nu)
 COSTS.addCost("r_sole_cop", CoPCostRF, 1)
 COSTS.addCost("l_sole_cop", CoPCostLF, 1)
 MODEL = crocoddyl.DifferentialActionModelContactFwdDynamics(ROBOT_STATE, ACTUATION, CONTACTS, COSTS, 0., True)

--- a/unittest/bindings/test_cop_cost.py
+++ b/unittest/bindings/test_cop_cost.py
@@ -28,12 +28,12 @@ CONTACTS.addContact("l_sole_contact", CONTACT_6D_LF)
 COSTS = crocoddyl.CostModelSum(ROBOT_STATE, ACTUATION.nu)
 CoPCostRF = crocoddyl.CostModelContactCoPPosition(
     ROBOT_STATE, activation, 
-    crocoddyl.FrameCoPSupport(ROBOT_MODEL.getFrameId('r_sole'), np.array([0.01, 0.01])),
-    np.array([0, 0, 1]), ACTUATION.nu)
+    crocoddyl.FrameCoPSupport(ROBOT_MODEL.getFrameId('r_sole'), np.array([0.01, 0.01]), np.array([0, 0, 1])),
+    ACTUATION.nu)
 CoPCostLF = crocoddyl.CostModelContactCoPPosition(
     ROBOT_STATE, activation, 
-    crocoddyl.FrameCoPSupport(ROBOT_MODEL.getFrameId('l_sole'), np.array([0.01, 0.01])),
-    np.array([0, 0, 1]), ACTUATION.nu)
+    crocoddyl.FrameCoPSupport(ROBOT_MODEL.getFrameId('l_sole'), np.array([0.01, 0.01]), np.array([0, 0, 1])),
+    ACTUATION.nu)
 COSTS.addCost("r_sole_cop", CoPCostRF, 1)
 COSTS.addCost("l_sole_cop", CoPCostLF, 1)
 MODEL = crocoddyl.DifferentialActionModelContactFwdDynamics(ROBOT_STATE, ACTUATION, CONTACTS, COSTS, 0., True)

--- a/unittest/bindings/test_cop_cost.py
+++ b/unittest/bindings/test_cop_cost.py
@@ -27,11 +27,11 @@ CONTACTS.addContact("r_sole_contact", CONTACT_6D_RF)
 CONTACTS.addContact("l_sole_contact", CONTACT_6D_LF)
 COSTS = crocoddyl.CostModelSum(ROBOT_STATE, ACTUATION.nu)
 CoPCostRF = crocoddyl.CostModelContactCoPPosition(
-    ROBOT_STATE, activation,
-    crocoddyl.FrameCoPSupport(ROBOT_MODEL.getFrameId('r_sole'), np.array([0.01, 0.01])), ACTUATION.nu)
+    ROBOT_STATE, activation, crocoddyl.FrameCoPSupport(ROBOT_MODEL.getFrameId('r_sole'), np.array([0.01, 0.01])),
+    ACTUATION.nu)
 CoPCostLF = crocoddyl.CostModelContactCoPPosition(
-    ROBOT_STATE, activation,
-    crocoddyl.FrameCoPSupport(ROBOT_MODEL.getFrameId('l_sole'), np.array([0.01, 0.01])), ACTUATION.nu)
+    ROBOT_STATE, activation, crocoddyl.FrameCoPSupport(ROBOT_MODEL.getFrameId('l_sole'), np.array([0.01, 0.01])),
+    ACTUATION.nu)
 COSTS.addCost("r_sole_cop", CoPCostRF, 1)
 COSTS.addCost("l_sole_cop", CoPCostLF, 1)
 MODEL = crocoddyl.DifferentialActionModelContactFwdDynamics(ROBOT_STATE, ACTUATION, CONTACTS, COSTS, 0., True)


### PR DESCRIPTION
The intention of this PR is to implement a cost function for the Center of Pressure (CoP) of a single contact surface (i.e. one cost for each foot in contact). 

Motivation: Preliminary investigations for the trajectory generation of a humanoid robot have shown that the computed CoP for various motions (balancing, slow walking) leaves the convex hull around the contact points by far. This leads to inherently unbalanced trajectories and consequently unstable motions when utilizing a simple control architecture.  

**The basic idea:** 
1. The constraints for the CoP to lie inside the convex hull of the foot (see [eq.(18-19) of this paper](https://hal.archives-ouvertes.fr/hal-02108449/document)) can be written as:
`$\begin{align}
\begin{split}
\tau^x &\leq Yf^z \\
-\tau^x &\leq Yf^z \\
\tau^y &\leq Yf^z \\
-\tau^y &\leq Yf^z 
\end{split}
\end{align}$`
2. Implement these inequality constraints as: 
`$r = A \cdot f \geq 0$`
with the according A matrix as
`$\begin{equation}
\begin{bmatrix} 0 & 0 & X/2 & 0 & -1 & 0 \\
0 & 0 & X/2 & 0 & 1 & 0 \\
0 & 0 & Y/2 & 1 & 0 & 0 \\
0 & 0 & Y/2 & -1 & 0 & 0 \end{bmatrix} 
\end{equation}$`