### PR TITLE
Enable createData for Python derived classes

### DIFF
--- a/bindings/python/crocoddyl/core/action-base.cpp
+++ b/bindings/python/crocoddyl/core/action-base.cpp
@@ -53,7 +53,8 @@ void exposeActionAbstract() {
       .def<void (ActionModelAbstract::*)(const boost::shared_ptr<ActionDataAbstract>&,
                                          const Eigen::Ref<const Eigen::VectorXd>&)>(
           "calcDiff", &ActionModelAbstract::calcDiff, bp::args("self", "data", "x"))
-      .def("createData", &ActionModelAbstract_wrap::createData, bp::args("self"),
+      .def("createData", &ActionModelAbstract_wrap::createData, &ActionModelAbstract_wrap::default_createData,
+           bp::args("self"),
            "Create the action data.\n\n"
            "Each action model (AM) has its own data that needs to be allocated.\n"
            "This function returns the allocated data for a predefined AM.\n"

--- a/bindings/python/crocoddyl/core/action-base.hpp
+++ b/bindings/python/crocoddyl/core/action-base.hpp
@@ -45,6 +45,15 @@ class ActionModelAbstract_wrap : public ActionModelAbstract, public bp::wrapper<
     }
     return bp::call<void>(this->get_override("calcDiff").ptr(), data, (Eigen::VectorXd)x, (Eigen::VectorXd)u);
   }
+
+  boost::shared_ptr<ActionDataAbstract> createData() {
+    if (boost::python::override createData = this->get_override("createData")) {
+      return bp::call<boost::shared_ptr<ActionDataAbstract> >(createData.ptr());
+    }
+    return ActionModelAbstract::createData();
+  }
+
+  boost::shared_ptr<ActionDataAbstract> default_createData() { return this->ActionModelAbstract::createData(); }
 };
 
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(ActionModel_quasiStatic_wraps, ActionModelAbstract::quasiStatic_x, 2, 4)

--- a/bindings/python/crocoddyl/core/activation-base.cpp
+++ b/bindings/python/crocoddyl/core/activation-base.cpp
@@ -33,8 +33,8 @@ void exposeActivationAbstract() {
            "It computes the partial derivatives of the residual vector function\n"
            ":param data: activation data\n"
            ":param r: residual vector \n")
-      .def("createData", &ActivationModelAbstract_wrap::createData, bp::args("self"),
-           "Create the activation data.\n\n")
+      .def("createData", &ActivationModelAbstract_wrap::createData, &ActivationModelAbstract_wrap::default_createData,
+           bp::args("self"), "Create the activation data.\n\n")
       .add_property(
           "nr",
           bp::make_function(&ActivationModelAbstract_wrap::get_nr, bp::return_value_policy<bp::return_by_value>()),

--- a/bindings/python/crocoddyl/core/activation-base.hpp
+++ b/bindings/python/crocoddyl/core/activation-base.hpp
@@ -35,6 +35,17 @@ class ActivationModelAbstract_wrap : public ActivationModelAbstract, public bp::
     }
     return bp::call<void>(this->get_override("calcDiff").ptr(), data, (Eigen::VectorXd)r);
   }
+
+  boost::shared_ptr<ActivationDataAbstract> createData() {
+    if (boost::python::override createData = this->get_override("createData")) {
+      return bp::call<boost::shared_ptr<ActivationDataAbstract> >(createData.ptr());
+    }
+    return ActivationModelAbstract::createData();
+  }
+
+  boost::shared_ptr<ActivationDataAbstract> default_createData() {
+    return this->ActivationModelAbstract::createData();
+  }
 };
 
 }  // namespace python

--- a/bindings/python/crocoddyl/core/actuation-base.cpp
+++ b/bindings/python/crocoddyl/core/actuation-base.cpp
@@ -39,7 +39,8 @@ void exposeActuationAbstract() {
            ":param data: actuation data\n"
            ":param x: state vector\n"
            ":param u: control input\n")
-      .def("createData", &ActuationModelAbstract_wrap::createData, bp::args("self"),
+      .def("createData", &ActuationModelAbstract_wrap::createData, &ActuationModelAbstract_wrap::default_createData,
+           bp::args("self"),
            "Create the actuation data.\n\n"
            "Each actuation model (AM) has its own data that needs to be allocated.\n"
            "This function returns the allocated data for a predefined AM.\n"

--- a/bindings/python/crocoddyl/core/actuation-base.hpp
+++ b/bindings/python/crocoddyl/core/actuation-base.hpp
@@ -35,6 +35,15 @@ class ActuationModelAbstract_wrap : public ActuationModelAbstract, public bp::wr
     assert_pretty(static_cast<std::size_t>(u.size()) == nu_, "u has wrong dimension");
     return bp::call<void>(this->get_override("calcDiff").ptr(), data, (Eigen::VectorXd)x, (Eigen::VectorXd)u);
   }
+
+  boost::shared_ptr<ActuationDataAbstract> createData() {
+    if (boost::python::override createData = this->get_override("createData")) {
+      return bp::call<boost::shared_ptr<ActuationDataAbstract> >(createData.ptr());
+    }
+    return ActuationModelAbstract::createData();
+  }
+
+  boost::shared_ptr<ActuationDataAbstract> default_createData() { return this->ActuationModelAbstract::createData(); }
 };
 
 }  // namespace python

