### PR TITLE
Improved get_reference + deprecated old getters in cost functions

### DIFF
--- a/bindings/python/crocoddyl/multibody/costs/centroidal-momentum.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/centroidal-momentum.cpp
@@ -75,10 +75,11 @@ void exposeCostCentroidalMomentum() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
-      .add_property(
-          "reference",
-          bp::make_function(&CostModelCentroidalMomentum::get_href, bp::return_value_policy<bp::return_by_value>()),
-          &CostModelCentroidalMomentum::set_reference<MathBaseTpl<double>::Vector6s>, "reference centroidal momentum")
+      .add_property("reference",
+                    bp::make_function(&CostModelCentroidalMomentum::get_reference<MathBaseTpl<double>::Vector6s>,
+                                      bp::return_value_policy<bp::return_by_value>()),
+                    &CostModelCentroidalMomentum::set_reference<MathBaseTpl<double>::Vector6s>,
+                    "reference centroidal momentum")
       .add_property(
           "href",
           bp::make_function(&CostModelCentroidalMomentum::get_href, bp::return_value_policy<bp::return_by_value>()),

--- a/bindings/python/crocoddyl/multibody/costs/centroidal-momentum.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/centroidal-momentum.cpp
@@ -80,10 +80,11 @@ void exposeCostCentroidalMomentum() {
                                       bp::return_value_policy<bp::return_by_value>()),
                     &CostModelCentroidalMomentum::set_reference<MathBaseTpl<double>::Vector6s>,
                     "reference centroidal momentum")
