### PR TITLE
Fix memory leaks in vector and map converters #795

### DIFF
--- a/bindings/python/crocoddyl/core/numdiff/diff-action.cpp
+++ b/bindings/python/crocoddyl/core/numdiff/diff-action.cpp
@@ -18,12 +18,10 @@ void exposeDifferentialActionNumDiff() {
   // Register custom converters between std::vector and Python list
   typedef boost::shared_ptr<DifferentialActionModelAbstract> DifferentialActionModelPtr;
   typedef boost::shared_ptr<DifferentialActionDataAbstract> DifferentialActionDataPtr;
-  bp::to_python_converter<std::vector<DifferentialActionModelPtr, std::allocator<DifferentialActionModelPtr> >,
-                          vector_to_list<DifferentialActionModelPtr, false> >();
-  bp::to_python_converter<std::vector<DifferentialActionDataPtr, std::allocator<DifferentialActionDataPtr> >,
-                          vector_to_list<DifferentialActionDataPtr, false> >();
-  list_to_vector()
-      .from_python<std::vector<DifferentialActionModelPtr, std::allocator<DifferentialActionModelPtr> > >();
+  StdVectorPythonVisitor<DifferentialActionModelPtr, std::allocator<DifferentialActionModelPtr>, true>::expose(
+      "StdVec_DiffActionModel");
+  StdVectorPythonVisitor<DifferentialActionDataPtr, std::allocator<DifferentialActionDataPtr>, true>::expose(
+      "StdVec_DiffActionData");
 
   bp::class_<DifferentialActionModelNumDiff, bp::bases<DifferentialActionModelAbstract> >(
       "DifferentialActionModelNumDiff",

--- a/bindings/python/crocoddyl/core/optctrl/shooting.cpp
+++ b/bindings/python/crocoddyl/core/optctrl/shooting.cpp
@@ -19,12 +19,8 @@ void exposeShootingProblem() {
   // Register custom converters between std::vector and Python list
   typedef boost::shared_ptr<ActionModelAbstract> ActionModelPtr;
   typedef boost::shared_ptr<ActionDataAbstract> ActionDataPtr;
-  bp::to_python_converter<std::vector<ActionModelPtr, std::allocator<ActionModelPtr> >,
-                          vector_to_list<ActionModelPtr, false> >();
-  bp::to_python_converter<std::vector<ActionDataPtr, std::allocator<ActionDataPtr> >,
-                          vector_to_list<ActionDataPtr, false> >();
-  list_to_vector().from_python<std::vector<ActionModelPtr, std::allocator<ActionModelPtr> > >();
-  list_to_vector().from_python<std::vector<ActionDataPtr, std::allocator<ActionDataPtr> > >();
+  StdVectorPythonVisitor<ActionModelPtr, std::allocator<ActionModelPtr>, true>::expose("StdVec_ActionModel");
+  StdVectorPythonVisitor<ActionDataPtr, std::allocator<ActionDataPtr>, true>::expose("StdVec_ActionData");
 
   bp::register_ptr_to_python<boost::shared_ptr<ShootingProblem> >();
 

--- a/bindings/python/crocoddyl/core/solver-base.cpp
+++ b/bindings/python/crocoddyl/core/solver-base.cpp
@@ -16,9 +16,7 @@ namespace python {
 void exposeSolverAbstract() {
   // Register custom converters between std::vector and Python list
   typedef boost::shared_ptr<CallbackAbstract> CallbackAbstractPtr;
-  bp::to_python_converter<std::vector<CallbackAbstractPtr, std::allocator<CallbackAbstractPtr> >,
-                          vector_to_list<CallbackAbstractPtr, false> >();
-  list_to_vector().from_python<std::vector<CallbackAbstractPtr, std::allocator<CallbackAbstractPtr> > >();
+  StdVectorPythonVisitor<CallbackAbstractPtr, std::allocator<CallbackAbstractPtr>, true>::expose("StdVec_Callback");
 
   bp::class_<SolverAbstract_wrap, boost::noncopyable>(
       "SolverAbstract",

--- a/bindings/python/crocoddyl/crocoddyl.cpp
+++ b/bindings/python/crocoddyl/crocoddyl.cpp
@@ -30,8 +30,8 @@ BOOST_PYTHON_MODULE(libcrocoddyl_pywrap) {
   eigenpy::enableEigenPySpecific<MatrixX3>();
 
   // Register converters between std::vector and Python list
-  StdVectorPythonVisitor<VectorX>::expose("StdVec_VectorX");
-  StdVectorPythonVisitor<MatrixX>::expose("StdVec_MatrixX");
+  StdVectorPythonVisitor<VectorX, std::allocator<VectorX>, true>::expose("StdVec_VectorX");
+  StdVectorPythonVisitor<MatrixX, std::allocator<MatrixX>, true>::expose("StdVec_MatrixX");
 
   exposeCore();
   exposeMultibody();

--- a/bindings/python/crocoddyl/crocoddyl.cpp
+++ b/bindings/python/crocoddyl/crocoddyl.cpp
@@ -30,14 +30,8 @@ BOOST_PYTHON_MODULE(libcrocoddyl_pywrap) {
   eigenpy::enableEigenPySpecific<MatrixX3>();
 
   // Register converters between std::vector and Python list
-  // TODO(cmastalli): figure out how to convert std::vector<double> to Python list
-  // bp::to_python_converter<std::vector<double, std::allocator<double> >, vector_to_list<double, false>, true>();
-  bp::to_python_converter<std::vector<VectorX, std::allocator<VectorX> >, vector_to_list<VectorX, false>, true>();
-  bp::to_python_converter<std::vector<MatrixX, std::allocator<MatrixX> >, vector_to_list<MatrixX, false>, true>();
-  list_to_vector()
-      .from_python<std::vector<double, std::allocator<double> > >()
-      .from_python<std::vector<VectorX, std::allocator<VectorX> > >()
-      .from_python<std::vector<MatrixX, std::allocator<MatrixX> > >();
+  StdVectorPythonVisitor<VectorX>::expose("StdVec_VectorX");
+  StdVectorPythonVisitor<MatrixX>::expose("StdVec_MatrixX");
 
   exposeCore();
   exposeMultibody();

--- a/bindings/python/crocoddyl/multibody/contacts/multiple-contacts.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/multiple-contacts.cpp
@@ -24,14 +24,12 @@ void exposeContactMultiple() {
   // Register custom converters between std::map and Python dict
   typedef boost::shared_ptr<ContactItem> ContactItemPtr;
   typedef boost::shared_ptr<ContactDataAbstract> ContactDataPtr;
-  bp::to_python_converter<std::map<std::string, ContactItemPtr, std::less<std::string>,
-                                   std::allocator<std::pair<const std::string, ContactItemPtr> > >,
-                          map_to_dict<std::string, ContactItemPtr, false> >();
-  bp::to_python_converter<std::map<std::string, ContactDataPtr, std::less<std::string>,
-                                   std::allocator<std::pair<const std::string, ContactDataPtr> > >,
-                          map_to_dict<std::string, ContactDataPtr, false> >();
-  dict_to_map<std::string, ContactItemPtr>().from_python();
-  dict_to_map<std::string, ContactDataPtr>().from_python();
+  StdMapPythonVisitor<std::string, ContactItemPtr, std::less<std::string>,
+                      std::allocator<std::pair<const std::string, ContactItemPtr> >,
+                      true>::expose("StdMap_ContactItem");
+  StdMapPythonVisitor<std::string, ContactDataPtr, std::less<std::string>,
+                      std::allocator<std::pair<const std::string, ContactDataPtr> >,
+                      true>::expose("StdMap_ContactData");
 
   bp::register_ptr_to_python<boost::shared_ptr<ContactItem> >();
 

--- a/bindings/python/crocoddyl/multibody/costs/cost-sum.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/cost-sum.cpp
@@ -26,14 +26,10 @@ void exposeCostSum() {
   // Register custom converters between std::map and Python dict
   typedef boost::shared_ptr<CostItem> CostItemPtr;
   typedef boost::shared_ptr<CostDataAbstract> CostDataPtr;
-  bp::to_python_converter<std::map<std::string, CostItemPtr, std::less<std::string>,
-                                   std::allocator<std::pair<const std::string, CostItemPtr> > >,
-                          map_to_dict<std::string, CostItemPtr, false> >();
-  bp::to_python_converter<std::map<std::string, CostDataPtr, std::less<std::string>,
-                                   std::allocator<std::pair<const std::string, CostDataPtr> > >,
-                          map_to_dict<std::string, CostDataPtr, false> >();
-  dict_to_map<std::string, CostItemPtr>().from_python();
-  dict_to_map<std::string, CostDataPtr>().from_python();
+  StdMapPythonVisitor<std::string, CostItemPtr, std::less<std::string>,
+                      std::allocator<std::pair<const std::string, CostItemPtr> >, true>::expose("StdMap_CostItem");
+  StdMapPythonVisitor<std::string, CostDataPtr, std::less<std::string>,
+                      std::allocator<std::pair<const std::string, CostDataPtr> >, true>::expose("StdMap_CostData");
 
   bp::register_ptr_to_python<boost::shared_ptr<CostItem> >();
 

--- a/bindings/python/crocoddyl/multibody/impulses/multiple-impulses.cpp
+++ b/bindings/python/crocoddyl/multibody/impulses/multiple-impulses.cpp
@@ -24,14 +24,12 @@ void exposeImpulseMultiple() {
   // Register custom converters between std::map and Python dict
   typedef boost::shared_ptr<ImpulseItem> ImpulseItemPtr;
   typedef boost::shared_ptr<ImpulseDataAbstract> ImpulseDataPtr;
-  bp::to_python_converter<std::map<std::string, ImpulseItemPtr, std::less<std::string>,
-                                   std::allocator<std::pair<const std::string, ImpulseItemPtr> > >,
-                          map_to_dict<std::string, ImpulseItemPtr, false> >();
-  bp::to_python_converter<std::map<std::string, ImpulseDataPtr, std::less<std::string>,
-                                   std::allocator<std::pair<const std::string, ImpulseDataPtr> > >,
-                          map_to_dict<std::string, ImpulseDataPtr, false> >();
-  dict_to_map<std::string, ImpulseItemPtr>().from_python();
-  dict_to_map<std::string, ImpulseDataPtr>().from_python();
+  StdMapPythonVisitor<std::string, ImpulseItemPtr, std::less<std::string>,
+                      std::allocator<std::pair<const std::string, ImpulseItemPtr> >,
+                      true>::expose("StdMap_ImpulseItem");
+  StdMapPythonVisitor<std::string, ImpulseDataPtr, std::less<std::string>,
+                      std::allocator<std::pair<const std::string, ImpulseDataPtr> >,
+                      true>::expose("StdMap_ImpulseData");
 
   bp::register_ptr_to_python<boost::shared_ptr<ImpulseItem> >();
 

--- a/bindings/python/crocoddyl/utils/__init__.py
+++ b/bindings/python/crocoddyl/utils/__init__.py
@@ -803,7 +803,7 @@ class DDPDerived(crocoddyl.SolverAbstract):
         self.u_reg = self.x_reg
 
     def allocateData(self):
-        models = self.problem.runningModels + [self.problem.terminalModel]
+        models = self.problem.runningModels.tolist() + [self.problem.terminalModel]
         self.Vxx = [a2m(np.zeros([m.state.ndx, m.state.ndx])) for m in models]
         self.Vx = [a2m(np.zeros([m.state.ndx])) for m in models]
 

--- a/bindings/python/crocoddyl/utils/map-converter.hpp
+++ b/bindings/python/crocoddyl/utils/map-converter.hpp
@@ -1,7 +1,8 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2018-2020, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2018-2020, LAAS-CNRS, University of Edinburgh,
+// Copyright (C) 2020, INRIA
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////

--- a/bindings/python/crocoddyl/utils/map-converter.hpp
+++ b/bindings/python/crocoddyl/utils/map-converter.hpp
@@ -52,18 +52,7 @@ struct dict_to_map {
     namespace python = boost::python;
 
     // Check if it is a list
-    if (!PyList_Check(object)) return 0;
-
-    // Retrieve the underlying list
-    bp::object bp_obj(bp::handle<>(bp::borrowed(object)));
-    python::list bp_list(bp_obj);
-    python::ssize_t list_size = python::len(bp_list);
-
-    // Check if all the elements contained in the current vector is of type T
-    for (python::ssize_t k = 0; k < list_size; ++k) {
-      python::extract<typename Container::value_type> elt(bp_list[k]);
-      if (!elt.check()) return 0;
-    }
+    if (!PyObject_GetIter(object)) return 0;
     return object;
   }
 
@@ -113,8 +102,11 @@ struct dict_to_map {
 
   static boost::python::dict todict(Container& self) {
     namespace python = boost::python;
-    typedef python::iterator<Container> iterator;
-    python::dict dict(iterator()(self));
+    python::dict dict;
+    typename Container::const_iterator it;
+    for (it = self.begin(); it != self.end(); ++it) {
+      dict.setdefault(it->first, it->second);
+    }
     return dict;
   }
 };

--- a/bindings/python/crocoddyl/utils/vector-converter.hpp
+++ b/bindings/python/crocoddyl/utils/vector-converter.hpp
@@ -2,6 +2,7 @@
 // BSD 3-Clause License
 //
 // Copyright (C) 2018-2020, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2020, INRIA
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////

--- a/bindings/python/crocoddyl/utils/vector-converter.hpp
+++ b/bindings/python/crocoddyl/utils/vector-converter.hpp
@@ -13,56 +13,69 @@
 #include <vector>
 #include <boost/python/stl_iterator.hpp>
 #include <boost/python/to_python_converter.hpp>
+#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 
 namespace crocoddyl {
 namespace python {
 
 namespace bp = boost::python;
 
-/// @note Registers converter from a provided type to the python
-///       iterable type to the.
-template <class T, bool NoProxy = true>
-struct vector_to_list {
-  static PyObject* convert(const std::vector<T>& vec) {
-    typedef typename std::vector<T>::const_iterator const_iter;
-    bp::list* l = new boost::python::list();
-    for (const_iter it = vec.begin(); it != vec.end(); ++it) {
-      if (NoProxy) {
-        l->append(boost::ref(*it));
-      } else {
-        l->append(*it);
-      }
-    }
-    return l->ptr();
+/**
+ * @brief Create a pickle interface for the std::vector and aligned vector
+ *
+ * @param[in] VecType Vector Type to pickle
+ *
+ * \sa Pickle
+ */
+template <typename VecType>
+struct PickleVector : boost::python::pickle_suite {
+  static boost::python::tuple getinitargs(const VecType&) { return boost::python::make_tuple(); }
+  static boost::python::tuple getstate(boost::python::object op) {
+    return boost::python::make_tuple(boost::python::list(boost::python::extract<const VecType&>(op)()));
   }
-  static PyTypeObject const* get_pytype() { return &PyList_Type; }
+  static void setstate(boost::python::object op, boost::python::tuple tup) {
+    VecType& o = boost::python::extract<VecType&>(op)();
+    boost::python::stl_input_iterator<typename VecType::value_type> begin(tup[0]), end;
+    o.insert(o.begin(), begin, end);
+  }
 };
 
-/// @brief Type that allows for registration of conversions from
-///        python iterable types.
+/** @brief Type that allows for registration of conversions from python iterable types. */
+template <typename Container>
 struct list_to_vector {
-  /// @note Registers converter from a python iterable type to the
-  ///       provided type.
-  template <typename Container>
-  list_to_vector& from_python() {
-    boost::python::converter::registry::push_back(&list_to_vector::convertible, &list_to_vector::construct<Container>,
+  /** @note Registers converter from a python iterable type to the provided type. */
+  static void register_converter() {
+    boost::python::converter::registry::push_back(&list_to_vector::convertible, &list_to_vector::construct,
                                                   boost::python::type_id<Container>());
-
-    // Support chaining.
-    return *this;
   }
 
-  /// @brief Check if PyObject is iterable.
-  static void* convertible(PyObject* object) { return PyObject_GetIter(object) ? object : NULL; }
+  /** @brief Check if PyObject is iterable. */
+  static void* convertible(PyObject* object) {
+    namespace python = boost::python;
 
-  /// @brief Convert iterable PyObject to C++ container type.
-  ///
-  /// Container Concept requirements:
-  ///
-  ///   * Container::value_type is CopyConstructable.
-  ///   * Container can be constructed and populated with two iterators.
-  ///     I.e. Container(begin, end)
-  template <typename Container>
+    // Check if it is a list
+    if (!PyList_Check(object)) return 0;
+
+    // Retrieve the underlying list
+    bp::object bp_obj(bp::handle<>(bp::borrowed(object)));
+    python::list bp_list(bp_obj);
+    python::ssize_t list_size = python::len(bp_list);
+
+    // Check if all the elements contained in the current vector is of type T
+    for (python::ssize_t k = 0; k < list_size; ++k) {
+      python::extract<typename Container::value_type> elt(bp_list[k]);
+      if (!elt.check()) return 0;
+    }
+    return object;
+  }
+
+  /** @brief Convert iterable PyObject to C++ container type.
+   *
+   * Container Concept requirements:
+   *    * Container::value_type is CopyConstructable.
+   *    * Container can be constructed and populated with two iterators.
+   * i.e. Container(begin, end)
+   */
   static void construct(PyObject* object, boost::python::converter::rvalue_from_python_stage1_data* data) {
     namespace python = boost::python;
     // Object is a borrowed reference, so create a handle indicting it is
@@ -83,6 +96,39 @@ struct list_to_vector {
     new (storage) Container(iterator(python::object(handle)),  // begin
                             iterator());                       // end
     data->convertible = storage;
+  }
+
+  static boost::python::list tolist(Container& self) {
+    namespace python = boost::python;
+    typedef python::iterator<Container> iterator;
+    python::list list(iterator()(self));
+    return list;
+  }
+};
+
+/**
+ * @brief Expose an std::vector from a type given as template argument.
+ *
+ * @param[in] T          Type to expose as std::vector<T>.
+ * @param[in] Allocator  Type for the Allocator in std::vector<T,Allocator>.
+ * @param[in] NoProxy    When set to false, the elements will be copied when returned to Python.
+ */
+template <class T, class Allocator = std::allocator<T>, bool NoProxy = false>
+struct StdVectorPythonVisitor
+    : public boost::python::vector_indexing_suite<typename std::vector<T, Allocator>, NoProxy>,
+      public list_to_vector<std::vector<T, Allocator> > {
+  typedef std::vector<T, Allocator> Container;
+  typedef list_to_vector<Container> FromPythonListConverter;
+
+  static void expose(const std::string& class_name, const std::string& doc_string = "") {
+    namespace bp = boost::python;
+
+    bp::class_<Container>(class_name.c_str(), doc_string.c_str())
+        .def(StdVectorPythonVisitor())
+        .def("tolist", &FromPythonListConverter::tolist, bp::arg("self"), "Returns the std::vector as a Python list.")
+        .def_pickle(PickleVector<Container>());
+    // Register conversion
+    FromPythonListConverter::register_converter();
   }
 };
 

--- a/bindings/python/crocoddyl/utils/vector-converter.hpp
+++ b/bindings/python/crocoddyl/utils/vector-converter.hpp
@@ -21,21 +21,20 @@ namespace python {
 namespace bp = boost::python;
 
 /**
- * @brief Create a pickle interface for the std::vector and aligned vector
+ * @brief Create a pickle interface for the std::vector
  *
- * @param[in] VecType Vector Type to pickle
- *
+ * @param[in] Container  Vector type to be pickled
  * \sa Pickle
  */
-template <typename VecType>
+template <typename Container>
 struct PickleVector : boost::python::pickle_suite {
-  static boost::python::tuple getinitargs(const VecType&) { return boost::python::make_tuple(); }
+  static boost::python::tuple getinitargs(const Container&) { return boost::python::make_tuple(); }
   static boost::python::tuple getstate(boost::python::object op) {
-    return boost::python::make_tuple(boost::python::list(boost::python::extract<const VecType&>(op)()));
+    return boost::python::make_tuple(boost::python::list(boost::python::extract<const Container&>(op)()));
   }
   static void setstate(boost::python::object op, boost::python::tuple tup) {
-    VecType& o = boost::python::extract<VecType&>(op)();
-    boost::python::stl_input_iterator<typename VecType::value_type> begin(tup[0]), end;
+    Container& o = boost::python::extract<Container&>(op)();
+    boost::python::stl_input_iterator<typename Container::value_type> begin(tup[0]), end;
     o.insert(o.begin(), begin, end);
   }
 };


### PR DESCRIPTION
This PR fixes the memory leak produced in the Python interface reported in #795.
I have test myself that there is no more memory leaks in vector and map converters.
To validate it, I used the following code:
```python
import numpy as np
import crocoddyl
import pinocchio
import example_robot_data
import time


def test1():
  model = crocoddyl.ActionModelUnicycle()
  model.r = [10,1]
  u0 = np.array([0., 0.])
  x0 = np.array([-1., -1., 1.])
  data = model.createData()
#  problem = crocoddyl.ShootingProblem(x0, [model], model, [data], data)
  duration = 0.
  while duration < 10.:
    t0 = time.time()
    problem = crocoddyl.ShootingProblem(x0, [model] * 10, model, [data] * 10, data)
    ddp = crocoddyl.SolverDDP(problem)
    ddp.solve([x0] * 11, [u0] * 10, 1)
    ddp.xs
    tf = time.time()
    duration += tf - t0

def test3():
  talos_arm = example_robot_data.loadTalosArm()
  robot_model = talos_arm.model

  state = crocoddyl.StateMultibody(robot_model)
  runningCostModel = crocoddyl.CostModelSum(state)
  terminalCostModel = crocoddyl.CostModelSum(state)
  Mref = crocoddyl.FramePlacement(robot_model.getFrameId("gripper_left_joint"),
                                  pinocchio.SE3(np.eye(3), np.array([.0, .0, .4])))
  goalTrackingCost = crocoddyl.CostModelFramePlacement(state, Mref)
  xRegCost = crocoddyl.CostModelState(state)
  uRegCost = crocoddyl.CostModelControl(state)

  runningCostModel.addCost("gripperPose", goalTrackingCost, 1)
  runningCostModel.addCost("xReg", xRegCost, 1e-4)
  runningCostModel.addCost("uReg", uRegCost, 1e-4)
  terminalCostModel.addCost("gripperPose", goalTrackingCost, 1)

  actuationModel = crocoddyl.ActuationModelFull(state)
  dt = 1e-3
  runningModel = crocoddyl.IntegratedActionModelEuler(
    crocoddyl.DifferentialActionModelFreeFwdDynamics(state, actuationModel, runningCostModel), dt)
  runningModel.differential.armature = np.array([0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.])
  terminalModel = crocoddyl.IntegratedActionModelEuler(
    crocoddyl.DifferentialActionModelFreeFwdDynamics(state, actuationModel, terminalCostModel), 0.)
  terminalModel.differential.armature = np.array([0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.])

  T = 250
  q0 = np.array([0.173046, 1., -0.52366, 0., 0., 0.1, -0.005])
  x0 = np.concatenate([q0, pinocchio.utils.zero(robot_model.nv)])

  duration = 0.
  while duration < 10.:
    t0 = time.time()
    problem = crocoddyl.ShootingProblem(x0, [runningModel] * T, terminalModel)
    problem.runningModels[0].differential.costs.costs
    tf = time.time()
    duration += tf - t0

if __name__ == '__main__':
  test1() # test2
```

and I run it using `mprof` as follows:
```
mprof run --include-children python test_memory_leak.py
mprof plot --output memory-profile.png
```

@gfadini I would be happy if you can check this yourself as well.