### PR TITLE
[Python] remove debug with wrong syntax

### DIFF
--- a/bindings/python/crocoddyl/utils/pendulum.py
+++ b/bindings/python/crocoddyl/utils/pendulum.py
@@ -33,7 +33,6 @@ class CostModelDoublePendulum(crocoddyl.CostModelAbstract):
         data.Lxx = np.diag(Lxx)
 
     def createData(self, collector):
-        print collector
         data = CostDataDoublePendulum(self, collector)
         return data
 


### PR DESCRIPTION
Couldn't compile devel with python 3 otherwise.