--- a/bindings/python/crocoddyl/core/diff-action-base.cpp
+++ b/bindings/python/crocoddyl/core/diff-action-base.cpp
@@ -51,7 +51,8 @@ void exposeDifferentialActionAbstract() {
       .def<void (DifferentialActionModelAbstract::*)(const boost::shared_ptr<DifferentialActionDataAbstract>&,
                                                      const Eigen::Ref<const Eigen::VectorXd>&)>(
           "calcDiff", &DifferentialActionModelAbstract::calcDiff, bp::args("self", "data", "x"))
-      .def("createData", &DifferentialActionModelAbstract_wrap::createData, bp::args("self"),
+      .def("createData", &DifferentialActionModelAbstract_wrap::createData,
+           &DifferentialActionModelAbstract_wrap::default_createData, bp::args("self"),
            "Create the differential action data.\n\n"
            "Each differential action model has its own data that needs to be\n"
            "allocated. This function returns the allocated data for a predefined\n"

--- a/bindings/python/crocoddyl/core/diff-action-base.hpp
+++ b/bindings/python/crocoddyl/core/diff-action-base.hpp
@@ -47,6 +47,17 @@ class DifferentialActionModelAbstract_wrap : public DifferentialActionModelAbstr
     }
     return bp::call<void>(this->get_override("calcDiff").ptr(), data, (Eigen::VectorXd)x, (Eigen::VectorXd)u);
   }
+
+  boost::shared_ptr<DifferentialActionDataAbstract> createData() {
+    if (boost::python::override createData = this->get_override("createData")) {
+      return bp::call<boost::shared_ptr<DifferentialActionDataAbstract> >(createData.ptr());
+    }
+    return DifferentialActionModelAbstract::createData();
+  }
+
+  boost::shared_ptr<DifferentialActionDataAbstract> default_createData() {
+    return this->DifferentialActionModelAbstract::createData();
+  }
 };
 
 }  // namespace python

--- a/bindings/python/crocoddyl/multibody/contact-base.cpp
+++ b/bindings/python/crocoddyl/multibody/contact-base.cpp
@@ -85,7 +85,7 @@ void exposeContactAbstract() {
       .add_property("pinocchio", bp::make_getter(&ContactDataAbstract::pinocchio, bp::return_internal_reference<>()),
                     "pinocchio data")
       .add_property("jMf", bp::make_getter(&ContactDataAbstract::jMf, bp::return_value_policy<bp::return_by_value>()),
-                    "local frame placement of the contact frame")
+                    bp::make_setter(&ContactDataAbstract::jMf), "local frame placement of the contact frame")
       .add_property("fXj", bp::make_getter(&ContactDataAbstract::fXj, bp::return_internal_reference<>()),
                     bp::make_setter(&ContactDataAbstract::fXj), "action matrix from contact to local frames")
       .add_property("Jc", bp::make_getter(&ContactDataAbstract::Jc, bp::return_internal_reference<>()),

--- a/bindings/python/crocoddyl/multibody/contact-base.cpp
+++ b/bindings/python/crocoddyl/multibody/contact-base.cpp
@@ -61,6 +61,7 @@ void exposeContactAbstract() {
            "returns the allocated data for a predefined contact.\n"
            ":param data: Pinocchio data\n"
            ":return contact data.")
+      .def("createData", &ContactModelAbstract_wrap::default_createData, bp::with_custodian_and_ward_postcall<0, 2>())
       .add_property(
           "state",
           bp::make_function(&ContactModelAbstract_wrap::get_state, bp::return_value_policy<bp::return_by_value>()),
@@ -85,8 +86,8 @@ void exposeContactAbstract() {
                     "pinocchio data")
       .add_property("jMf", bp::make_getter(&ContactDataAbstract::jMf, bp::return_value_policy<bp::return_by_value>()),
                     "local frame placement of the contact frame")
-      .add_property("fXj", bp::make_getter(&ContactDataAbstract::fXj, bp::return_value_policy<bp::return_by_value>()),
-                    "action matrix from contact to local frames")
+      .add_property("fXj", bp::make_getter(&ContactDataAbstract::fXj, bp::return_internal_reference<>()),
+                    bp::make_setter(&ContactDataAbstract::fXj), "action matrix from contact to local frames")
       .add_property("Jc", bp::make_getter(&ContactDataAbstract::Jc, bp::return_internal_reference<>()),
                     bp::make_setter(&ContactDataAbstract::Jc), "contact Jacobian")
       .add_property("a0", bp::make_getter(&ContactDataAbstract::a0, bp::return_internal_reference<>()),

--- a/bindings/python/crocoddyl/multibody/contact-base.hpp
+++ b/bindings/python/crocoddyl/multibody/contact-base.hpp
@@ -36,6 +36,17 @@ class ContactModelAbstract_wrap : public ContactModelAbstract, public bp::wrappe
     assert_pretty(static_cast<std::size_t>(force.size()) == nc_, "force has wrong dimension");
     return bp::call<void>(this->get_override("updateForce").ptr(), data, force);
   }
+
+  boost::shared_ptr<ContactDataAbstract> createData(pinocchio::DataTpl<Scalar>* const data) {
+    if (boost::python::override createData = this->get_override("createData")) {
+      return bp::call<boost::shared_ptr<ContactDataAbstract> >(createData.ptr(), boost::ref(data));
+    }
+    return ContactModelAbstract::createData(data);
+  }
+
+  boost::shared_ptr<ContactDataAbstract> default_createData(pinocchio::DataTpl<Scalar>* const data) {
+    return this->ContactModelAbstract::createData(data);
+  }
 };
 
 }  // namespace python

--- a/bindings/python/crocoddyl/multibody/cost-base.cpp
+++ b/bindings/python/crocoddyl/multibody/cost-base.cpp
@@ -67,6 +67,7 @@ void exposeCostAbstract() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.")
+      .def("createData", &CostModelAbstract_wrap::default_createData, bp::with_custodian_and_ward_postcall<0, 2>())
       .add_property(
           "state",
           bp::make_function(&CostModelAbstract_wrap::get_state, bp::return_value_policy<bp::return_by_value>()),

--- a/bindings/python/crocoddyl/multibody/cost-base.hpp
+++ b/bindings/python/crocoddyl/multibody/cost-base.hpp
@@ -47,7 +47,7 @@ class CostModelAbstract_wrap : public CostModelAbstract, public bp::wrapper<Cost
 
   boost::shared_ptr<CostDataAbstract> createData(DataCollectorAbstract* const data) {
     if (boost::python::override createData = this->get_override("createData")) {
-      return bp::call<boost::shared_ptr<CostDataAbstract> >(createData.ptr(), data);
+      return bp::call<boost::shared_ptr<CostDataAbstract> >(createData.ptr(), boost::ref(data));
     }
     return CostModelAbstract::createData(data);
   }

--- a/bindings/python/crocoddyl/multibody/cost-base.hpp
+++ b/bindings/python/crocoddyl/multibody/cost-base.hpp
@@ -44,6 +44,17 @@ class CostModelAbstract_wrap : public CostModelAbstract, public bp::wrapper<Cost
     assert_pretty((static_cast<std::size_t>(u.size()) == nu_ || nu_ == 0), "u has wrong dimension");
     return bp::call<void>(this->get_override("calcDiff").ptr(), data, (Eigen::VectorXd)x, (Eigen::VectorXd)u);
   }