-      .add_property(
-          "href",
-          bp::make_function(&CostModelCentroidalMomentum::get_href, bp::return_value_policy<bp::return_by_value>()),
-          &CostModelCentroidalMomentum::set_href, "reference centroidal momentum");
+      .add_property("href",
+                    bp::make_function(&CostModelCentroidalMomentum::get_reference<MathBaseTpl<double>::Vector6s>,
+                                      bp::return_value_policy<bp::return_by_value>()),
+                    &CostModelCentroidalMomentum::set_reference<MathBaseTpl<double>::Vector6s>,
+                    "reference centroidal momentum");
 
   bp::class_<CostDataCentroidalMomentum, bp::bases<CostDataAbstract> >(
       "CostDataCentroidalMomentum", "Data for centroidal momentum cost.\n\n",

--- a/bindings/python/crocoddyl/multibody/costs/centroidal-momentum.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/centroidal-momentum.cpp
@@ -75,9 +75,7 @@ void exposeCostCentroidalMomentum() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
-      .add_property("reference",
-                    bp::make_function(&CostModelCentroidalMomentum::get_reference<MathBaseTpl<double>::Vector6s>,
-                                      bp::return_value_policy<bp::return_by_value>()),
+      .add_property("reference", &CostModelCentroidalMomentum::get_reference<MathBaseTpl<double>::Vector6s>,
                     &CostModelCentroidalMomentum::set_reference<MathBaseTpl<double>::Vector6s>,
                     "reference centroidal momentum")
       .add_property("href",

--- a/bindings/python/crocoddyl/multibody/costs/centroidal-momentum.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/centroidal-momentum.cpp
@@ -9,6 +9,7 @@
 #include "python/crocoddyl/multibody/multibody.hpp"
 #include "python/crocoddyl/multibody/cost-base.hpp"
 #include "crocoddyl/multibody/costs/centroidal-momentum.hpp"
+#include "python/crocoddyl/utils/deprecate.hpp"
 
 namespace crocoddyl {
 namespace python {
@@ -80,8 +81,9 @@ void exposeCostCentroidalMomentum() {
                     "reference centroidal momentum")
       .add_property("href",
                     bp::make_function(&CostModelCentroidalMomentum::get_reference<MathBaseTpl<double>::Vector6s>,
-                                      bp::return_value_policy<bp::return_by_value>()),
-                    &CostModelCentroidalMomentum::set_reference<MathBaseTpl<double>::Vector6s>,
+                                      deprecated<>("Deprecated. Use reference.")),
+                    bp::make_function(&CostModelCentroidalMomentum::set_reference<MathBaseTpl<double>::Vector6s>,
+                                      deprecated<>("Deprecated. Use reference.")),
                     "reference centroidal momentum");
 
   bp::class_<CostDataCentroidalMomentum, bp::bases<CostDataAbstract> >(

--- a/bindings/python/crocoddyl/multibody/costs/com-position.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/com-position.cpp
@@ -74,7 +74,7 @@ void exposeCostCoMPosition() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
-      .add_property("reference", bp::make_function(&CostModelCoMPosition::get_reference<Eigen::Vector3d>),
+      .add_property("reference", &CostModelCoMPosition::get_reference<Eigen::Vector3d>,
                     &CostModelCoMPosition::set_reference<Eigen::Vector3d>, "reference CoM position")
       .add_property("cref", bp::make_function(&CostModelCoMPosition::get_reference<Eigen::Vector3d>),
                     &CostModelCoMPosition::set_reference<Eigen::Vector3d>, "reference CoM position");

--- a/bindings/python/crocoddyl/multibody/costs/com-position.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/com-position.cpp
@@ -76,8 +76,8 @@ void exposeCostCoMPosition() {
            ":return cost data.")
       .add_property("reference", bp::make_function(&CostModelCoMPosition::get_reference<Eigen::Vector3d>),
                     &CostModelCoMPosition::set_reference<Eigen::Vector3d>, "reference CoM position")
-      .add_property("cref", bp::make_function(&CostModelCoMPosition::get_cref, bp::return_internal_reference<>()),
-                    &CostModelCoMPosition::set_cref, "reference CoM position");
+      .add_property("cref", bp::make_function(&CostModelCoMPosition::get_reference<Eigen::Vector3d>),
+                    &CostModelCoMPosition::set_reference<Eigen::Vector3d>, "reference CoM position");
 }
 
 }  // namespace python

--- a/bindings/python/crocoddyl/multibody/costs/com-position.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/com-position.cpp
@@ -74,7 +74,7 @@ void exposeCostCoMPosition() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
-      .add_property("reference", bp::make_function(&CostModelCoMPosition::get_cref, bp::return_internal_reference<>()),
+      .add_property("reference", bp::make_function(&CostModelCoMPosition::get_reference<Eigen::Vector3d>),
                     &CostModelCoMPosition::set_reference<Eigen::Vector3d>, "reference CoM position")
       .add_property("cref", bp::make_function(&CostModelCoMPosition::get_cref, bp::return_internal_reference<>()),
                     &CostModelCoMPosition::set_cref, "reference CoM position");

--- a/bindings/python/crocoddyl/multibody/costs/com-position.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/com-position.cpp
@@ -9,6 +9,7 @@
 #include "python/crocoddyl/multibody/multibody.hpp"
 #include "python/crocoddyl/multibody/cost-base.hpp"
 #include "crocoddyl/multibody/costs/com-position.hpp"
+#include "python/crocoddyl/utils/deprecate.hpp"
 
 namespace crocoddyl {
 namespace python {
@@ -76,8 +77,12 @@ void exposeCostCoMPosition() {
            ":return cost data.")
       .add_property("reference", &CostModelCoMPosition::get_reference<Eigen::Vector3d>,
                     &CostModelCoMPosition::set_reference<Eigen::Vector3d>, "reference CoM position")
-      .add_property("cref", bp::make_function(&CostModelCoMPosition::get_reference<Eigen::Vector3d>),
-                    &CostModelCoMPosition::set_reference<Eigen::Vector3d>, "reference CoM position");
+      .add_property("cref",
+                    bp::make_function(&CostModelCoMPosition::get_reference<Eigen::Vector3d>,
+                                      deprecated<>("Deprecated. Use reference.")),
+                    bp::make_function(&CostModelCoMPosition::set_reference<Eigen::Vector3d>,
+                                      deprecated<>("Deprecated. Use reference.")),
+                    "reference CoM position");
 }
 
 }  // namespace python

--- a/bindings/python/crocoddyl/multibody/costs/contact-cop-position.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/contact-cop-position.cpp
@@ -63,8 +63,7 @@ void exposeCostContactCoPPosition() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
-      .add_property("reference",
-                    bp::make_function(&CostModelContactCoPPosition::get_copSupport, bp::return_internal_reference<>()),
+      .add_property("reference", &CostModelContactCoPPosition::get_reference<FrameCoPSupport>,
                     &CostModelContactCoPPosition::set_reference<FrameCoPSupport>, "reference foot geometry");
 
   bp::register_ptr_to_python<boost::shared_ptr<CostDataContactCoPPosition> >();

--- a/bindings/python/crocoddyl/multibody/costs/contact-force.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/contact-force.cpp
@@ -87,8 +87,7 @@ void exposeCostContactForce() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
-      .add_property("reference",
-                    bp::make_function(&CostModelContactForce::get_fref, bp::return_internal_reference<>()),
+      .add_property("reference", bp::make_function(&CostModelContactForce::get_reference<FrameForce>),
                     &CostModelContactForce::set_reference<FrameForce>,
                     "reference spatial contact force in the contact coordinates")
       .add_property("fref", bp::make_function(&CostModelContactForce::get_fref, bp::return_internal_reference<>()),

--- a/bindings/python/crocoddyl/multibody/costs/contact-force.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/contact-force.cpp
@@ -87,7 +87,7 @@ void exposeCostContactForce() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
-      .add_property("reference", bp::make_function(&CostModelContactForce::get_reference<FrameForce>),
+      .add_property("reference", &CostModelContactForce::get_reference<FrameForce>,
                     &CostModelContactForce::set_reference<FrameForce>,
                     "reference spatial contact force in the contact coordinates")
       .add_property("fref", bp::make_function(&CostModelContactForce::get_reference<FrameForce>),

--- a/bindings/python/crocoddyl/multibody/costs/contact-force.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/contact-force.cpp
@@ -9,6 +9,7 @@
 #include "python/crocoddyl/multibody/multibody.hpp"
 #include "python/crocoddyl/multibody/cost-base.hpp"
 #include "crocoddyl/multibody/costs/contact-force.hpp"
+#include "python/crocoddyl/utils/deprecate.hpp"
 
 namespace crocoddyl {
 namespace python {
@@ -90,8 +91,11 @@ void exposeCostContactForce() {
       .add_property("reference", &CostModelContactForce::get_reference<FrameForce>,
                     &CostModelContactForce::set_reference<FrameForce>,
                     "reference spatial contact force in the contact coordinates")
-      .add_property("fref", bp::make_function(&CostModelContactForce::get_reference<FrameForce>),
-                    &CostModelContactForce::set_reference<FrameForce>,
+      .add_property("fref",
+                    bp::make_function(&CostModelContactForce::get_reference<FrameForce>,
+                                      deprecated<>("Deprecated. Use reference.")),
+                    bp::make_function(&CostModelContactForce::set_reference<FrameForce>,
+                                      deprecated<>("Deprecated. Use reference.")),
                     "reference spatial contact force in the contact coordinates");
 
   bp::register_ptr_to_python<boost::shared_ptr<CostDataContactForce> >();

--- a/bindings/python/crocoddyl/multibody/costs/contact-force.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/contact-force.cpp
@@ -90,8 +90,9 @@ void exposeCostContactForce() {
       .add_property("reference", bp::make_function(&CostModelContactForce::get_reference<FrameForce>),
                     &CostModelContactForce::set_reference<FrameForce>,
                     "reference spatial contact force in the contact coordinates")
-      .add_property("fref", bp::make_function(&CostModelContactForce::get_fref, bp::return_internal_reference<>()),
-                    &CostModelContactForce::set_fref, "reference spatial contact force in the contact coordinates");
+      .add_property("fref", bp::make_function(&CostModelContactForce::get_reference<FrameForce>),
+                    &CostModelContactForce::set_reference<FrameForce>,
+                    "reference spatial contact force in the contact coordinates");
 
   bp::register_ptr_to_python<boost::shared_ptr<CostDataContactForce> >();
 

--- a/bindings/python/crocoddyl/multibody/costs/contact-friction-cone.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/contact-friction-cone.cpp
@@ -74,7 +74,7 @@ void exposeCostContactFrictionCone() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
-      .add_property("reference", bp::make_function(&CostModelContactFrictionCone::get_reference<FrameFrictionCone>),
+      .add_property("reference", &CostModelContactFrictionCone::get_reference<FrameFrictionCone>,
                     &CostModelContactFrictionCone::set_reference<FrameFrictionCone>, "reference frame friction cone");
 
   bp::register_ptr_to_python<boost::shared_ptr<CostDataContactFrictionCone> >();

--- a/bindings/python/crocoddyl/multibody/costs/contact-friction-cone.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/contact-friction-cone.cpp
@@ -74,8 +74,7 @@ void exposeCostContactFrictionCone() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
-      .add_property("reference",
-                    bp::make_function(&CostModelContactFrictionCone::get_fref, bp::return_internal_reference<>()),
+      .add_property("reference", bp::make_function(&CostModelContactFrictionCone::get_reference<FrameFrictionCone>),
                     &CostModelContactFrictionCone::set_reference<FrameFrictionCone>, "reference frame friction cone");
 
   bp::register_ptr_to_python<boost::shared_ptr<CostDataContactFrictionCone> >();

--- a/bindings/python/crocoddyl/multibody/costs/contact-impulse.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/contact-impulse.cpp
@@ -68,7 +68,7 @@ void exposeCostContactImpulse() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
-      .add_property("reference", bp::make_function(&CostModelContactImpulse::get_reference<FrameForce>),
+      .add_property("reference", &CostModelContactImpulse::get_reference<FrameForce>,
                     &CostModelContactImpulse::set_reference<FrameForce>,
                     "reference spatial contact impulse in the contact coordinates")
       .add_property("fref", bp::make_function(&CostModelContactImpulse::get_reference<FrameForce>),

--- a/bindings/python/crocoddyl/multibody/costs/contact-impulse.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/contact-impulse.cpp
@@ -71,8 +71,8 @@ void exposeCostContactImpulse() {
       .add_property("reference", bp::make_function(&CostModelContactImpulse::get_reference<FrameForce>),
                     &CostModelContactImpulse::set_reference<FrameForce>,
                     "reference spatial contact impulse in the contact coordinates")
-      .add_property("fref", bp::make_function(&CostModelContactImpulse::get_fref, bp::return_internal_reference<>()),
-                    &CostModelContactImpulse::set_fref,
+      .add_property("fref", bp::make_function(&CostModelContactImpulse::get_reference<FrameForce>),
+                    &CostModelContactImpulse::set_reference<FrameForce>,
                     "reference spatial contact impulse in the contact coordinates");
 
   bp::register_ptr_to_python<boost::shared_ptr<CostDataContactImpulse> >();

--- a/bindings/python/crocoddyl/multibody/costs/contact-impulse.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/contact-impulse.cpp
@@ -68,8 +68,7 @@ void exposeCostContactImpulse() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
-      .add_property("reference",
-                    bp::make_function(&CostModelContactImpulse::get_fref, bp::return_internal_reference<>()),
+      .add_property("reference", bp::make_function(&CostModelContactImpulse::get_reference<FrameForce>),
                     &CostModelContactImpulse::set_reference<FrameForce>,
                     "reference spatial contact impulse in the contact coordinates")
       .add_property("fref", bp::make_function(&CostModelContactImpulse::get_fref, bp::return_internal_reference<>()),

--- a/bindings/python/crocoddyl/multibody/costs/contact-impulse.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/contact-impulse.cpp
@@ -9,6 +9,7 @@
 #include "python/crocoddyl/multibody/multibody.hpp"
 #include "python/crocoddyl/multibody/cost-base.hpp"
 #include "crocoddyl/multibody/costs/contact-impulse.hpp"
+#include "python/crocoddyl/utils/deprecate.hpp"
 
 namespace crocoddyl {
 namespace python {
@@ -71,8 +72,11 @@ void exposeCostContactImpulse() {
       .add_property("reference", &CostModelContactImpulse::get_reference<FrameForce>,
                     &CostModelContactImpulse::set_reference<FrameForce>,
                     "reference spatial contact impulse in the contact coordinates")
-      .add_property("fref", bp::make_function(&CostModelContactImpulse::get_reference<FrameForce>),
-                    &CostModelContactImpulse::set_reference<FrameForce>,
+      .add_property("fref",
+                    bp::make_function(&CostModelContactImpulse::get_reference<FrameForce>,
+                                      deprecated<>("Deprecated. Use reference.")),
+                    bp::make_function(&CostModelContactImpulse::set_reference<FrameForce>,
+                                      deprecated<>("Deprecated. Use reference.")),
                     "reference spatial contact impulse in the contact coordinates");
 
   bp::register_ptr_to_python<boost::shared_ptr<CostDataContactImpulse> >();

--- a/bindings/python/crocoddyl/multibody/costs/control.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/control.cpp
@@ -9,6 +9,7 @@
 #include "python/crocoddyl/multibody/multibody.hpp"
 #include "python/crocoddyl/multibody/cost-base.hpp"
 #include "crocoddyl/multibody/costs/control.hpp"
+#include "python/crocoddyl/utils/deprecate.hpp"
 
 namespace crocoddyl {
 namespace python {
@@ -78,8 +79,12 @@ void exposeCostControl() {
           "calcDiff", &CostModelAbstract::calcDiff, bp::args("self", "data", "x"))
       .add_property("reference", &CostModelControl::get_reference<Eigen::VectorXd>,
                     &CostModelControl::set_reference<Eigen::VectorXd>, "reference control vector")
-      .add_property("uref", bp::make_function(&CostModelControl::get_reference<Eigen::VectorXd>),
-                    &CostModelControl::set_reference<Eigen::VectorXd>, "reference control vector");
+      .add_property("uref",
+                    bp::make_function(&CostModelControl::get_reference<Eigen::VectorXd>,
+                                      deprecated<>("Deprecated. Use reference.")),
+                    bp::make_function(&CostModelControl::set_reference<Eigen::VectorXd>,
+                                      deprecated<>("Deprecated. Use reference.")),
+                    "reference control vector");
 }
 
 }  // namespace python

--- a/bindings/python/crocoddyl/multibody/costs/control.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/control.cpp
@@ -76,7 +76,7 @@ void exposeCostControl() {
       .def<void (CostModelControl::*)(const boost::shared_ptr<CostDataAbstract>&,
                                       const Eigen::Ref<const Eigen::VectorXd>&)>(
           "calcDiff", &CostModelAbstract::calcDiff, bp::args("self", "data", "x"))
-      .add_property("reference", bp::make_function(&CostModelControl::get_reference<Eigen::VectorXd>),
+      .add_property("reference", &CostModelControl::get_reference<Eigen::VectorXd>,
                     &CostModelControl::set_reference<Eigen::VectorXd>, "reference control vector")
       .add_property("uref", bp::make_function(&CostModelControl::get_reference<Eigen::VectorXd>),
                     &CostModelControl::set_reference<Eigen::VectorXd>, "reference control vector");

--- a/bindings/python/crocoddyl/multibody/costs/control.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/control.cpp
@@ -76,7 +76,7 @@ void exposeCostControl() {
       .def<void (CostModelControl::*)(const boost::shared_ptr<CostDataAbstract>&,
                                       const Eigen::Ref<const Eigen::VectorXd>&)>(
           "calcDiff", &CostModelAbstract::calcDiff, bp::args("self", "data", "x"))
-      .add_property("reference", bp::make_function(&CostModelControl::get_uref, bp::return_internal_reference<>()),
+      .add_property("reference", bp::make_function(&CostModelControl::get_reference<Eigen::VectorXd>),
                     &CostModelControl::set_reference<Eigen::VectorXd>, "reference control vector")
       .add_property("uref", bp::make_function(&CostModelControl::get_uref, bp::return_internal_reference<>()),
                     &CostModelControl::set_uref, "reference control");

--- a/bindings/python/crocoddyl/multibody/costs/control.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/control.cpp
@@ -78,8 +78,8 @@ void exposeCostControl() {
           "calcDiff", &CostModelAbstract::calcDiff, bp::args("self", "data", "x"))
       .add_property("reference", bp::make_function(&CostModelControl::get_reference<Eigen::VectorXd>),
                     &CostModelControl::set_reference<Eigen::VectorXd>, "reference control vector")
-      .add_property("uref", bp::make_function(&CostModelControl::get_uref, bp::return_internal_reference<>()),
-                    &CostModelControl::set_uref, "reference control");
+      .add_property("uref", bp::make_function(&CostModelControl::get_reference<Eigen::VectorXd>),
+                    &CostModelControl::set_reference<Eigen::VectorXd>, "reference control vector");
 }
 
 }  // namespace python

--- a/bindings/python/crocoddyl/multibody/costs/frame-placement.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-placement.cpp
@@ -74,8 +74,7 @@ void exposeCostFramePlacement() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
-      .add_property("reference",
-                    bp::make_function(&CostModelFramePlacement::get_Mref, bp::return_internal_reference<>()),
+      .add_property("reference", bp::make_function(&CostModelFramePlacement::get_reference<FramePlacement>),
                     &CostModelFramePlacement::set_reference<FramePlacement>, "reference frame placement")
       .add_property("Mref", bp::make_function(&CostModelFramePlacement::get_Mref, bp::return_internal_reference<>()),
                     &CostModelFramePlacement::set_Mref, "reference frame placement");

--- a/bindings/python/crocoddyl/multibody/costs/frame-placement.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-placement.cpp
@@ -76,8 +76,8 @@ void exposeCostFramePlacement() {
            ":return cost data.")
       .add_property("reference", bp::make_function(&CostModelFramePlacement::get_reference<FramePlacement>),
                     &CostModelFramePlacement::set_reference<FramePlacement>, "reference frame placement")
-      .add_property("Mref", bp::make_function(&CostModelFramePlacement::get_Mref, bp::return_internal_reference<>()),
-                    &CostModelFramePlacement::set_Mref, "reference frame placement");
+      .add_property("Mref", bp::make_function(&CostModelFramePlacement::get_reference<FramePlacement>),
+                    &CostModelFramePlacement::set_reference<FramePlacement>, "reference frame placement");
 
   bp::register_ptr_to_python<boost::shared_ptr<CostDataFramePlacement> >();
 

--- a/bindings/python/crocoddyl/multibody/costs/frame-placement.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-placement.cpp
@@ -74,7 +74,7 @@ void exposeCostFramePlacement() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
-      .add_property("reference", bp::make_function(&CostModelFramePlacement::get_reference<FramePlacement>),
+      .add_property("reference", &CostModelFramePlacement::get_reference<FramePlacement>,
                     &CostModelFramePlacement::set_reference<FramePlacement>, "reference frame placement")
       .add_property("Mref", bp::make_function(&CostModelFramePlacement::get_reference<FramePlacement>),
                     &CostModelFramePlacement::set_reference<FramePlacement>, "reference frame placement");

--- a/bindings/python/crocoddyl/multibody/costs/frame-placement.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-placement.cpp
@@ -9,6 +9,7 @@
 #include "python/crocoddyl/multibody/multibody.hpp"
 #include "python/crocoddyl/multibody/cost-base.hpp"
 #include "crocoddyl/multibody/costs/frame-placement.hpp"
+#include "python/crocoddyl/utils/deprecate.hpp"
 
 namespace crocoddyl {
 namespace python {
@@ -76,8 +77,12 @@ void exposeCostFramePlacement() {
            ":return cost data.")
       .add_property("reference", &CostModelFramePlacement::get_reference<FramePlacement>,
                     &CostModelFramePlacement::set_reference<FramePlacement>, "reference frame placement")
-      .add_property("Mref", bp::make_function(&CostModelFramePlacement::get_reference<FramePlacement>),
-                    &CostModelFramePlacement::set_reference<FramePlacement>, "reference frame placement");
+      .add_property("Mref",
+                    bp::make_function(&CostModelFramePlacement::get_reference<FramePlacement>,
+                                      deprecated<>("Deprecated. Use reference.")),
+                    bp::make_function(&CostModelFramePlacement::set_reference<FramePlacement>,
+                                      deprecated<>("Deprecated. Use reference.")),
+                    "reference frame placement");
 
   bp::register_ptr_to_python<boost::shared_ptr<CostDataFramePlacement> >();
 

--- a/bindings/python/crocoddyl/multibody/costs/frame-rotation.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-rotation.cpp
@@ -76,8 +76,8 @@ void exposeCostFrameRotation() {
            ":return cost data.")
       .add_property("reference", bp::make_function(&CostModelFrameRotation::get_reference<FrameRotation>),
                     &CostModelFrameRotation::set_reference<FrameRotation>, "reference frame rotation")
-      .add_property("Rref", bp::make_function(&CostModelFrameRotation::get_Rref, bp::return_internal_reference<>()),
-                    &CostModelFrameRotation::set_Rref, "reference frame rotation");
+      .add_property("Rref", bp::make_function(&CostModelFrameRotation::get_reference<FrameRotation>),
+                    &CostModelFrameRotation::set_reference<FrameRotation>, "reference frame rotation");
 
   bp::register_ptr_to_python<boost::shared_ptr<CostDataFrameRotation> >();
 

--- a/bindings/python/crocoddyl/multibody/costs/frame-rotation.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-rotation.cpp
@@ -9,6 +9,7 @@
 #include "python/crocoddyl/multibody/multibody.hpp"
 #include "python/crocoddyl/multibody/cost-base.hpp"
 #include "crocoddyl/multibody/costs/frame-rotation.hpp"
+#include "python/crocoddyl/utils/deprecate.hpp"
 
 namespace crocoddyl {
 namespace python {
@@ -76,8 +77,12 @@ void exposeCostFrameRotation() {
            ":return cost data.")
       .add_property("reference", &CostModelFrameRotation::get_reference<FrameRotation>,
                     &CostModelFrameRotation::set_reference<FrameRotation>, "reference frame rotation")
-      .add_property("Rref", bp::make_function(&CostModelFrameRotation::get_reference<FrameRotation>),
-                    &CostModelFrameRotation::set_reference<FrameRotation>, "reference frame rotation");
+      .add_property("Rref",
+                    bp::make_function(&CostModelFrameRotation::get_reference<FrameRotation>,
+                                      deprecated<>("Deprecated. Use reference.")),
+                    bp::make_function(&CostModelFrameRotation::set_reference<FrameRotation>,
+                                      deprecated<>("Deprecated. Use reference.")),
+                    "reference frame rotation");
 
   bp::register_ptr_to_python<boost::shared_ptr<CostDataFrameRotation> >();
 

--- a/bindings/python/crocoddyl/multibody/costs/frame-rotation.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-rotation.cpp
@@ -74,7 +74,7 @@ void exposeCostFrameRotation() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
-      .add_property("reference", bp::make_function(&CostModelFrameRotation::get_reference<FrameRotation>),
+      .add_property("reference", &CostModelFrameRotation::get_reference<FrameRotation>,
                     &CostModelFrameRotation::set_reference<FrameRotation>, "reference frame rotation")
       .add_property("Rref", bp::make_function(&CostModelFrameRotation::get_reference<FrameRotation>),
                     &CostModelFrameRotation::set_reference<FrameRotation>, "reference frame rotation");

--- a/bindings/python/crocoddyl/multibody/costs/frame-rotation.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-rotation.cpp
@@ -74,8 +74,7 @@ void exposeCostFrameRotation() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
-      .add_property("reference",
-                    bp::make_function(&CostModelFrameRotation::get_Rref, bp::return_internal_reference<>()),
+      .add_property("reference", bp::make_function(&CostModelFrameRotation::get_reference<FrameRotation>),
                     &CostModelFrameRotation::set_reference<FrameRotation>, "reference frame rotation")
       .add_property("Rref", bp::make_function(&CostModelFrameRotation::get_Rref, bp::return_internal_reference<>()),
                     &CostModelFrameRotation::set_Rref, "reference frame rotation");

--- a/bindings/python/crocoddyl/multibody/costs/frame-translation.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-translation.cpp
@@ -74,8 +74,7 @@ void exposeCostFrameTranslation() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
-      .add_property("reference",
-                    bp::make_function(&CostModelFrameTranslation::get_xref, bp::return_internal_reference<>()),
+      .add_property("reference", bp::make_function(&CostModelFrameTranslation::get_reference<FrameTranslation>),
                     &CostModelFrameTranslation::set_reference<FrameTranslation>, "reference frame translation")
       .add_property("xref", bp::make_function(&CostModelFrameTranslation::get_xref, bp::return_internal_reference<>()),
                     &CostModelFrameTranslation::set_xref, "reference frame translation");

--- a/bindings/python/crocoddyl/multibody/costs/frame-translation.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-translation.cpp
@@ -74,7 +74,7 @@ void exposeCostFrameTranslation() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
-      .add_property("reference", bp::make_function(&CostModelFrameTranslation::get_reference<FrameTranslation>),
+      .add_property("reference", &CostModelFrameTranslation::get_reference<FrameTranslation>,
                     &CostModelFrameTranslation::set_reference<FrameTranslation>, "reference frame translation")
       .add_property("xref", bp::make_function(&CostModelFrameTranslation::get_reference<FrameTranslation>),
                     &CostModelFrameTranslation::set_reference<FrameTranslation>, "reference frame translation");

--- a/bindings/python/crocoddyl/multibody/costs/frame-translation.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-translation.cpp
@@ -9,6 +9,7 @@
 #include "python/crocoddyl/multibody/multibody.hpp"
 #include "python/crocoddyl/multibody/cost-base.hpp"
 #include "crocoddyl/multibody/costs/frame-translation.hpp"
+#include "python/crocoddyl/utils/deprecate.hpp"
 
 namespace crocoddyl {
 namespace python {
@@ -76,8 +77,12 @@ void exposeCostFrameTranslation() {
            ":return cost data.")
       .add_property("reference", &CostModelFrameTranslation::get_reference<FrameTranslation>,
                     &CostModelFrameTranslation::set_reference<FrameTranslation>, "reference frame translation")
-      .add_property("xref", bp::make_function(&CostModelFrameTranslation::get_reference<FrameTranslation>),
-                    &CostModelFrameTranslation::set_reference<FrameTranslation>, "reference frame translation");
+      .add_property("xref",
+                    bp::make_function(&CostModelFrameTranslation::get_reference<FrameTranslation>,
+                                      deprecated<>("Deprecated. Use reference.")),
+                    bp::make_function(&CostModelFrameTranslation::set_reference<FrameTranslation>,
+                                      deprecated<>("Deprecated. Use reference.")),
+                    "reference frame translation");
 
   bp::register_ptr_to_python<boost::shared_ptr<CostDataFrameTranslation> >();
 

--- a/bindings/python/crocoddyl/multibody/costs/frame-translation.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-translation.cpp
@@ -76,8 +76,8 @@ void exposeCostFrameTranslation() {
            ":return cost data.")
       .add_property("reference", bp::make_function(&CostModelFrameTranslation::get_reference<FrameTranslation>),
                     &CostModelFrameTranslation::set_reference<FrameTranslation>, "reference frame translation")
-      .add_property("xref", bp::make_function(&CostModelFrameTranslation::get_xref, bp::return_internal_reference<>()),
-                    &CostModelFrameTranslation::set_xref, "reference frame translation");
+      .add_property("xref", bp::make_function(&CostModelFrameTranslation::get_reference<FrameTranslation>),
+                    &CostModelFrameTranslation::set_reference<FrameTranslation>, "reference frame translation");
 
   bp::register_ptr_to_python<boost::shared_ptr<CostDataFrameTranslation> >();
 

--- a/bindings/python/crocoddyl/multibody/costs/frame-velocity.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-velocity.cpp
@@ -76,8 +76,8 @@ void exposeCostFrameVelocity() {
            ":return cost data.")
       .add_property("reference", bp::make_function(&CostModelFrameVelocity::get_reference<FrameMotion>),
                     &CostModelFrameVelocity::set_reference<FrameMotion>, "reference frame velocity")
-      .add_property("vref", bp::make_function(&CostModelFrameVelocity::get_vref, bp::return_internal_reference<>()),
-                    &CostModelFrameVelocity::set_vref, "reference frame velocity");
+      .add_property("vref", bp::make_function(&CostModelFrameVelocity::get_reference<FrameMotion>),
+                    &CostModelFrameVelocity::set_reference<FrameMotion>, "reference frame velocity");
 
   bp::register_ptr_to_python<boost::shared_ptr<CostDataFrameVelocity> >();
 

--- a/bindings/python/crocoddyl/multibody/costs/frame-velocity.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-velocity.cpp
@@ -9,6 +9,7 @@
 #include "python/crocoddyl/multibody/multibody.hpp"
 #include "python/crocoddyl/multibody/cost-base.hpp"
 #include "crocoddyl/multibody/costs/frame-velocity.hpp"
+#include "python/crocoddyl/utils/deprecate.hpp"
 
 namespace crocoddyl {
 namespace python {
@@ -76,8 +77,12 @@ void exposeCostFrameVelocity() {
            ":return cost data.")
       .add_property("reference", &CostModelFrameVelocity::get_reference<FrameMotion>,
                     &CostModelFrameVelocity::set_reference<FrameMotion>, "reference frame velocity")
-      .add_property("vref", bp::make_function(&CostModelFrameVelocity::get_reference<FrameMotion>),
-                    &CostModelFrameVelocity::set_reference<FrameMotion>, "reference frame velocity");
+      .add_property("vref",
+                    bp::make_function(&CostModelFrameVelocity::get_reference<FrameMotion>,
+                                      deprecated<>("Deprecated. Use reference.")),
+                    bp::make_function(&CostModelFrameVelocity::set_reference<FrameMotion>,
+                                      deprecated<>("Deprecated. Use reference.")),
+                    "reference frame velocity");
 
   bp::register_ptr_to_python<boost::shared_ptr<CostDataFrameVelocity> >();
 

--- a/bindings/python/crocoddyl/multibody/costs/frame-velocity.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-velocity.cpp
@@ -74,8 +74,7 @@ void exposeCostFrameVelocity() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
-      .add_property("reference",
-                    bp::make_function(&CostModelFrameVelocity::get_vref, bp::return_internal_reference<>()),
+      .add_property("reference", bp::make_function(&CostModelFrameVelocity::get_reference<FrameMotion>),
                     &CostModelFrameVelocity::set_reference<FrameMotion>, "reference frame velocity")
       .add_property("vref", bp::make_function(&CostModelFrameVelocity::get_vref, bp::return_internal_reference<>()),
                     &CostModelFrameVelocity::set_vref, "reference frame velocity");

--- a/bindings/python/crocoddyl/multibody/costs/frame-velocity.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/frame-velocity.cpp
@@ -74,7 +74,7 @@ void exposeCostFrameVelocity() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
-      .add_property("reference", bp::make_function(&CostModelFrameVelocity::get_reference<FrameMotion>),
+      .add_property("reference", &CostModelFrameVelocity::get_reference<FrameMotion>,
                     &CostModelFrameVelocity::set_reference<FrameMotion>, "reference frame velocity")
       .add_property("vref", bp::make_function(&CostModelFrameVelocity::get_reference<FrameMotion>),
                     &CostModelFrameVelocity::set_reference<FrameMotion>, "reference frame velocity");

--- a/bindings/python/crocoddyl/multibody/costs/impulse-friction-cone.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/impulse-friction-cone.cpp
@@ -58,7 +58,7 @@ void exposeCostImpulseFrictionCone() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
-      .add_property("reference", bp::make_function(&CostModelImpulseFrictionCone::get_reference<FrameFrictionCone>),
+      .add_property("reference", &CostModelImpulseFrictionCone::get_reference<FrameFrictionCone>,
                     &CostModelImpulseFrictionCone::set_reference<FrameFrictionCone>, "reference frame friction cone");
 
   bp::register_ptr_to_python<boost::shared_ptr<CostDataImpulseFrictionCone> >();

--- a/bindings/python/crocoddyl/multibody/costs/impulse-friction-cone.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/impulse-friction-cone.cpp
@@ -58,8 +58,7 @@ void exposeCostImpulseFrictionCone() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
-      .add_property("reference",
-                    bp::make_function(&CostModelImpulseFrictionCone::get_fref, bp::return_internal_reference<>()),
+      .add_property("reference", bp::make_function(&CostModelImpulseFrictionCone::get_reference<FrameFrictionCone>),
                     &CostModelImpulseFrictionCone::set_reference<FrameFrictionCone>, "reference frame friction cone");
 
   bp::register_ptr_to_python<boost::shared_ptr<CostDataImpulseFrictionCone> >();

--- a/bindings/python/crocoddyl/multibody/costs/state.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/state.cpp
@@ -98,7 +98,7 @@ void exposeCostState() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
-      .add_property("reference", bp::make_function(&CostModelState::get_reference<Eigen::VectorXd>),
+      .add_property("reference", &CostModelState::get_reference<Eigen::VectorXd>,
                     &CostModelState::set_reference<Eigen::VectorXd>, "reference state")
       .add_property("xref", bp::make_function(&CostModelState::get_reference<Eigen::VectorXd>),
                     &CostModelState::set_reference<Eigen::VectorXd>, "reference state");

--- a/bindings/python/crocoddyl/multibody/costs/state.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/state.cpp
@@ -9,6 +9,7 @@
 #include "python/crocoddyl/multibody/multibody.hpp"
 #include "python/crocoddyl/multibody/cost-base.hpp"
 #include "crocoddyl/multibody/costs/state.hpp"
+#include "python/crocoddyl/utils/deprecate.hpp"
 
 namespace crocoddyl {
 namespace python {
@@ -100,8 +101,12 @@ void exposeCostState() {
            ":return cost data.")
       .add_property("reference", &CostModelState::get_reference<Eigen::VectorXd>,
                     &CostModelState::set_reference<Eigen::VectorXd>, "reference state")
-      .add_property("xref", bp::make_function(&CostModelState::get_reference<Eigen::VectorXd>),
-                    &CostModelState::set_reference<Eigen::VectorXd>, "reference state");
+      .add_property("xref",
+                    bp::make_function(&CostModelState::get_reference<Eigen::VectorXd>,
+                                      deprecated<>("Deprecated. Use reference.")),
+                    bp::make_function(&CostModelState::set_reference<Eigen::VectorXd>,
+                                      deprecated<>("Deprecated. Use reference.")),
+                    "reference state");
 }
 
 }  // namespace python

--- a/bindings/python/crocoddyl/multibody/costs/state.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/state.cpp
@@ -98,7 +98,7 @@ void exposeCostState() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
-      .add_property("reference", bp::make_function(&CostModelState::get_xref, bp::return_internal_reference<>()),
+      .add_property("reference", bp::make_function(&CostModelState::get_reference<Eigen::VectorXd>),
                     &CostModelState::set_reference<Eigen::VectorXd>, "reference state")
       .add_property("xref", bp::make_function(&CostModelState::get_xref, bp::return_internal_reference<>()),
                     "reference state");

--- a/bindings/python/crocoddyl/multibody/costs/state.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/state.cpp
@@ -100,8 +100,8 @@ void exposeCostState() {
            ":return cost data.")
       .add_property("reference", bp::make_function(&CostModelState::get_reference<Eigen::VectorXd>),
                     &CostModelState::set_reference<Eigen::VectorXd>, "reference state")
-      .add_property("xref", bp::make_function(&CostModelState::get_xref, bp::return_internal_reference<>()),
-                    "reference state");
+      .add_property("xref", bp::make_function(&CostModelState::get_reference<Eigen::VectorXd>),
+                    &CostModelState::set_reference<Eigen::VectorXd>, "reference state");
 }
 
 }  // namespace python

--- a/bindings/python/crocoddyl/utils/deprecate.hpp
+++ b/bindings/python/crocoddyl/utils/deprecate.hpp
@@ -1,0 +1,37 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2020, INRIA, University of Edinburgh
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef BINDINGS_PYTHON_CROCODDYL_UTILS_DEPRECATE_HPP_
+#define BINDINGS_PYTHON_CROCODDYL_UTILS_DEPRECATE_HPP_
+
+#include <Python.h>
+#include <boost/python.hpp>
+#include <string>
+
+namespace crocoddyl {
+namespace python {
+template <class Policy = boost::python::default_call_policies>
+struct deprecated : Policy {
+  deprecated(const std::string& warning_message = "") : Policy(), m_warning_message(warning_message) {}
+
+  template <class ArgumentPackage>
+  bool precall(ArgumentPackage const& args) const {
+    PyErr_WarnEx(PyExc_UserWarning, m_warning_message.c_str(), 1);
+    return static_cast<const Policy*>(this)->precall(args);
+  }
+
+  typedef typename Policy::result_converter result_converter;
+  typedef typename Policy::argument_package argument_package;
+
+ protected:
+  const std::string m_warning_message;
+};
+}  // namespace python
+}  // namespace crocoddyl
+
+#endif  // BINDINGS_PYTHON_CROCODDYL_UTILS_DEPRECATE_HPP_

--- a/examples/notebooks/cartpole_swing_up.ipynb
+++ b/examples/notebooks/cartpole_swing_up.ipynb
@@ -92,16 +92,16 @@
     "        data.r = np.matrix(self.costWeights * np.array([ s, 1 - c, y, ydot, thdot, f ])).T\n",
     "        data.cost = .5 * sum(np.asarray(data.r) ** 2).item()\n",
     "\n",
-    "    def calcDiff(model, data, x, u=None):\n",
-    "        # Advance user might implement the derivatives\n",
-    "        pass"
+    "    def calcDiff(model,data,x,u=None):\n",
+    "        # Advance user might implement the derivatives in cartpole_analytical_derivatives\n",
+    "        cartpole_analytical_derivatives(model, data, x, u)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can get the solution by uncommenting the following line:"
+    "You can get the solution of the cartpole dynamics by uncommenting the following line:"
    ]
   },
   {
@@ -341,6 +341,57 @@
    "source": [
     "HTML(animateCartpole(ddp.xs).to_jshtml())"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using analytical derivatives\n",
+    "\n",
+    "You can get the solution of the analytical derivatives by uncommenting the following line:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %load solutions/cartpole_analytical_derivatives.py\n",
+    "def cartpole_analytical_derivatives(model, data, x, u=None):\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The analytical derivatives being defined, we do not need to use DAMNumDiff to numerically approximate the derivatives."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "timeStep = 5e-2\n",
+    "cartpoleIAM = crocoddyl.IntegratedActionModelEuler(cartpoleDAM, timeStep)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can now run again all the blocks in \"IV. Write the problem, create the solver\" since cartpoleIAM has been redefined to directly used the analytical derivatives."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/notebooks/solutions/cartpole_analytical_derivatives.py
+++ b/examples/notebooks/solutions/cartpole_analytical_derivatives.py
@@ -1,0 +1,39 @@
+def cartpole_analytical_derivatives(model, data, x, u=None):
+    if u is None: 
+        u = model.unone
+
+    # Getting the state and control variables
+    y, th, ydot, thdot = x[0].item(), x[1].item(), x[2].item(), x[3].item()
+    f = u[0].item()
+
+    # Shortname for system parameters
+    m1, m2, l, g = model.m1, model.m2, model.l, model.g
+    s, c = np.sin(th), np.cos(th)
+    m = m1 + m2
+    mu = m1 + m2 * s ** 2
+    w = model.costWeights
+
+    # derivative of xddot by x, theta, xdot, thetadot
+    # derivative of thddot by x, theta, xdot, thetadot
+    data.Fx[:, :] = np.array([[0.0, 
+                               (m2 * g * c * c - m2 * g * s * s - m2 * l * c * thdot)/mu, 
+                               0.0, 
+                               -m2*l*s/mu ],
+                               [0.0, 
+                               ((- s * f / l) + (m * g * c / l) - (m2 * c * c * thdot**2) + (m2 * s * s * thdot**2))/mu,
+                               0.0, 
+                               - 2 * m2 * c * s * thdot ]])
+    # derivative of xddot and thddot by f    
+    data.Fu[:] = np.array([1 / mu, c / (l * mu)])
+    # first derivative of data.cost by x, theta, xdot, thetadot
+    data.Lx[:] = np.array([y * w[2]**2, s * ((w[0]**2 - w[1]**2) * c + w[1]**2), ydot * w[3]**2, thdot * w[4]**2])
+    # first derivative of data.cost by f
+    data.Lu[:] = np.array([f * w[5]**2])
+    # second derivative of data.cost by x, theta, xdot, thetadot
+    data.Lxx[:] = np.array([w[2]**2, 
+                            w[0]**2 * (c**2 - s**2) + w[1]**2 * (s**2 - c**2 + c),
+                            w[3]**2,
+                            w[4]**2])
+    # second derivative of data.cost by f
+    data.Luu[:] = np.array([w[5]**2])
+

--- a/examples/notebooks/solutions/cartpole_analytical_derivatives.py
+++ b/examples/notebooks/solutions/cartpole_analytical_derivatives.py
@@ -1,5 +1,5 @@
 def cartpole_analytical_derivatives(model, data, x, u=None):
-    if u is None: 
+    if u is None:
         u = model.unone
 
     # Getting the state and control variables

--- a/examples/notebooks/solutions/cartpole_analytical_derivatives.py
+++ b/examples/notebooks/solutions/cartpole_analytical_derivatives.py
@@ -1,5 +1,5 @@
 def cartpole_analytical_derivatives(model, data, x, u=None):
-    if u is None: 
+    if u is None:
         u = model.unone
 
     # Getting the state and control variables
@@ -10,30 +10,24 @@ def cartpole_analytical_derivatives(model, data, x, u=None):
     m1, m2, l, g = model.m1, model.m2, model.l, model.g
     s, c = np.sin(th), np.cos(th)
     m = m1 + m2
-    mu = m1 + m2 * s ** 2
+    mu = m1 + m2 * s**2
     w = model.costWeights
 
     # derivative of xddot by x, theta, xdot, thetadot
     # derivative of thddot by x, theta, xdot, thetadot
-    data.Fx[:, :] = np.array([[0.0, 
-                               (m2 * g * c * c - m2 * g * s * s - m2 * l * c * thdot)/mu, 
-                               0.0, 
-                               -m2*l*s/mu ],
-                               [0.0, 
-                               ((- s * f / l) + (m * g * c / l) - (m2 * c * c * thdot**2) + (m2 * s * s * thdot**2))/mu,
-                               0.0, 
-                               - 2 * m2 * c * s * thdot ]])
-    # derivative of xddot and thddot by f    
+    data.Fx[:, :] = np.array(
+        [[0.0, (m2 * g * c * c - m2 * g * s * s - m2 * l * c * thdot) / mu, 0.0, -m2 * l * s / mu],
+         [
+             0.0, ((-s * f / l) + (m * g * c / l) - (m2 * c * c * thdot**2) + (m2 * s * s * thdot**2)) / mu, 0.0,
+             -2 * m2 * c * s * thdot
+         ]])
+    # derivative of xddot and thddot by f
     data.Fu[:] = np.array([1 / mu, c / (l * mu)])
     # first derivative of data.cost by x, theta, xdot, thetadot
     data.Lx[:] = np.array([y * w[2]**2, s * ((w[0]**2 - w[1]**2) * c + w[1]**2), ydot * w[3]**2, thdot * w[4]**2])
     # first derivative of data.cost by f
     data.Lu[:] = np.array([f * w[5]**2])
     # second derivative of data.cost by x, theta, xdot, thetadot
-    data.Lxx[:] = np.array([w[2]**2, 
-                            w[0]**2 * (c**2 - s**2) + w[1]**2 * (s**2 - c**2 + c),
-                            w[3]**2,
-                            w[4]**2])
+    data.Lxx[:] = np.array([w[2]**2, w[0]**2 * (c**2 - s**2) + w[1]**2 * (s**2 - c**2 + c), w[3]**2, w[4]**2])
     # second derivative of data.cost by f
     data.Luu[:] = np.array([w[5]**2])
-

--- a/examples/notebooks/solutions/cartpole_dyn.py
+++ b/examples/notebooks/solutions/cartpole_dyn.py
@@ -14,7 +14,7 @@ def cartpole_dynamics(model, data, x, u):
     # Defining the equation of motions
     m = m1 + m2
     mu = m1 + m2 * s**2
-    xddot = (f + m2 * c * s * g - m2 * l * s * thdot**2) / mu
+    xddot = (f + m2 * c * s * g - m2 * l * s * thdot) / mu
     thddot = (c * f / l + m * g * s / l - m2 * c * s * thdot**2) / mu
 
     return [xddot, thddot]

--- a/include/crocoddyl/core/utils/deprecate.hpp
+++ b/include/crocoddyl/core/utils/deprecate.hpp
@@ -1,0 +1,28 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2020, University of Edinburgh
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef CROCODDYL_CORE_UTILS_DEPRECATE_HPP_
+#define CROCODDYL_CORE_UTILS_DEPRECATE_HPP_
+
+// Helper to deprecate functions and methods
+// See https://blog.samat.io/2017/02/27/Deprecating-functions-and-methods-in-Cplusplus/
+// For C++14
+#if defined(__has_cpp_attribute)
+#if __has_cpp_attribute(deprecated)
+#define DEPRECATED(msg, func) [[deprecated(msg)]] func
+#endif
+// For everyone else
+#else
+#ifdef __GNUC__
+#define DEPRECATED(msg, func) func __attribute__((deprecated(msg)))
+#elif defined(_MSC_VER)
+#define DEPRECATED(msg, func) __declspec(deprecated(msg)) func
+#endif
+#endif
+
+#endif  // CROCODDYL_CORE_UTILS_DEPRECATE_HPP_

--- a/include/crocoddyl/multibody/cost-base.hpp
+++ b/include/crocoddyl/multibody/cost-base.hpp
@@ -56,11 +56,11 @@ class CostModelAbstractTpl {
   const boost::shared_ptr<ActivationModelAbstract>& get_activation() const;
   const std::size_t& get_nu() const;
 
-  template <class T>
-  void set_reference(T ref);
+  template <class ReferenceType>
+  void set_reference(ReferenceType ref);
 
-  template <class T>
-  void get_reference(T& ref);
+  template <class ReferenceType>
+  ReferenceType get_reference() const;
 
  protected:
   virtual void set_referenceImpl(const std::type_info&, const void*);

--- a/include/crocoddyl/multibody/cost-base.hpp
+++ b/include/crocoddyl/multibody/cost-base.hpp
@@ -64,7 +64,7 @@ class CostModelAbstractTpl {
 
  protected:
   virtual void set_referenceImpl(const std::type_info&, const void*);
-  virtual void get_referenceImpl(const std::type_info&, void*);
+  virtual void get_referenceImpl(const std::type_info&, void*) const;
 
   boost::shared_ptr<StateMultibody> state_;
   boost::shared_ptr<ActivationModelAbstract> activation_;

--- a/include/crocoddyl/multibody/cost-base.hxx
+++ b/include/crocoddyl/multibody/cost-base.hxx
@@ -68,8 +68,8 @@ const std::size_t& CostModelAbstractTpl<Scalar>::get_nu() const {
 }
 
 template <typename Scalar>
-template <class T>
-void CostModelAbstractTpl<Scalar>::set_reference(T ref) {
+template <class ReferenceType>
+void CostModelAbstractTpl<Scalar>::set_reference(ReferenceType ref) {
   set_referenceImpl(typeid(ref), &ref);
 }
 
@@ -79,9 +79,11 @@ void CostModelAbstractTpl<Scalar>::set_referenceImpl(const std::type_info&, cons
 }
 
 template <typename Scalar>
-template <class T>
-void CostModelAbstractTpl<Scalar>::get_reference(T& ref) {
+template <class ReferenceType>
+ReferenceType CostModelAbstractTpl<Scalar>::get_reference() const {
+  ReferenceType ref;
   get_referenceImpl(typeid(ref), &ref);
+  return ref;
 }
 
 template <typename Scalar>

--- a/include/crocoddyl/multibody/cost-base.hxx
+++ b/include/crocoddyl/multibody/cost-base.hxx
@@ -85,7 +85,7 @@ void CostModelAbstractTpl<Scalar>::get_reference(T& ref) {
 }
 
 template <typename Scalar>
-void CostModelAbstractTpl<Scalar>::get_referenceImpl(const std::type_info&, void*) {
+void CostModelAbstractTpl<Scalar>::get_referenceImpl(const std::type_info&, void*) const {
   throw_pretty("It has not been implemented the set_referenceImpl() function");
 }
 

--- a/include/crocoddyl/multibody/costs/centroidal-momentum.hpp
+++ b/include/crocoddyl/multibody/costs/centroidal-momentum.hpp
@@ -13,6 +13,7 @@
 #include "crocoddyl/multibody/cost-base.hpp"
 #include "crocoddyl/multibody/data/multibody.hpp"
 #include "crocoddyl/core/utils/exception.hpp"
+#include "crocoddyl/core/utils/deprecate.hpp"
 
 namespace crocoddyl {
 
@@ -53,8 +54,8 @@ class CostModelCentroidalMomentumTpl : public CostModelAbstractTpl<_Scalar> {
   virtual void set_referenceImpl(const std::type_info& ti, const void* pv);
   virtual void get_referenceImpl(const std::type_info& ti, void* pv) const;
 
-  const Vector6s& get_href() const;
-  void set_href(const Vector6s& mref_in);
+  DEPRECATED("Use set_reference<MathBaseTpl<Scalar>::Vector6s>()", void set_href(const Vector6s& mref_in);)
+  DEPRECATED("Use get_reference<MathBaseTpl<Scalar>::Vector6s>()", const Vector6s& get_href() const;)
 
  protected:
   using Base::activation_;

--- a/include/crocoddyl/multibody/costs/centroidal-momentum.hpp
+++ b/include/crocoddyl/multibody/costs/centroidal-momentum.hpp
@@ -51,7 +51,7 @@ class CostModelCentroidalMomentumTpl : public CostModelAbstractTpl<_Scalar> {
   virtual boost::shared_ptr<CostDataAbstract> createData(DataCollectorAbstract* const data);
 
   virtual void set_referenceImpl(const std::type_info& ti, const void* pv);
-  virtual void get_referenceImpl(const std::type_info& ti, void* pv);
+  virtual void get_referenceImpl(const std::type_info& ti, void* pv) const;
 
   const Vector6s& get_href() const;
   void set_href(const Vector6s& mref_in);

--- a/include/crocoddyl/multibody/costs/centroidal-momentum.hxx
+++ b/include/crocoddyl/multibody/costs/centroidal-momentum.hxx
@@ -100,7 +100,7 @@ void CostModelCentroidalMomentumTpl<Scalar>::set_referenceImpl(const std::type_i
 }
 
 template <typename Scalar>
-void CostModelCentroidalMomentumTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) {
+void CostModelCentroidalMomentumTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) const {
   if (ti == typeid(Vector6s)) {
     Eigen::Map<Vector6s> ref_map(static_cast<Vector6s*>(pv)->data());
     ref_map[0] = href_[0];

--- a/include/crocoddyl/multibody/costs/com-position.hpp
+++ b/include/crocoddyl/multibody/costs/com-position.hpp
@@ -54,7 +54,7 @@ class CostModelCoMPositionTpl : public CostModelAbstractTpl<_Scalar> {
 
  protected:
   virtual void set_referenceImpl(const std::type_info& ti, const void* pv);
-  virtual void get_referenceImpl(const std::type_info& ti, void* pv);
+  virtual void get_referenceImpl(const std::type_info& ti, void* pv) const;
 
   using Base::activation_;
   using Base::nu_;

--- a/include/crocoddyl/multibody/costs/com-position.hpp
+++ b/include/crocoddyl/multibody/costs/com-position.hpp
@@ -13,6 +13,7 @@
 #include "crocoddyl/multibody/cost-base.hpp"
 #include "crocoddyl/multibody/data/multibody.hpp"
 #include "crocoddyl/core/utils/exception.hpp"
+#include "crocoddyl/core/utils/deprecate.hpp"
 
 namespace crocoddyl {
 
@@ -49,8 +50,8 @@ class CostModelCoMPositionTpl : public CostModelAbstractTpl<_Scalar> {
                         const Eigen::Ref<const VectorXs>& u);
   virtual boost::shared_ptr<CostDataAbstract> createData(DataCollectorAbstract* const data);
 
-  const Vector3s& get_cref() const;
-  void set_cref(const Vector3s& cref_in);
+  DEPRECATED("Use set_reference<MathBaseTpl<Scalar>::Vector3s>()", void set_cref(const Vector3s& cref_in);)
+  DEPRECATED("Use get_reference<MathBaseTpl<Scalar>::Vector3s>()", const Vector3s& get_cref() const;)
 
  protected:
   virtual void set_referenceImpl(const std::type_info& ti, const void* pv);

--- a/include/crocoddyl/multibody/costs/com-position.hxx
+++ b/include/crocoddyl/multibody/costs/com-position.hxx
@@ -87,7 +87,7 @@ void CostModelCoMPositionTpl<Scalar>::set_referenceImpl(const std::type_info& ti
 }
 
 template <typename Scalar>
-void CostModelCoMPositionTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) {
+void CostModelCoMPositionTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) const {
   if (ti == typeid(Vector3s)) {
     Eigen::Map<Vector3s> ref_map(static_cast<Vector3s*>(pv)->data());
     ref_map[0] = cref_[0];

--- a/include/crocoddyl/multibody/costs/contact-cop-position.hpp
+++ b/include/crocoddyl/multibody/costs/contact-cop-position.hpp
@@ -161,7 +161,7 @@ class CostModelContactCoPPositionTpl : public CostModelAbstractTpl<_Scalar> {
   /**
    * @brief Modify the cop
    */
-  virtual void get_referenceImpl(const std::type_info& ti, void* pv);
+  virtual void get_referenceImpl(const std::type_info& ti, void* pv) const;
 
   using Base::activation_;
   using Base::nu_;

--- a/include/crocoddyl/multibody/costs/contact-cop-position.hpp
+++ b/include/crocoddyl/multibody/costs/contact-cop-position.hpp
@@ -152,11 +152,6 @@ class CostModelContactCoPPositionTpl : public CostModelAbstractTpl<_Scalar> {
    */
   virtual boost::shared_ptr<CostDataAbstract> createData(DataCollectorAbstract* const data);
 
-  /**
-   * @brief Return the cop parameter, i.e. contat frame id and support region
-   */
-  const FrameCoPSupport& get_copSupport() const;
-
  protected:
   /**
    * @brief Return the cop
@@ -206,8 +201,7 @@ struct CostDataContactCoPPositionTpl : public CostDataAbstractTpl<_Scalar> {
     }
 
     // Get the active 6d contact (avoids data casting at runtime)
-    FrameCoPSupport cop_support;
-    model->get_reference(cop_support);
+    FrameCoPSupport cop_support = model->template get_reference<FrameCoPSupport>();
     std::string frame_name = model->get_state()->get_pinocchio()->frames[cop_support.get_frame()].name;
     bool found_contact = false;
     for (typename ContactModelMultiple::ContactDataContainer::iterator it = d->contacts->contacts.begin();

--- a/include/crocoddyl/multibody/costs/contact-cop-position.hxx
+++ b/include/crocoddyl/multibody/costs/contact-cop-position.hxx
@@ -94,11 +94,6 @@ boost::shared_ptr<CostDataAbstractTpl<Scalar> > CostModelContactCoPPositionTpl<S
 }
 
 template <typename Scalar>
-const FrameCoPSupportTpl<Scalar>& CostModelContactCoPPositionTpl<Scalar>::get_copSupport() const {
-  return cop_support_;
-}
-
-template <typename Scalar>
 void CostModelContactCoPPositionTpl<Scalar>::set_referenceImpl(const std::type_info& ti, const void* pv) {
   if (ti == typeid(FrameCoPSupport)) {
     cop_support_ = *static_cast<const FrameCoPSupport*>(pv);

--- a/include/crocoddyl/multibody/costs/contact-cop-position.hxx
+++ b/include/crocoddyl/multibody/costs/contact-cop-position.hxx
@@ -103,7 +103,7 @@ void CostModelContactCoPPositionTpl<Scalar>::set_referenceImpl(const std::type_i
 }
 
 template <typename Scalar>
-void CostModelContactCoPPositionTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) {
+void CostModelContactCoPPositionTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) const {
   if (ti == typeid(FrameCoPSupport)) {
     FrameCoPSupport& ref_map = *static_cast<FrameCoPSupport*>(pv);
     ref_map = cop_support_;

--- a/include/crocoddyl/multibody/costs/contact-force.hpp
+++ b/include/crocoddyl/multibody/costs/contact-force.hpp
@@ -191,7 +191,7 @@ class CostModelContactForceTpl : public CostModelAbstractTpl<_Scalar> {
    * @brief Modify the reference spatial contact force in the contact coordinates
    * \f${}^o\underline{\boldsymbol{\lambda}}_c^{reference}\f$
    */
-  virtual void get_referenceImpl(const std::type_info& ti, void* pv);
+  virtual void get_referenceImpl(const std::type_info& ti, void* pv) const;
 
   using Base::activation_;
   using Base::nu_;

--- a/include/crocoddyl/multibody/costs/contact-force.hpp
+++ b/include/crocoddyl/multibody/costs/contact-force.hpp
@@ -17,6 +17,7 @@
 #include "crocoddyl/multibody/data/contacts.hpp"
 #include "crocoddyl/multibody/frames.hpp"
 #include "crocoddyl/core/utils/exception.hpp"
+#include "crocoddyl/core/utils/deprecate.hpp"
 
 namespace crocoddyl {
 
@@ -168,17 +169,8 @@ class CostModelContactForceTpl : public CostModelAbstractTpl<_Scalar> {
    */
   virtual boost::shared_ptr<CostDataAbstract> createData(DataCollectorAbstract* const data);
 
-  /**
-   * @brief Return the reference spatial contact force in the contact coordinates
-   * \f${}^o\underline{\boldsymbol{\lambda}}_c^{reference}\f$
-   */
-  const FrameForce& get_fref() const;
-
-  /**
-   * @brief Modify the reference spatial contact force in the contact coordinates
-   * \f${}^o\underline{\boldsymbol{\lambda}}_c^{reference}\f$
-   */
-  void set_fref(const FrameForce& fref);
+  DEPRECATED("Use set_reference<FrameForceTpl<Scalar> >()", void set_fref(const FrameForce& fref);)
+  DEPRECATED("Use get_reference<FrameForceTpl<Scalar> >()", const FrameForce& get_fref() const;)
 
  protected:
   /**
@@ -230,8 +222,8 @@ struct CostDataContactForceTpl : public CostDataAbstractTpl<_Scalar> {
     }
 
     // Avoids data casting at runtime
-    const FrameForce& fref = model->get_fref();
-    std::string frame_name = model->get_state()->get_pinocchio()->frames[model->get_fref().frame].name;
+    FrameForce fref = model->template get_reference<FrameForce>();
+    std::string frame_name = model->get_state()->get_pinocchio()->frames[fref.frame].name;
     bool found_contact = false;
     for (typename ContactModelMultiple::ContactDataContainer::iterator it = d->contacts->contacts.begin();
          it != d->contacts->contacts.end(); ++it) {

--- a/include/crocoddyl/multibody/costs/contact-force.hxx
+++ b/include/crocoddyl/multibody/costs/contact-force.hxx
@@ -132,7 +132,7 @@ void CostModelContactForceTpl<Scalar>::set_referenceImpl(const std::type_info& t
 }
 
 template <typename Scalar>
-void CostModelContactForceTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) {
+void CostModelContactForceTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) const {
   if (ti == typeid(FrameForce)) {
     FrameForce& ref_map = *static_cast<FrameForce*>(pv);
     ref_map = fref_;

--- a/include/crocoddyl/multibody/costs/contact-friction-cone.hpp
+++ b/include/crocoddyl/multibody/costs/contact-friction-cone.hpp
@@ -18,6 +18,7 @@
 #include "crocoddyl/multibody/frames.hpp"
 #include "crocoddyl/multibody/friction-cone.hpp"
 #include "crocoddyl/core/utils/exception.hpp"
+#include "crocoddyl/core/utils/deprecate.hpp"
 
 namespace crocoddyl {
 
@@ -60,8 +61,8 @@ class CostModelContactFrictionConeTpl : public CostModelAbstractTpl<_Scalar> {
                         const Eigen::Ref<const VectorXs>& u);
   virtual boost::shared_ptr<CostDataAbstract> createData(DataCollectorAbstract* const data);
 
-  const FrameFrictionCone& get_fref() const;
-  void set_fref(const FrameFrictionCone& fref);
+  DEPRECATED("Use set_reference<FrameFrictionConeTpl<Scalar> >()", void set_fref(const FrameFrictionCone& fref);)
+  DEPRECATED("Use get_reference<FrameFrictionConeTpl<Scalar> >()", const FrameFrictionCone& get_fref() const;)
 
  protected:
   virtual void set_referenceImpl(const std::type_info& ti, const void* pv);
@@ -104,7 +105,7 @@ struct CostDataContactFrictionConeTpl : public CostDataAbstractTpl<_Scalar> {
     }
 
     // Avoids data casting at runtime
-    const FrameFrictionCone& fref = model->get_fref();
+    FrameFrictionCone fref = model->template get_reference<FrameFrictionCone>();
     std::string frame_name = model->get_state()->get_pinocchio()->frames[fref.frame].name;
     bool found_contact = false;
     for (typename ContactModelMultiple::ContactDataContainer::iterator it = d->contacts->contacts.begin();

--- a/include/crocoddyl/multibody/costs/contact-friction-cone.hpp
+++ b/include/crocoddyl/multibody/costs/contact-friction-cone.hpp
@@ -65,7 +65,7 @@ class CostModelContactFrictionConeTpl : public CostModelAbstractTpl<_Scalar> {
 
  protected:
   virtual void set_referenceImpl(const std::type_info& ti, const void* pv);
-  virtual void get_referenceImpl(const std::type_info& ti, void* pv);
+  virtual void get_referenceImpl(const std::type_info& ti, void* pv) const;
 
   using Base::activation_;
   using Base::nu_;

--- a/include/crocoddyl/multibody/costs/contact-friction-cone.hxx
+++ b/include/crocoddyl/multibody/costs/contact-friction-cone.hxx
@@ -106,7 +106,7 @@ void CostModelContactFrictionConeTpl<Scalar>::set_referenceImpl(const std::type_
 }
 
 template <typename Scalar>
-void CostModelContactFrictionConeTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) {
+void CostModelContactFrictionConeTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) const {
   if (ti == typeid(FrameFrictionCone)) {
     FrameFrictionCone& ref_map = *static_cast<FrameFrictionCone*>(pv);
     ref_map = fref_;

--- a/include/crocoddyl/multibody/costs/contact-impulse.hpp
+++ b/include/crocoddyl/multibody/costs/contact-impulse.hpp
@@ -157,7 +157,7 @@ class CostModelContactImpulseTpl : public CostModelAbstractTpl<_Scalar> {
    * @brief Modify the reference spatial contact impulse in the contact coordinates
    * \f${}^o\underline{\boldsymbol{\Lambda}}_c^{reference}\f$
    */
-  virtual void get_referenceImpl(const std::type_info& ti, void* pv);
+  virtual void get_referenceImpl(const std::type_info& ti, void* pv) const;
 
   using Base::activation_;
   using Base::nu_;

--- a/include/crocoddyl/multibody/costs/contact-impulse.hpp
+++ b/include/crocoddyl/multibody/costs/contact-impulse.hpp
@@ -17,6 +17,7 @@
 #include "crocoddyl/multibody/data/impulses.hpp"
 #include "crocoddyl/multibody/frames.hpp"
 #include "crocoddyl/core/utils/exception.hpp"
+#include "crocoddyl/core/utils/deprecate.hpp"
 
 namespace crocoddyl {
 
@@ -134,17 +135,8 @@ class CostModelContactImpulseTpl : public CostModelAbstractTpl<_Scalar> {
    */
   virtual boost::shared_ptr<CostDataAbstract> createData(DataCollectorAbstract* const data);
 
-  /**
-   * @brief Return the reference spatial contact impulse in the contact coordinates
-   * \f${}^o\underline{\boldsymbol{\Lambda}}_c^{reference}\f$
-   */
-  const FrameForce& get_fref() const;
-
-  /**
-   * @brief Modify the reference spatial contact impulse in the contact coordinates
-   * \f${}^o\underline{\boldsymbol{\Lambda}}_c^{reference}\f$
-   */
-  void set_fref(const FrameForce& fref);
+  DEPRECATED("Used set_reference<FrameForceTpl<Scalar> >()", void set_fref(const FrameForce& fref);)
+  DEPRECATED("Used get_reference<FrameForceTpl<Scalar> >()", const FrameForce& get_fref() const;)
 
  protected:
   /**
@@ -194,8 +186,8 @@ struct CostDataContactImpulseTpl : public CostDataAbstractTpl<_Scalar> {
     }
 
     // Avoids data casting at runtime
-    const FrameForce& fref = model->get_fref();
-    std::string frame_name = model->get_state()->get_pinocchio()->frames[model->get_fref().frame].name;
+    FrameForce fref = model->template get_reference<FrameForce>();
+    std::string frame_name = model->get_state()->get_pinocchio()->frames[fref.frame].name;
     bool found_impulse = false;
     for (typename ImpulseModelMultiple::ImpulseDataContainer::iterator it = d->impulses->impulses.begin();
          it != d->impulses->impulses.end(); ++it) {

--- a/include/crocoddyl/multibody/costs/contact-impulse.hxx
+++ b/include/crocoddyl/multibody/costs/contact-impulse.hxx
@@ -102,7 +102,7 @@ void CostModelContactImpulseTpl<Scalar>::set_referenceImpl(const std::type_info&
 }
 
 template <typename Scalar>
-void CostModelContactImpulseTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) {
+void CostModelContactImpulseTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) const {
   if (ti == typeid(FrameForce)) {
     FrameForce& ref_map = *static_cast<FrameForce*>(pv);
     ref_map = fref_;

--- a/include/crocoddyl/multibody/costs/control.hpp
+++ b/include/crocoddyl/multibody/costs/control.hpp
@@ -50,7 +50,7 @@ class CostModelControlTpl : public CostModelAbstractTpl<_Scalar> {
 
  protected:
   virtual void set_referenceImpl(const std::type_info& ti, const void* pv);
-  virtual void get_referenceImpl(const std::type_info& ti, void* pv);
+  virtual void get_referenceImpl(const std::type_info& ti, void* pv) const;
 
   using Base::activation_;
   using Base::nu_;

--- a/include/crocoddyl/multibody/costs/control.hpp
+++ b/include/crocoddyl/multibody/costs/control.hpp
@@ -11,6 +11,7 @@
 
 #include "crocoddyl/multibody/fwd.hpp"
 #include "crocoddyl/multibody/cost-base.hpp"
+#include "crocoddyl/core/utils/deprecate.hpp"
 
 namespace crocoddyl {
 
@@ -45,8 +46,8 @@ class CostModelControlTpl : public CostModelAbstractTpl<_Scalar> {
   virtual void calcDiff(const boost::shared_ptr<CostDataAbstract>& data, const Eigen::Ref<const VectorXs>& x,
                         const Eigen::Ref<const VectorXs>& u);
 
-  const VectorXs& get_uref() const;
-  void set_uref(const VectorXs& uref_in);
+  DEPRECATED("Use set_reference<MathbTpl<Scalare>::VectorXs>()", void set_uref(const VectorXs& uref_in);)
+  DEPRECATED("Use get_reference<MathbTpl<Scalare>::VectorXs>()", const VectorXs& get_uref() const;)
 
  protected:
   virtual void set_referenceImpl(const std::type_info& ti, const void* pv);

--- a/include/crocoddyl/multibody/costs/control.hxx
+++ b/include/crocoddyl/multibody/costs/control.hxx
@@ -100,7 +100,7 @@ void CostModelControlTpl<Scalar>::set_referenceImpl(const std::type_info& ti, co
 }
 
 template <typename Scalar>
-void CostModelControlTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) {
+void CostModelControlTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) const {
   if (ti == typeid(VectorXs)) {
     VectorXs& tmp = *static_cast<VectorXs*>(pv);
     tmp.resize(nu_);

--- a/include/crocoddyl/multibody/costs/frame-placement.hpp
+++ b/include/crocoddyl/multibody/costs/frame-placement.hpp
@@ -14,6 +14,7 @@
 #include "crocoddyl/multibody/data/multibody.hpp"
 #include "crocoddyl/multibody/frames.hpp"
 #include "crocoddyl/core/utils/exception.hpp"
+#include "crocoddyl/core/utils/deprecate.hpp"
 
 namespace crocoddyl {
 
@@ -51,8 +52,8 @@ class CostModelFramePlacementTpl : public CostModelAbstractTpl<_Scalar> {
                         const Eigen::Ref<const VectorXs>& u);
   virtual boost::shared_ptr<CostDataAbstract> createData(DataCollectorAbstract* const data);
 
-  const FramePlacement& get_Mref() const;
-  void set_Mref(const FramePlacement& Mref_in);
+  DEPRECATED("Use set_reference<FramePlacementTpl<Scalar> >()", void set_Mref(const FramePlacement& Mref_in);)
+  DEPRECATED("Use get_reference<FramePlacementTpl<Scalar> >()", const FramePlacement& get_Mref() const;)
 
  protected:
   virtual void set_referenceImpl(const std::type_info& ti, const void* pv);

--- a/include/crocoddyl/multibody/costs/frame-placement.hpp
+++ b/include/crocoddyl/multibody/costs/frame-placement.hpp
@@ -56,7 +56,7 @@ class CostModelFramePlacementTpl : public CostModelAbstractTpl<_Scalar> {
 
  protected:
   virtual void set_referenceImpl(const std::type_info& ti, const void* pv);
-  virtual void get_referenceImpl(const std::type_info& ti, void* pv);
+  virtual void get_referenceImpl(const std::type_info& ti, void* pv) const;
 
   using Base::activation_;
   using Base::nu_;

--- a/include/crocoddyl/multibody/costs/frame-placement.hxx
+++ b/include/crocoddyl/multibody/costs/frame-placement.hxx
@@ -102,7 +102,7 @@ void CostModelFramePlacementTpl<Scalar>::set_referenceImpl(const std::type_info&
 }
 
 template <typename Scalar>
-void CostModelFramePlacementTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) {
+void CostModelFramePlacementTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) const {
   if (ti == typeid(FramePlacement)) {
     FramePlacement& ref_map = *static_cast<FramePlacement*>(pv);
     ref_map = Mref_;

--- a/include/crocoddyl/multibody/costs/frame-rotation.hpp
+++ b/include/crocoddyl/multibody/costs/frame-rotation.hpp
@@ -14,6 +14,7 @@
 #include "crocoddyl/multibody/data/multibody.hpp"
 #include "crocoddyl/multibody/frames.hpp"
 #include "crocoddyl/core/utils/exception.hpp"
+#include "crocoddyl/core/utils/deprecate.hpp"
 
 namespace crocoddyl {
 
@@ -50,8 +51,8 @@ class CostModelFrameRotationTpl : public CostModelAbstractTpl<_Scalar> {
                         const Eigen::Ref<const VectorXs>& u);
   virtual boost::shared_ptr<CostDataAbstract> createData(DataCollectorAbstract* const data);
 
-  const FrameRotation& get_Rref() const;
-  void set_Rref(const FrameRotation& Rref_in);
+  DEPRECATED("Use set_reference<FrameRotationTpl<Scalar> >()", void set_Rref(const FrameRotation& Rref_in);)
+  DEPRECATED("Use get_reference<FrameRotationTpl<Scalar> >()", const FrameRotation& get_Rref() const;)
 
  protected:
   virtual void set_referenceImpl(const std::type_info& ti, const void* pv);

--- a/include/crocoddyl/multibody/costs/frame-rotation.hpp
+++ b/include/crocoddyl/multibody/costs/frame-rotation.hpp
@@ -55,7 +55,7 @@ class CostModelFrameRotationTpl : public CostModelAbstractTpl<_Scalar> {
 
  protected:
   virtual void set_referenceImpl(const std::type_info& ti, const void* pv);
-  virtual void get_referenceImpl(const std::type_info& ti, void* pv);
+  virtual void get_referenceImpl(const std::type_info& ti, void* pv) const;
 
   using Base::activation_;
   using Base::nu_;

--- a/include/crocoddyl/multibody/costs/frame-rotation.hxx
+++ b/include/crocoddyl/multibody/costs/frame-rotation.hxx
@@ -102,7 +102,7 @@ void CostModelFrameRotationTpl<Scalar>::set_referenceImpl(const std::type_info& 
 }
 
 template <typename Scalar>
-void CostModelFrameRotationTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) {
+void CostModelFrameRotationTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) const {
   if (ti == typeid(FrameRotation)) {
     FrameRotation& ref_map = *static_cast<FrameRotation*>(pv);
     ref_map = Rref_;

--- a/include/crocoddyl/multibody/costs/frame-translation.hpp
+++ b/include/crocoddyl/multibody/costs/frame-translation.hpp
@@ -57,7 +57,7 @@ class CostModelFrameTranslationTpl : public CostModelAbstractTpl<_Scalar> {
 
  protected:
   virtual void set_referenceImpl(const std::type_info& ti, const void* pv);
-  virtual void get_referenceImpl(const std::type_info& ti, void* pv);
+  virtual void get_referenceImpl(const std::type_info& ti, void* pv) const;
 
   using Base::activation_;
   using Base::nu_;

--- a/include/crocoddyl/multibody/costs/frame-translation.hpp
+++ b/include/crocoddyl/multibody/costs/frame-translation.hpp
@@ -15,6 +15,7 @@
 #include "crocoddyl/multibody/data/multibody.hpp"
 #include "crocoddyl/multibody/frames.hpp"
 #include "crocoddyl/core/utils/exception.hpp"
+#include "crocoddyl/core/utils/deprecate.hpp"
 
 namespace crocoddyl {
 
@@ -52,8 +53,8 @@ class CostModelFrameTranslationTpl : public CostModelAbstractTpl<_Scalar> {
                         const Eigen::Ref<const VectorXs>& u);
   virtual boost::shared_ptr<CostDataAbstract> createData(DataCollectorAbstract* const data);
 
-  const FrameTranslation& get_xref() const;
-  void set_xref(const FrameTranslation& xref_in);
+  DEPRECATED("Use set_reference<FrameTranslation<Scalar> >()", void set_xref(const FrameTranslation& xref_in);)
+  DEPRECATED("Use get_reference<FrameTranslation<Scalar> >()", const FrameTranslation& get_xref() const;)
 
  protected:
   virtual void set_referenceImpl(const std::type_info& ti, const void* pv);

--- a/include/crocoddyl/multibody/costs/frame-translation.hxx
+++ b/include/crocoddyl/multibody/costs/frame-translation.hxx
@@ -96,7 +96,7 @@ void CostModelFrameTranslationTpl<Scalar>::set_referenceImpl(const std::type_inf
 }
 
 template <typename Scalar>
-void CostModelFrameTranslationTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) {
+void CostModelFrameTranslationTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) const {
   if (ti == typeid(FrameTranslation)) {
     FrameTranslation& ref_map = *static_cast<FrameTranslation*>(pv);
     ref_map = xref_;

--- a/include/crocoddyl/multibody/costs/frame-velocity.hpp
+++ b/include/crocoddyl/multibody/costs/frame-velocity.hpp
@@ -55,7 +55,7 @@ class CostModelFrameVelocityTpl : public CostModelAbstractTpl<_Scalar> {
 
  protected:
   virtual void set_referenceImpl(const std::type_info& ti, const void* pv);
-  virtual void get_referenceImpl(const std::type_info& ti, void* pv);
+  virtual void get_referenceImpl(const std::type_info& ti, void* pv) const;
 
   using Base::activation_;
   using Base::nu_;

--- a/include/crocoddyl/multibody/costs/frame-velocity.hpp
+++ b/include/crocoddyl/multibody/costs/frame-velocity.hpp
@@ -14,6 +14,7 @@
 #include "crocoddyl/multibody/data/multibody.hpp"
 #include "crocoddyl/multibody/frames.hpp"
 #include "crocoddyl/core/utils/exception.hpp"
+#include "crocoddyl/core/utils/deprecate.hpp"
 
 namespace crocoddyl {
 
@@ -50,8 +51,8 @@ class CostModelFrameVelocityTpl : public CostModelAbstractTpl<_Scalar> {
                         const Eigen::Ref<const VectorXs>& u);
   virtual boost::shared_ptr<CostDataAbstract> createData(DataCollectorAbstract* const data);
 
-  const FrameMotion& get_vref() const;
-  void set_vref(const FrameMotion& vref_in);
+  DEPRECATED("Use set_reference<FrameMotionTpl<Scalar> >()", void set_vref(const FrameMotion& vref_in);)
+  DEPRECATED("Use get_reference<FrameMotionTpl<Scalar> >()", const FrameMotion& get_vref() const;)
 
  protected:
   virtual void set_referenceImpl(const std::type_info& ti, const void* pv);

--- a/include/crocoddyl/multibody/costs/frame-velocity.hpp
+++ b/include/crocoddyl/multibody/costs/frame-velocity.hpp
@@ -82,9 +82,16 @@ struct CostDataFrameVelocityTpl : public CostDataAbstractTpl<_Scalar> {
   template <template <typename Scalar> class Model>
   CostDataFrameVelocityTpl(Model<Scalar>* const model, DataCollectorAbstract* const data)
       : Base(model, data),
-        joint(model->get_state()->get_pinocchio()->frames[model->get_vref().frame].parent),
+        joint(model->get_state()
+                  ->get_pinocchio()
+                  ->frames[model->template get_reference<FrameMotionTpl<Scalar> >().frame]
+                  .parent),
         vr(pinocchio::MotionTpl<Scalar>::Zero()),
-        fXj(model->get_state()->get_pinocchio()->frames[model->get_vref().frame].placement.inverse().toActionMatrix()),
+        fXj(model->get_state()
+                ->get_pinocchio()
+                ->frames[model->template get_reference<FrameMotionTpl<Scalar> >().frame]
+                .placement.inverse()
+                .toActionMatrix()),
         dv_dq(6, model->get_state()->get_nv()),
         dv_dv(6, model->get_state()->get_nv()),
         Arr_Rx(6, model->get_state()->get_nv()) {

--- a/include/crocoddyl/multibody/costs/frame-velocity.hxx
+++ b/include/crocoddyl/multibody/costs/frame-velocity.hxx
@@ -98,7 +98,7 @@ void CostModelFrameVelocityTpl<Scalar>::set_referenceImpl(const std::type_info& 
 }
 
 template <typename Scalar>
-void CostModelFrameVelocityTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) {
+void CostModelFrameVelocityTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) const {
   if (ti == typeid(FrameMotion)) {
     FrameMotion& ref_map = *static_cast<FrameMotion*>(pv);
     ref_map = vref_;

--- a/include/crocoddyl/multibody/costs/impulse-friction-cone.hpp
+++ b/include/crocoddyl/multibody/costs/impulse-friction-cone.hpp
@@ -60,7 +60,7 @@ class CostModelImpulseFrictionConeTpl : public CostModelAbstractTpl<_Scalar> {
 
  protected:
   virtual void set_referenceImpl(const std::type_info& ti, const void* pv);
-  virtual void get_referenceImpl(const std::type_info& ti, void* pv);
+  virtual void get_referenceImpl(const std::type_info& ti, void* pv) const;
 
   using Base::activation_;
   using Base::state_;

--- a/include/crocoddyl/multibody/costs/impulse-friction-cone.hpp
+++ b/include/crocoddyl/multibody/costs/impulse-friction-cone.hpp
@@ -18,6 +18,7 @@
 #include "crocoddyl/multibody/frames.hpp"
 #include "crocoddyl/multibody/friction-cone.hpp"
 #include "crocoddyl/core/utils/exception.hpp"
+#include "crocoddyl/core/utils/deprecate.hpp"
 
 namespace crocoddyl {
 
@@ -55,8 +56,8 @@ class CostModelImpulseFrictionConeTpl : public CostModelAbstractTpl<_Scalar> {
                         const Eigen::Ref<const VectorXs>& u);
   virtual boost::shared_ptr<CostDataAbstract> createData(DataCollectorAbstract* const data);
 
-  const FrameFrictionCone& get_fref() const;
-  void set_fref(const FrameFrictionCone& fref);
+  DEPRECATED("Use set_reference<FrameFrictionConeTpl<Scalar> >()", void set_fref(const FrameFrictionCone& fref);)
+  DEPRECATED("Use get_reference<FrameFrictionConeTpl<Scalar> >()", const FrameFrictionCone& get_fref() const;)
 
  protected:
   virtual void set_referenceImpl(const std::type_info& ti, const void* pv);
@@ -94,7 +95,7 @@ struct CostDataImpulseFrictionConeTpl : public CostDataAbstractTpl<_Scalar> {
     }
 
     // Avoids data casting at runtime
-    const FrameFrictionCone& fref = model->get_fref();
+    FrameFrictionCone fref = model->template get_reference<FrameFrictionCone>();
     std::string frame_name = model->get_state()->get_pinocchio()->frames[fref.frame].name;
     bool found_impulse = false;
     for (typename ImpulseModelMultiple::ImpulseDataContainer::iterator it = d->impulses->impulses.begin();

--- a/include/crocoddyl/multibody/costs/impulse-friction-cone.hxx
+++ b/include/crocoddyl/multibody/costs/impulse-friction-cone.hxx
@@ -80,7 +80,7 @@ void CostModelImpulseFrictionConeTpl<Scalar>::set_referenceImpl(const std::type_
 }
 
 template <typename Scalar>
-void CostModelImpulseFrictionConeTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) {
+void CostModelImpulseFrictionConeTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) const {
   if (ti == typeid(FrameFrictionCone)) {
     FrameFrictionCone& ref_map = *static_cast<FrameFrictionCone*>(pv);
     ref_map = fref_;

--- a/include/crocoddyl/multibody/costs/state.hpp
+++ b/include/crocoddyl/multibody/costs/state.hpp
@@ -12,6 +12,7 @@
 #include "crocoddyl/multibody/fwd.hpp"
 #include "crocoddyl/core/state-base.hpp"
 #include "crocoddyl/multibody/cost-base.hpp"
+#include "crocoddyl/core/utils/deprecate.hpp"
 
 namespace crocoddyl {
 
@@ -50,8 +51,8 @@ class CostModelStateTpl : public CostModelAbstractTpl<_Scalar> {
                         const Eigen::Ref<const VectorXs>& u);
   virtual boost::shared_ptr<CostDataAbstract> createData(DataCollectorAbstract* const data);
 
-  const VectorXs& get_xref() const;
-  void set_xref(const VectorXs& xref_in);
+  DEPRECATED("Use set_reference<MathBaseTpl<Scalar>::VectorXs>()", void set_xref(const VectorXs& xref_in);)
+  DEPRECATED("Use get_reference<MathBaseTpl<Scalar>::VectorXs>()", const VectorXs& get_xref() const;)
 
  protected:
   virtual void set_referenceImpl(const std::type_info& ti, const void* pv);

--- a/include/crocoddyl/multibody/costs/state.hpp
+++ b/include/crocoddyl/multibody/costs/state.hpp
@@ -55,7 +55,7 @@ class CostModelStateTpl : public CostModelAbstractTpl<_Scalar> {
 
  protected:
   virtual void set_referenceImpl(const std::type_info& ti, const void* pv);
-  virtual void get_referenceImpl(const std::type_info& ti, void* pv);
+  virtual void get_referenceImpl(const std::type_info& ti, void* pv) const;
 
   using Base::activation_;
   using Base::nu_;

--- a/include/crocoddyl/multibody/costs/state.hxx
+++ b/include/crocoddyl/multibody/costs/state.hxx
@@ -188,7 +188,7 @@ void CostModelStateTpl<Scalar>::set_referenceImpl(const std::type_info& ti, cons
 }
 
 template <typename Scalar>
-void CostModelStateTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) {
+void CostModelStateTpl<Scalar>::get_referenceImpl(const std::type_info& ti, void* pv) const {
   if (ti == typeid(VectorXs)) {
     VectorXs& tmp = *static_cast<VectorXs*>(pv);
     tmp.resize(state_->get_nx());


### PR DESCRIPTION
The `set_reference` and `get_reference` are here to avoid down casting in case you need to modify / retrieve them. This was merged before, but it seems to be not well known for everyone. To make a smooth transition for our users, I have create deprecated messages at both levels: c++ and Python.

I will make a new release after merging this PR, so we can notify users these deprecations.