### PR TITLE
Included eigenpy header to avoid memory leak

### DIFF
--- a/bindings/python/crocoddyl/core/actuation/actuation-squashing.cpp
+++ b/bindings/python/crocoddyl/core/actuation/actuation-squashing.cpp
@@ -7,7 +7,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "python/crocoddyl/core/core.hpp"
-
 #include "crocoddyl/core/actuation/actuation-squashing.hpp"
 #include "crocoddyl/core/utils/exception.hpp"
 

--- a/bindings/python/crocoddyl/core/state-base.cpp
+++ b/bindings/python/crocoddyl/core/state-base.cpp
@@ -6,6 +6,7 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
+#include "python/crocoddyl/core/core.hpp"
 #include "python/crocoddyl/core/state-base.hpp"
 
 namespace crocoddyl {


### PR DESCRIPTION
It turns out that there was only a single place that we were not including the eigenpy header. This hopefully should fix the issue #795. @gfadini could you try this branch and report if this fixes your issue?