+
+  boost::shared_ptr<CostDataAbstract> createData(DataCollectorAbstract* const data) {
+    if (boost::python::override createData = this->get_override("createData")) {
+      return bp::call<boost::shared_ptr<CostDataAbstract> >(createData.ptr(), data);
+    }
+    return CostModelAbstract::createData(data);
+  }
+
+  boost::shared_ptr<CostDataAbstract> default_createData(DataCollectorAbstract* const data) {
+    return this->CostModelAbstract::createData(data);
+  }
 };
 
 }  // namespace python

--- a/bindings/python/crocoddyl/multibody/costs/control.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/control.cpp
@@ -77,6 +77,13 @@ void exposeCostControl() {
       .def<void (CostModelControl::*)(const boost::shared_ptr<CostDataAbstract>&,
                                       const Eigen::Ref<const Eigen::VectorXd>&)>(
           "calcDiff", &CostModelAbstract::calcDiff, bp::args("self", "data", "x"))
+      .def("createData", &CostModelControl::createData, bp::with_custodian_and_ward_postcall<0, 2>(),
+           bp::args("self", "data"),
+           "Create the control cost data.\n\n"
+           "Each cost model has its own data that needs to be allocated. This function\n"
+           "returns the allocated data for a predefined cost.\n"
+           ":param data: shared data\n"
+           ":return cost data.")
       .add_property("reference", &CostModelControl::get_reference<Eigen::VectorXd>,
                     &CostModelControl::set_reference<Eigen::VectorXd>, "reference control vector")
       .add_property("uref",

--- a/bindings/python/crocoddyl/multibody/impulse-base.cpp
+++ b/bindings/python/crocoddyl/multibody/impulse-base.cpp
@@ -54,6 +54,7 @@ void exposeImpulseAbstract() {
            "returns the allocated data for a predefined impulse.\n"
            ":param data: Pinocchio data\n"
            ":return impulse data.")
+      .def("createData", &ImpulseModelAbstract_wrap::default_createData, bp::with_custodian_and_ward_postcall<0, 2>())
       .add_property(
           "state",
           bp::make_function(&ImpulseModelAbstract_wrap::get_state, bp::return_value_policy<bp::return_by_value>()),
@@ -74,7 +75,7 @@ void exposeImpulseAbstract() {
       .add_property("pinocchio", bp::make_getter(&ImpulseDataAbstract::pinocchio, bp::return_internal_reference<>()),
                     "pinocchio data")
       .add_property("jMf", bp::make_getter(&ImpulseDataAbstract::jMf, bp::return_value_policy<bp::return_by_value>()),
-                    "local frame placement of the impulse frame")
+                    bp::make_setter(&ImpulseDataAbstract::jMf), "local frame placement of the impulse frame")
       .add_property("Jc", bp::make_getter(&ImpulseDataAbstract::Jc, bp::return_internal_reference<>()),
                     bp::make_setter(&ImpulseDataAbstract::Jc), "impulse Jacobian")
       .add_property("dv0_dq", bp::make_getter(&ImpulseDataAbstract::dv0_dq, bp::return_internal_reference<>()),

--- a/bindings/python/crocoddyl/multibody/impulse-base.hpp
+++ b/bindings/python/crocoddyl/multibody/impulse-base.hpp
@@ -34,6 +34,17 @@ class ImpulseModelAbstract_wrap : public ImpulseModelAbstract, public bp::wrappe
     assert_pretty(static_cast<std::size_t>(force.size()) == ni_, "force has wrong dimension");
     return bp::call<void>(this->get_override("updateForce").ptr(), data, force);
   }
+
+  boost::shared_ptr<ImpulseDataAbstract> createData(pinocchio::DataTpl<Scalar>* const data) {
+    if (boost::python::override createData = this->get_override("createData")) {
+      return bp::call<boost::shared_ptr<ImpulseDataAbstract> >(createData.ptr(), boost::ref(data));
+    }
+    return ImpulseModelAbstract::createData(data);
+  }
+
+  boost::shared_ptr<ImpulseDataAbstract> default_createData(pinocchio::DataTpl<Scalar>* const data) {
+    return this->ImpulseModelAbstract::createData(data);
+  }
 };
 
 }  // namespace python

--- a/bindings/python/crocoddyl/utils/__init__.py
+++ b/bindings/python/crocoddyl/utils/__init__.py
@@ -153,11 +153,10 @@ class FreeFloatingActuationDerived(crocoddyl.ActuationModelAbstract):
         crocoddyl.ActuationModelAbstract.__init__(self, state, state.nv - 6)
 
     def calc(self, data, x, u):
-        data.tau = np.vstack([pinocchio.utils.zero(6), u])
+        data.tau[:] = np.hstack([np.zeros(6), u])
 
     def calcDiff(self, data, x, u):
-        dtau_du = np.vstack([pinocchio.utils.zero((6, self.nu)), pinocchio.utils.eye(self.nu)])
-        data.dtau_du = dtau_du
+        data.dtau_du[:, :] = np.vstack([np.zeros((6, self.nu)), np.eye(self.nu)])
 
 
 class FullActuationDerived(crocoddyl.ActuationModelAbstract):
@@ -166,10 +165,10 @@ class FullActuationDerived(crocoddyl.ActuationModelAbstract):
         crocoddyl.ActuationModelAbstract.__init__(self, state, state.nv)
 
     def calc(self, data, x, u):
-        data.tau = u
+        data.tau[:] = u
 
     def calcDiff(self, data, x, u):
-        data.dtau_du = pinocchio.utils.eye(self.nu)
+        data.dtau_du[:, :] = pinocchio.utils.eye(self.nu)
 
 
 class UnicycleModelDerived(crocoddyl.ActionModelAbstract):

--- a/bindings/python/crocoddyl/utils/pendulum.py
+++ b/bindings/python/crocoddyl/utils/pendulum.py
@@ -42,18 +42,21 @@ class ActuationModelDoublePendulum(crocoddyl.ActuationModelAbstract):
         self.actLink = actLink
 
     def calc(self, data, x, u):
-        S = pinocchio.utils.zero((self.nv, self.nu))
-        if self.actLink == 1:
-            S[0] = 1
-        else:
-            S[1] = 1
-        data.tau = S * u
+        data.tau = data.S * u
 
     def calcDiff(self, data, x, u):
-        S = np.zeros((self.nv, self.nu))
-        if self.actLink == 1:
-            S[0] = 1
-        else:
-            S[1] = 1
+        data.dtau_du = data.S
 
-        data.dtau_du = S
+    def createData(self):
+        data = ActuationDataDoublePendulum(self)
+        return data
+
+
+class ActuationDataDoublePendulum(crocoddyl.ActuationDataAbstract):
+    def __init__(self, model):
+        crocoddyl.ActuationDataAbstract.__init__(self, model)
+        self.S = np.zeros((model.nv, model.nu))
+        if model.actLink == 1:
+            self.S[0] = 1
+        else:
+            self.S[1] = 1

--- a/bindings/python/crocoddyl/utils/pendulum.py
+++ b/bindings/python/crocoddyl/utils/pendulum.py
@@ -21,18 +21,28 @@ class CostModelDoublePendulum(crocoddyl.CostModelAbstract):
 
         self.activation.calcDiff(data.activation, data.r)
 
-        J = pinocchio.utils.zero((6, 4))
-        J[:2, :2] = np.diag([c1, c2])
-        J[2:4, :2] = np.diag([s1, s2])
-        J[4:6, 2:4] = np.diag([1, 1])
-        data.Lx = np.dot(J.T, data.activation.Ar)
+        data.J[:2, :2] = np.diag([c1, c2])
+        data.J[2:4, :2] = np.diag([s1, s2])
+        data.J[4:6, 2:4] = np.diag([1, 1])
+        data.Lx = np.dot(data.J.T, data.activation.Ar)
 
-        H = pinocchio.utils.zero((6, 4))
-        H[:2, :2] = np.diag([c1**2 - s1**2, c2**2 - s2**2])
-        H[2:4, :2] = np.diag([s1**2 + (1 - c1) * c1, s2**2 + (1 - c2) * c2])
-        H[4:6, 2:4] = np.diag([1, 1])
-        Lxx = np.dot(H.T, np.diag(data.activation.Arr))
+        data.H[:2, :2] = np.diag([c1**2 - s1**2, c2**2 - s2**2])
+        data.H[2:4, :2] = np.diag([s1**2 + (1 - c1) * c1, s2**2 + (1 - c2) * c2])
+        data.H[4:6, 2:4] = np.diag([1, 1])
+        Lxx = np.dot(data.H.T, np.diag(data.activation.Arr))
         data.Lxx = np.diag(Lxx)
+
+    def createData(self, collector):
+        print collector
+        data = CostDataDoublePendulum(self, collector)
+        return data
+
+
+class CostDataDoublePendulum(crocoddyl.CostDataAbstract):
+    def __init__(self, model, collector):
+        crocoddyl.CostDataAbstract.__init__(self, model, collector)
+        self.J = np.zeros((6, 4))
+        self.H = np.zeros((6, 4))
 
 
 class ActuationModelDoublePendulum(crocoddyl.ActuationModelAbstract):

--- a/unittest/bindings/test_actions.py
+++ b/unittest/bindings/test_actions.py
@@ -10,7 +10,6 @@ import pinocchio
 from crocoddyl.utils import DifferentialFreeFwdDynamicsModelDerived, DifferentialLQRModelDerived, LQRModelDerived, UnicycleModelDerived
 
 
-
 class ActionModelAbstractTestCase(unittest.TestCase):
     MODEL = None
     MODEL_DER = None

--- a/unittest/bindings/test_actions.py
+++ b/unittest/bindings/test_actions.py
@@ -9,7 +9,6 @@ import crocoddyl
 import pinocchio
 from crocoddyl.utils import DifferentialFreeFwdDynamicsModelDerived, DifferentialLQRModelDerived, LQRModelDerived, UnicycleModelDerived
 
-pinocchio.switchToNumpyMatrix()
 
 
 class ActionModelAbstractTestCase(unittest.TestCase):
@@ -19,7 +18,7 @@ class ActionModelAbstractTestCase(unittest.TestCase):
     def setUp(self):
         state = self.MODEL.state
         self.x = state.rand()
-        self.u = np.matrix(np.random.rand(self.MODEL.nu)).T
+        self.u = np.random.rand(self.MODEL.nu)
         self.DATA = self.MODEL.createData()
         self.DATA_DER = self.MODEL_DER.createData()
 
@@ -71,15 +70,15 @@ class UnicycleTest(ActionModelAbstractTestCase):
 
 
 class LQRTest(ActionModelAbstractTestCase):
-    NX = randint(1, 21)
-    NU = randint(1, NX)
+    NX = randint(2, 21)
+    NU = randint(2, NX)
     MODEL = crocoddyl.ActionModelLQR(NX, NU)
     MODEL_DER = LQRModelDerived(NX, NU)
 
 
 class DifferentialLQRTest(ActionModelAbstractTestCase):
-    NX = randint(1, 21)
-    NU = randint(1, NX)
+    NX = randint(2, 21)
+    NU = randint(2, NX)
     MODEL = crocoddyl.DifferentialActionModelLQR(NX, NU)
     MODEL_DER = DifferentialLQRModelDerived(NX, NU)
 
@@ -114,8 +113,8 @@ class TalosArmFreeFwdDynamicsWithArmatureTest(ActionModelAbstractTestCase):
     COST_SUM.addCost("uReg", crocoddyl.CostModelControl(STATE), 1e-7)
     MODEL = crocoddyl.DifferentialActionModelFreeFwdDynamics(STATE, ACTUATION, COST_SUM)
     MODEL_DER = DifferentialFreeFwdDynamicsModelDerived(STATE, ACTUATION, COST_SUM)
-    MODEL.armature = 0.1 * np.matrix(np.ones(ROBOT_MODEL.nv)).T
-    MODEL_DER.set_armature(0.1 * np.matrix(np.ones(ROBOT_MODEL.nv)).T)
+    MODEL.armature = 0.1 * np.ones(ROBOT_MODEL.nv)
+    MODEL_DER.set_armature(0.1 * np.ones(ROBOT_MODEL.nv))
 
 
 class AnymalFreeFwdDynamicsTest(ActionModelAbstractTestCase):

--- a/unittest/bindings/test_actions.py
+++ b/unittest/bindings/test_actions.py
@@ -7,7 +7,7 @@ import numpy as np
 
 import crocoddyl
 import pinocchio
-from crocoddyl.utils import DifferentialFreeFwdDynamicsDerived, DifferentialLQRDerived, LQRDerived, UnicycleDerived
+from crocoddyl.utils import DifferentialFreeFwdDynamicsModelDerived, DifferentialLQRModelDerived, LQRModelDerived, UnicycleModelDerived
 
 pinocchio.switchToNumpyMatrix()
 
@@ -67,21 +67,21 @@ class ActionModelAbstractTestCase(unittest.TestCase):
 
 class UnicycleTest(ActionModelAbstractTestCase):
     MODEL = crocoddyl.ActionModelUnicycle()
-    MODEL_DER = UnicycleDerived()
+    MODEL_DER = UnicycleModelDerived()
 
 
 class LQRTest(ActionModelAbstractTestCase):
     NX = randint(1, 21)
     NU = randint(1, NX)
     MODEL = crocoddyl.ActionModelLQR(NX, NU)
-    MODEL_DER = LQRDerived(NX, NU)
+    MODEL_DER = LQRModelDerived(NX, NU)
 
 
 class DifferentialLQRTest(ActionModelAbstractTestCase):
     NX = randint(1, 21)
     NU = randint(1, NX)
     MODEL = crocoddyl.DifferentialActionModelLQR(NX, NU)
-    MODEL_DER = DifferentialLQRDerived(NX, NU)
+    MODEL_DER = DifferentialLQRModelDerived(NX, NU)
 
 
 class TalosArmFreeFwdDynamicsTest(ActionModelAbstractTestCase):
@@ -97,7 +97,7 @@ class TalosArmFreeFwdDynamicsTest(ActionModelAbstractTestCase):
     COST_SUM.addCost("xReg", crocoddyl.CostModelState(STATE), 1e-7)
     COST_SUM.addCost("uReg", crocoddyl.CostModelControl(STATE), 1e-7)
     MODEL = crocoddyl.DifferentialActionModelFreeFwdDynamics(STATE, ACTUATION, COST_SUM)
-    MODEL_DER = DifferentialFreeFwdDynamicsDerived(STATE, ACTUATION, COST_SUM)
+    MODEL_DER = DifferentialFreeFwdDynamicsModelDerived(STATE, ACTUATION, COST_SUM)
 
 
 class TalosArmFreeFwdDynamicsWithArmatureTest(ActionModelAbstractTestCase):
@@ -113,7 +113,7 @@ class TalosArmFreeFwdDynamicsWithArmatureTest(ActionModelAbstractTestCase):
     COST_SUM.addCost("xReg", crocoddyl.CostModelState(STATE), 1e-7)
     COST_SUM.addCost("uReg", crocoddyl.CostModelControl(STATE), 1e-7)
     MODEL = crocoddyl.DifferentialActionModelFreeFwdDynamics(STATE, ACTUATION, COST_SUM)
-    MODEL_DER = DifferentialFreeFwdDynamicsDerived(STATE, ACTUATION, COST_SUM)
+    MODEL_DER = DifferentialFreeFwdDynamicsModelDerived(STATE, ACTUATION, COST_SUM)
     MODEL.armature = 0.1 * np.matrix(np.ones(ROBOT_MODEL.nv)).T
     MODEL_DER.set_armature(0.1 * np.matrix(np.ones(ROBOT_MODEL.nv)).T)
 
@@ -126,7 +126,7 @@ class AnymalFreeFwdDynamicsTest(ActionModelAbstractTestCase):
     COST_SUM.addCost("xReg", crocoddyl.CostModelState(STATE, ACTUATION.nu), 1e-7)
     COST_SUM.addCost("uReg", crocoddyl.CostModelControl(STATE, ACTUATION.nu), 1e-7)
     MODEL = crocoddyl.DifferentialActionModelFreeFwdDynamics(STATE, ACTUATION, COST_SUM)
-    MODEL_DER = DifferentialFreeFwdDynamicsDerived(STATE, ACTUATION, COST_SUM)
+    MODEL_DER = DifferentialFreeFwdDynamicsModelDerived(STATE, ACTUATION, COST_SUM)
 
 
 if __name__ == '__main__':

--- a/unittest/bindings/test_actuations.py
+++ b/unittest/bindings/test_actuations.py
@@ -8,7 +8,6 @@ import pinocchio
 from crocoddyl.utils import FreeFloatingActuationDerived, FullActuationDerived
 import example_robot_data
 
-crocoddyl.switchToNumpyMatrix()
 
 
 class ActuationModelAbstractTestCase(unittest.TestCase):

--- a/unittest/bindings/test_actuations.py
+++ b/unittest/bindings/test_actuations.py
@@ -9,7 +9,6 @@ from crocoddyl.utils import FreeFloatingActuationDerived, FullActuationDerived
 import example_robot_data
 
 
-
 class ActuationModelAbstractTestCase(unittest.TestCase):
     STATE = None
     ACTUATION = None

--- a/unittest/bindings/test_contacts.py
+++ b/unittest/bindings/test_contacts.py
@@ -7,9 +7,8 @@ import numpy as np
 
 import crocoddyl
 import pinocchio
-from crocoddyl.utils import Contact3DDerived, Contact6DDerived
+from crocoddyl.utils import Contact3DModelDerived, Contact6DModelDerived
 
-pinocchio.switchToNumpyMatrix()
 
 
 class ContactModelAbstractTestCase(unittest.TestCase):
@@ -89,7 +88,7 @@ class ContactModelMultipleAbstractTestCase(unittest.TestCase):
         self.contactSum.calc(self.dataSum, self.x)
         # Checking the cost value and its residual
         Jc = np.vstack([data.Jc for data in self.datas.values()])
-        a0 = np.vstack([data.a0 for data in self.datas.values()])
+        a0 = np.hstack([data.a0 for data in self.datas.values()])
         self.assertTrue(np.allclose(self.dataSum.Jc, Jc, atol=1e-9), "Wrong contact Jacobian (Jc).")
         self.assertTrue(np.allclose(self.dataSum.a0, a0, atol=1e-9), "Wrong drift acceleration (a0).")
 
@@ -113,7 +112,7 @@ class Contact3DTest(ContactModelAbstractTestCase):
     gains = pinocchio.utils.rand(2)
     xref = crocoddyl.FrameTranslation(ROBOT_MODEL.getFrameId('lf_foot'), pinocchio.SE3.Random().translation)
     CONTACT = crocoddyl.ContactModel3D(ROBOT_STATE, xref, gains)
-    CONTACT_DER = Contact3DDerived(ROBOT_STATE, xref, gains)
+    CONTACT_DER = Contact3DModelDerived(ROBOT_STATE, xref, gains)
 
 
 class Contact3DMultipleTest(ContactModelMultipleAbstractTestCase):
@@ -143,7 +142,7 @@ class Contact6DTest(ContactModelAbstractTestCase):
     gains = pinocchio.utils.rand(2)
     Mref = crocoddyl.FramePlacement(ROBOT_MODEL.getFrameId('r_sole'), pinocchio.SE3.Random())
     CONTACT = crocoddyl.ContactModel6D(ROBOT_STATE, Mref, gains)
-    CONTACT_DER = Contact6DDerived(ROBOT_STATE, Mref, gains)
+    CONTACT_DER = Contact6DModelDerived(ROBOT_STATE, Mref, gains)
 
 
 class Contact6DMultipleTest(ContactModelMultipleAbstractTestCase):

--- a/unittest/bindings/test_contacts.py
+++ b/unittest/bindings/test_contacts.py
@@ -10,7 +10,6 @@ import pinocchio
 from crocoddyl.utils import Contact3DModelDerived, Contact6DModelDerived
 
 
-
 class ContactModelAbstractTestCase(unittest.TestCase):
     ROBOT_MODEL = None
     ROBOT_STATE = None

--- a/unittest/bindings/test_costs.py
+++ b/unittest/bindings/test_costs.py
@@ -10,8 +10,6 @@ from crocoddyl.utils import (CoMPositionCostModelDerived, ControlCostModelDerive
                              FrameRotationCostModelDerived, FrameTranslationCostModelDerived,
                              FrameVelocityCostModelDerived, StateCostModelDerived)
 
-crocoddyl.switchToNumpyMatrix()
-
 
 class CostModelAbstractTestCase(unittest.TestCase):
     ROBOT_MODEL = None

--- a/unittest/bindings/test_costs.py
+++ b/unittest/bindings/test_costs.py
@@ -6,9 +6,9 @@ import numpy as np
 
 import crocoddyl
 import pinocchio
-from crocoddyl.utils import (CoMPositionCostDerived, ControlCostDerived, FramePlacementCostDerived,
-                             FrameRotationCostDerived, FrameTranslationCostDerived, FrameVelocityCostDerived,
-                             StateCostDerived)
+from crocoddyl.utils import (CoMPositionCostModelDerived, ControlCostModelDerived, FramePlacementCostModelDerived,
+                             FrameRotationCostModelDerived, FrameTranslationCostModelDerived,
+                             FrameVelocityCostModelDerived, StateCostModelDerived)
 
 crocoddyl.switchToNumpyMatrix()
 
@@ -136,7 +136,7 @@ class StateCostTest(CostModelAbstractTestCase):
     ROBOT_STATE = crocoddyl.StateMultibody(ROBOT_MODEL)
 
     COST = crocoddyl.CostModelState(ROBOT_STATE)
-    COST_DER = StateCostDerived(ROBOT_STATE)
+    COST_DER = StateCostModelDerived(ROBOT_STATE)
 
 
 class StateCostSumTest(CostModelSumTestCase):
@@ -151,7 +151,7 @@ class ControlCostTest(CostModelAbstractTestCase):
     ROBOT_STATE = crocoddyl.StateMultibody(ROBOT_MODEL)
 
     COST = crocoddyl.CostModelControl(ROBOT_STATE)
-    COST_DER = ControlCostDerived(ROBOT_STATE)
+    COST_DER = ControlCostModelDerived(ROBOT_STATE)
 
 
 class ControlCostSumTest(CostModelSumTestCase):
@@ -167,7 +167,7 @@ class CoMPositionCostTest(CostModelAbstractTestCase):
 
     cref = pinocchio.utils.rand(3)
     COST = crocoddyl.CostModelCoMPosition(ROBOT_STATE, cref)
-    COST_DER = CoMPositionCostDerived(ROBOT_STATE, cref=cref)
+    COST_DER = CoMPositionCostModelDerived(ROBOT_STATE, cref=cref)
 
 
 class CoMPositionCostSumTest(CostModelSumTestCase):
@@ -184,7 +184,7 @@ class FramePlacementCostTest(CostModelAbstractTestCase):
 
     Mref = crocoddyl.FramePlacement(ROBOT_MODEL.getFrameId('r_sole'), pinocchio.SE3.Random())
     COST = crocoddyl.CostModelFramePlacement(ROBOT_STATE, Mref)
-    COST_DER = FramePlacementCostDerived(ROBOT_STATE, Mref=Mref)
+    COST_DER = FramePlacementCostModelDerived(ROBOT_STATE, Mref=Mref)
 
 
 class FramePlacementCostSumTest(CostModelSumTestCase):
@@ -201,7 +201,7 @@ class FrameTranslationCostTest(CostModelAbstractTestCase):
 
     xref = crocoddyl.FrameTranslation(ROBOT_MODEL.getFrameId('r_sole'), pinocchio.utils.rand(3))
     COST = crocoddyl.CostModelFrameTranslation(ROBOT_STATE, xref)
-    COST_DER = FrameTranslationCostDerived(ROBOT_STATE, xref=xref)
+    COST_DER = FrameTranslationCostModelDerived(ROBOT_STATE, xref=xref)
 
 
 class FrameTranslationCostSumTest(CostModelSumTestCase):
@@ -218,7 +218,7 @@ class FrameRotationCostTest(CostModelAbstractTestCase):
 
     Rref = crocoddyl.FrameRotation(ROBOT_MODEL.getFrameId('r_sole'), pinocchio.SE3.Random().rotation)
     COST = crocoddyl.CostModelFrameRotation(ROBOT_STATE, Rref)
-    COST_DER = FrameRotationCostDerived(ROBOT_STATE, Rref=Rref)
+    COST_DER = FrameRotationCostModelDerived(ROBOT_STATE, Rref=Rref)
 
 
 class FrameRotationCostSumTest(CostModelSumTestCase):
@@ -235,7 +235,7 @@ class FrameVelocityCostTest(CostModelAbstractTestCase):
 
     vref = crocoddyl.FrameMotion(ROBOT_MODEL.getFrameId('r_sole'), pinocchio.Motion.Random())
     COST = crocoddyl.CostModelFrameVelocity(ROBOT_STATE, vref)
-    COST_DER = FrameVelocityCostDerived(ROBOT_STATE, vref=vref)
+    COST_DER = FrameVelocityCostModelDerived(ROBOT_STATE, vref=vref)
 
 
 class FrameVelocityCostSumTest(CostModelSumTestCase):

--- a/unittest/bindings/test_force_cost.py
+++ b/unittest/bindings/test_force_cost.py
@@ -3,7 +3,6 @@ import example_robot_data
 import pinocchio
 from test_utils import NUMDIFF_MODIFIER, assertNumDiff
 
-crocoddyl.switchToNumpyMatrix()
 
 # Create robot model and data
 ROBOT_MODEL = example_robot_data.loadICub().model

--- a/unittest/bindings/test_force_cost.py
+++ b/unittest/bindings/test_force_cost.py
@@ -3,7 +3,6 @@ import example_robot_data
 import pinocchio
 from test_utils import NUMDIFF_MODIFIER, assertNumDiff
 
-
 # Create robot model and data
 ROBOT_MODEL = example_robot_data.loadICub().model
 ROBOT_DATA = ROBOT_MODEL.createData()

--- a/unittest/bindings/test_impulse_com_cost.py
+++ b/unittest/bindings/test_impulse_com_cost.py
@@ -4,7 +4,6 @@ import example_robot_data
 
 from test_utils import NUMDIFF_MODIFIER, assertNumDiff
 
-crocoddyl.switchToNumpyMatrix()
 
 # Create robot model and data
 ROBOT_MODEL = example_robot_data.loadICub().model

--- a/unittest/bindings/test_impulse_com_cost.py
+++ b/unittest/bindings/test_impulse_com_cost.py
@@ -4,7 +4,6 @@ import example_robot_data
 
 from test_utils import NUMDIFF_MODIFIER, assertNumDiff
 
-
 # Create robot model and data
 ROBOT_MODEL = example_robot_data.loadICub().model
 ROBOT_DATA = ROBOT_MODEL.createData()

--- a/unittest/bindings/test_impulses.py
+++ b/unittest/bindings/test_impulses.py
@@ -7,9 +7,7 @@ import numpy as np
 
 import crocoddyl
 import pinocchio
-from crocoddyl.utils import Impulse3DDerived, Impulse6DDerived
-
-pinocchio.switchToNumpyMatrix()
+from crocoddyl.utils import Impulse3DModelDerived, Impulse6DModelDerived
 
 
 class ImpulseModelAbstractTestCase(unittest.TestCase):
@@ -111,7 +109,7 @@ class Impulse3DTest(ImpulseModelAbstractTestCase):
     # gains = pinocchio.utils.rand(2)
     frame = ROBOT_MODEL.getFrameId('lf_foot')
     IMPULSE = crocoddyl.ImpulseModel3D(ROBOT_STATE, frame)
-    IMPULSE_DER = Impulse3DDerived(ROBOT_STATE, frame)
+    IMPULSE_DER = Impulse3DModelDerived(ROBOT_STATE, frame)
 
 
 class Impulse3DMultipleTest(ImpulseModelMultipleAbstractTestCase):
@@ -132,7 +130,7 @@ class Impulse6DTest(ImpulseModelAbstractTestCase):
 
     frame = ROBOT_MODEL.getFrameId('r_sole')
     IMPULSE = crocoddyl.ImpulseModel6D(ROBOT_STATE, frame)
-    IMPULSE_DER = Impulse6DDerived(ROBOT_STATE, frame)
+    IMPULSE_DER = Impulse6DModelDerived(ROBOT_STATE, frame)
 
 
 class Impulse6DMultipleTest(ImpulseModelMultipleAbstractTestCase):

--- a/unittest/bindings/test_shooting.py
+++ b/unittest/bindings/test_shooting.py
@@ -7,7 +7,7 @@ import numpy as np
 
 import crocoddyl
 import pinocchio
-from crocoddyl.utils import DifferentialFreeFwdDynamicsDerived, UnicycleDerived
+from crocoddyl.utils import DifferentialFreeFwdDynamicsModelDerived, UnicycleModelDerived
 
 pinocchio.switchToNumpyMatrix()
 
@@ -22,7 +22,7 @@ class ShootingProblemTestCase(unittest.TestCase):
         self.xs = []
         self.us = []
         self.xs.append(state.rand())
-        for i in range(self.T):
+        for _ in range(self.T):
             self.xs.append(state.rand())
             self.us.append(np.matrix(np.random.rand(self.MODEL.nu)).T)
         self.PROBLEM = crocoddyl.ShootingProblem(self.xs[0], [self.MODEL] * self.T, self.MODEL)
@@ -66,7 +66,7 @@ class ShootingProblemTestCase(unittest.TestCase):
 
 class UnicycleShootingTest(ShootingProblemTestCase):
     MODEL = crocoddyl.ActionModelUnicycle()
-    MODEL_DER = UnicycleDerived()
+    MODEL_DER = UnicycleModelDerived()
 
 
 class TalosArmShootingTest(ShootingProblemTestCase):
@@ -82,7 +82,7 @@ class TalosArmShootingTest(ShootingProblemTestCase):
     COST_SUM.addCost("xReg", crocoddyl.CostModelState(STATE), 1e-7)
     COST_SUM.addCost("uReg", crocoddyl.CostModelControl(STATE), 1e-7)
     DIFF_MODEL = crocoddyl.DifferentialActionModelFreeFwdDynamics(STATE, ACTUATION, COST_SUM)
-    DIFF_MODEL_DER = DifferentialFreeFwdDynamicsDerived(STATE, ACTUATION, COST_SUM)
+    DIFF_MODEL_DER = DifferentialFreeFwdDynamicsModelDerived(STATE, ACTUATION, COST_SUM)
     MODEL = crocoddyl.IntegratedActionModelEuler(DIFF_MODEL, 1e-3)
     MODEL_DER = crocoddyl.IntegratedActionModelEuler(DIFF_MODEL_DER, 1e-3)
 

--- a/unittest/bindings/test_shooting.py
+++ b/unittest/bindings/test_shooting.py
@@ -9,8 +9,6 @@ import crocoddyl
 import pinocchio
 from crocoddyl.utils import DifferentialFreeFwdDynamicsModelDerived, UnicycleModelDerived
 
-pinocchio.switchToNumpyMatrix()
-
 
 class ShootingProblemTestCase(unittest.TestCase):
     MODEL = None

--- a/unittest/bindings/test_solvers.py
+++ b/unittest/bindings/test_solvers.py
@@ -9,8 +9,6 @@ import crocoddyl
 import pinocchio
 from crocoddyl.utils import DDPDerived, FDDPDerived
 
-pinocchio.switchToNumpyMatrix()
-
 
 class SolverAbstractTestCase(unittest.TestCase):
     MODEL = None
@@ -24,9 +22,9 @@ class SolverAbstractTestCase(unittest.TestCase):
         self.xs = []
         self.us = []
         self.xs.append(state.rand())
-        for i in range(self.T):
+        for _ in range(self.T):
             self.xs.append(state.rand())
-            self.us.append(pinocchio.utils.rand(self.MODEL.nu))
+            self.us.append(np.random.rand(self.MODEL.nu))
         self.PROBLEM = crocoddyl.ShootingProblem(self.xs[0], [self.MODEL] * self.T, self.MODEL)
         self.PROBLEM_DER = crocoddyl.ShootingProblem(self.xs[0], [self.MODEL] * self.T, self.MODEL)
         self.solver = self.SOLVER(self.PROBLEM)

--- a/unittest/bindings/test_squashing.py
+++ b/unittest/bindings/test_squashing.py
@@ -8,7 +8,6 @@ import pinocchio
 from crocoddyl.utils import (SquashingSmoothSatDerived)
 
 
-
 class SquashingModelAbstractTestCase(unittest.TestCase):
     SQUASHING = None
     SQUASHING_DER = None

--- a/unittest/bindings/test_squashing.py
+++ b/unittest/bindings/test_squashing.py
@@ -7,7 +7,6 @@ import crocoddyl
 import pinocchio
 from crocoddyl.utils import (SquashingSmoothSatDerived)
 
-crocoddyl.switchToNumpyMatrix()
 
 
 class SquashingModelAbstractTestCase(unittest.TestCase):

--- a/unittest/bindings/test_states.py
+++ b/unittest/bindings/test_states.py
@@ -9,7 +9,6 @@ import crocoddyl
 from crocoddyl.utils import StateMultibodyDerived, StateVectorDerived
 
 
-
 class StateAbstractTestCase(unittest.TestCase):
     NX = None
     NDX = None
@@ -24,10 +23,10 @@ class StateAbstractTestCase(unittest.TestCase):
         self.assertEqual(self.STATE.nv, self.STATE_DER.nv, "Wrong nv value.")
 
         # Checking the dimension of zero and random states
-        self.assertEqual(self.STATE.zero().shape, (self.NX,), "Wrong dimension of zero state.")
-        self.assertEqual(self.STATE.rand().shape, (self.NX,), "Wrong dimension of random state.")
-        self.assertEqual(self.STATE.lb.shape, (self.NX,), "Wrong dimension of lower bound.")
-        self.assertEqual(self.STATE.ub.shape, (self.NX,), "Wrong dimension of lower bound.")
+        self.assertEqual(self.STATE.zero().shape, (self.NX, ), "Wrong dimension of zero state.")
+        self.assertEqual(self.STATE.rand().shape, (self.NX, ), "Wrong dimension of random state.")
+        self.assertEqual(self.STATE.lb.shape, (self.NX, ), "Wrong dimension of lower bound.")
+        self.assertEqual(self.STATE.ub.shape, (self.NX, ), "Wrong dimension of lower bound.")
 
     def test_python_derived_diff(self):
         x0 = self.STATE.rand()

--- a/unittest/bindings/test_states.py
+++ b/unittest/bindings/test_states.py
@@ -8,7 +8,6 @@ import numpy as np
 import crocoddyl
 from crocoddyl.utils import StateMultibodyDerived, StateVectorDerived
 
-crocoddyl.switchToNumpyMatrix()
 
 
 class StateAbstractTestCase(unittest.TestCase):
@@ -25,10 +24,10 @@ class StateAbstractTestCase(unittest.TestCase):
         self.assertEqual(self.STATE.nv, self.STATE_DER.nv, "Wrong nv value.")
 
         # Checking the dimension of zero and random states
-        self.assertEqual(self.STATE.zero().shape, (self.NX, 1), "Wrong dimension of zero state.")
-        self.assertEqual(self.STATE.rand().shape, (self.NX, 1), "Wrong dimension of random state.")
-        self.assertEqual(self.STATE.lb.shape, (self.NX, 1), "Wrong dimension of lower bound.")
-        self.assertEqual(self.STATE.ub.shape, (self.NX, 1), "Wrong dimension of lower bound.")
+        self.assertEqual(self.STATE.zero().shape, (self.NX,), "Wrong dimension of zero state.")
+        self.assertEqual(self.STATE.rand().shape, (self.NX,), "Wrong dimension of random state.")
+        self.assertEqual(self.STATE.lb.shape, (self.NX,), "Wrong dimension of lower bound.")
+        self.assertEqual(self.STATE.ub.shape, (self.NX,), "Wrong dimension of lower bound.")
 
     def test_python_derived_diff(self):
         x0 = self.STATE.rand()


### PR DESCRIPTION
This PR solves the issue #799 for all the type of models:  action, diff-action, actuation, activation, cost, contact and impulses.
It also updated the unittest code by defining a `createData` function for each case that it needs. Finally, it rewrites this code to use numpy array.

@gfadini you might want to try this stuff.

@nmansard, @proyan, @PepMS, @wxmerkt, @julesser fyi. You need to be aware that it is possible to create a data structure in Python. For more details see the changes inside `__init__.py`