### PR TITLE
Update benchmarks given changes in the Python unittest

### DIFF
--- a/benchmark/arm_manipulation_optctrl.py
+++ b/benchmark/arm_manipulation_optctrl.py
@@ -1,5 +1,5 @@
 import crocoddyl
-from crocoddyl.utils import DifferentialFreeFwdDynamicsDerived
+from crocoddyl.utils import DifferentialFreeFwdDynamicsModelDerived
 import pinocchio
 import example_robot_data
 import numpy as np
@@ -67,7 +67,7 @@ def runDDPSolveBenchmark(xs, us, problem):
     if CALLBACKS:
         ddp.setCallbacks([crocoddyl.CallbackVerbose()])
     duration = []
-    for i in range(T):
+    for _ in range(T):
         c_start = time.time()
         ddp.solve(xs, us, MAXITER, False, 0.1)
         c_end = time.time()
@@ -81,7 +81,7 @@ def runDDPSolveBenchmark(xs, us, problem):
 
 def runShootingProblemCalcBenchmark(xs, us, problem):
     duration = []
-    for i in range(T):
+    for _ in range(T):
         c_start = time.time()
         problem.calc(xs, us)
         c_end = time.time()
@@ -95,7 +95,7 @@ def runShootingProblemCalcBenchmark(xs, us, problem):
 
 def runShootingProblemCalcDiffBenchmark(xs, us, problem):
     duration = []
-    for i in range(T):
+    for _ in range(T):
         c_start = time.time()
         problem.calcDiff(xs, us)
         c_end = time.time()
@@ -121,7 +121,7 @@ avrg_duration, min_duration, max_duration = runShootingProblemCalcDiffBenchmark(
 print('  ShootingProblem.calcDiff [ms]: {0} ({1}, {2})'.format(avrg_duration, min_duration, max_duration))
 
 print('Python:')
-xs, us, problem = createProblem(DifferentialFreeFwdDynamicsDerived)
+xs, us, problem = createProblem(DifferentialFreeFwdDynamicsModelDerived)
 avrg_duration, min_duration, max_duration = runDDPSolveBenchmark(xs, us, problem)
 print('  DDP.solve [ms]: {0} ({1}, {2})'.format(avrg_duration, min_duration, max_duration))
 avrg_duration, min_duration, max_duration = runShootingProblemCalcBenchmark(xs, us, problem)

--- a/benchmark/bipedal_walk_optctrl.py
+++ b/benchmark/bipedal_walk_optctrl.py
@@ -37,7 +37,7 @@ def runDDPSolveBenchmark(xs, us, problem):
     ddp = crocoddyl.SolverDDP(problem)
 
     duration = []
-    for i in range(T):
+    for _ in range(T):
         c_start = time.time()
         ddp.solve(xs, us, MAXITER, False, 0.1)
         c_end = time.time()
@@ -51,7 +51,7 @@ def runDDPSolveBenchmark(xs, us, problem):
 
 def runShootingProblemCalcBenchmark(xs, us, problem):
     duration = []
-    for i in range(T):
+    for _ in range(T):
         c_start = time.time()
         problem.calc(xs, us)
         c_end = time.time()
@@ -65,7 +65,7 @@ def runShootingProblemCalcBenchmark(xs, us, problem):
 
 def runShootingProblemCalcDiffBenchmark(xs, us, problem):
     duration = []
-    for i in range(T):
+    for _ in range(T):
         c_start = time.time()
         problem.calcDiff(xs, us)
         c_end = time.time()

--- a/benchmark/quadrupedal_gaits_optctrl.py
+++ b/benchmark/quadrupedal_gaits_optctrl.py
@@ -80,7 +80,7 @@ def runDDPSolveBenchmark(xs, us, problem):
     if CALLBACKS:
         ddp.setCallbacks([crocoddyl.CallbackVerbose()])
     duration = []
-    for i in range(T):
+    for _ in range(T):
         c_start = time.time()
         ddp.solve(xs, us, MAXITER, False, 0.1)
         c_end = time.time()
@@ -94,7 +94,7 @@ def runDDPSolveBenchmark(xs, us, problem):
 
 def runShootingProblemCalcBenchmark(xs, us, problem):
     duration = []
-    for i in range(T):
+    for _ in range(T):
         c_start = time.time()
         problem.calc(xs, us)
         c_end = time.time()


### PR DESCRIPTION
Changes in #808 introduced a rename in a Python derived class. This class is using in the arm_manipulation.py as well.

I noticed that the quadrupedal benchmark is not running, i.e. this fails:
```bash
make -s benchmarks-py-quadrupedal_gaits_optctrl
```

However, I decided to do not modify since there are important changes in #809. @proyan could you check this command in your PR?