### PR TITLE
Fixed test_codegen

### DIFF
--- a/include/crocoddyl/multibody/actuations/floating-base.hpp
+++ b/include/crocoddyl/multibody/actuations/floating-base.hpp
@@ -26,8 +26,8 @@ class ActuationModelFloatingBaseTpl : public ActuationModelAbstractTpl<_Scalar> 
   typedef typename MathBase::VectorXs VectorXs;
   typedef typename MathBase::MatrixXs MatrixXs;
 
-  explicit ActuationModelFloatingBaseTpl(boost::shared_ptr<StateMultibody> state) : Base(state, state->get_nv() - state->get_pinocchio()->joints[1].nv()) {
-  };
+  explicit ActuationModelFloatingBaseTpl(boost::shared_ptr<StateMultibody> state)
+      : Base(state, state->get_nv() - state->get_pinocchio()->joints[1].nv()){};
   virtual ~ActuationModelFloatingBaseTpl(){};
 
   virtual void calc(const boost::shared_ptr<Data>& data, const Eigen::Ref<const VectorXs>& /*x*/,

--- a/include/crocoddyl/multibody/states/multibody.hxx
+++ b/include/crocoddyl/multibody/states/multibody.hxx
@@ -14,9 +14,7 @@ namespace crocoddyl {
 
 template <typename Scalar>
 StateMultibodyTpl<Scalar>::StateMultibodyTpl(boost::shared_ptr<pinocchio::ModelTpl<Scalar> > model)
-    : Base(model->nq + model->nv, 2 * model->nv),
-      pinocchio_(model),
-      x0_(VectorXs::Zero(model->nq + model->nv)) {
+    : Base(model->nq + model->nv, 2 * model->nv), pinocchio_(model), x0_(VectorXs::Zero(model->nq + model->nv)) {
   x0_.head(nq_) = pinocchio::neutral(*pinocchio_.get());
 
   // In a multibody system, we could define the first joint using Lie groups.

--- a/unittest/test_codegen.cpp
+++ b/unittest/test_codegen.cpp
@@ -191,6 +191,10 @@ const boost::shared_ptr<crocoddyl::ActionModelAbstractTpl<Scalar> > build_bipeda
   typedef typename crocoddyl::CostModelContactForceTpl<Scalar> CostModelContactForce;
   typedef typename crocoddyl::CostModelCentroidalMomentumTpl<Scalar> CostModelCentroidalMomentum;
   typedef typename crocoddyl::CostModelSumTpl<Scalar> CostModelSum;
+  typedef typename crocoddyl::ContactModelAbstractTpl<Scalar> ContactModelAbstract;
+  typedef typename crocoddyl::ContactModelMultipleTpl<Scalar> ContactModelMultiple;
+  typedef typename crocoddyl::ContactModel3DTpl<Scalar> ContactModel3D;
+  typedef typename crocoddyl::ContactModel6DTpl<Scalar> ContactModel6D;
   typedef typename crocoddyl::FrameForceTpl<Scalar> FrameForce;
   typedef typename crocoddyl::ActionModelAbstractTpl<Scalar> ActionModelAbstract;
   typedef typename crocoddyl::ActuationModelFloatingBaseTpl<Scalar> ActuationModelFloatingBase;


### PR DESCRIPTION
This PR includes missing typedef needed to compile `test_codegen`. Additionally, there is an additional issue that seems to be related with https://github.com/stack-of-tasks/pinocchio/pull/1255.

For completeness this is the compilation error that I encountered:
```
In file included from /usr/local/include/eigen3/Eigen/Core:427:0,
                 from /usr/local/include/pinocchio/utils/cast.hpp:8,
                 from /usr/local/include/pinocchio/fwd.hpp:23,
                 from /usr/local/include/pinocchio/spatial/fwd.hpp:9,
                 from /usr/local/include/pinocchio/multibody/model.hpp:9,
                 from /usr/local/include/pinocchio/parsers/urdf.hpp:9,
                 from /home/cmastalli/devel/crocoddyl/unittest/test_codegen.cpp:9:
/usr/local/include/eigen3/Eigen/src/Core/functors/AssignmentFunctors.h: In instantiation of ‘void Eigen::internal::assign_op<DstScalar, SrcScalar>::assignCoeff(DstScalar&, const SrcScalar&) const [with DstScalar = double; SrcScalar = CppAD::AD<CppAD::cg::CG<double> >]’:
/usr/local/include/eigen3/Eigen/src/Core/AssignEvaluator.h:637:5:   required from ‘void Eigen::internal::generic_dense_assignment_kernel<DstEvaluatorTypeT, SrcEvaluatorTypeT, Functor, Version>::assignCoeff(Eigen::Index) [with DstEvaluatorTypeT = Eigen::internal::evaluator<Eigen::Matrix<double, 3, 1> >; SrcEvaluatorTypeT = Eigen::internal::evaluator<Eigen::Product<Eigen::Matrix<CppAD::AD<CppAD::cg::CG<double> >, 3, 3, 0, 3, 3>, Eigen::Matrix<CppAD::AD<CppAD::cg::CG<double> >, 3, 1, 0, 3, 1>, 0> >; Functor = Eigen::internal::assign_op<double, CppAD::AD<CppAD::cg::CG<double> > >; int Version = 0; Eigen::Index = long int]’
/usr/local/include/eigen3/Eigen/src/Core/AssignEvaluator.h:242:5:   required from ‘static void Eigen::internal::copy_using_evaluator_LinearTraversal_CompleteUnrolling<Kernel, Index, Stop>::run(Kernel&) [with Kernel = Eigen::internal::generic_dense_assignment_kernel<Eigen::internal::evaluator<Eigen::Matrix<double, 3, 1> >, Eigen::internal::evaluator<Eigen::Product<Eigen::Matrix<CppAD::AD<CppAD::cg::CG<double> >, 3, 3, 0, 3, 3>, Eigen::Matrix<CppAD::AD<CppAD::cg::CG<double> >, 3, 1, 0, 3, 1>, 0> >, Eigen::internal::assign_op<double, CppAD::AD<CppAD::cg::CG<double> > >, 0>; int Index = 0; int Stop = 3]’
/usr/local/include/eigen3/Eigen/src/Core/AssignEvaluator.h:507:106:   required from ‘static void Eigen::internal::dense_assignment_loop<Kernel, 1, 2>::run(Kernel&) [with Kernel = Eigen::internal::generic_dense_assignment_kernel<Eigen::internal::evaluator<Eigen::Matrix<double, 3, 1> >, Eigen::internal::evaluator<Eigen::Product<Eigen::Matrix<CppAD::AD<CppAD::cg::CG<double> >, 3, 3, 0, 3, 3>, Eigen::Matrix<CppAD::AD<CppAD::cg::CG<double> >, 3, 1, 0, 3, 1>, 0> >, Eigen::internal::assign_op<double, CppAD::AD<CppAD::cg::CG<double> > >, 0>]’
/usr/local/include/eigen3/Eigen/src/Core/AssignEvaluator.h:741:37:   required from ‘void Eigen::internal::call_dense_assignment_loop(DstXprType&, const SrcXprType&, const Functor&) [with DstXprType = Eigen::Matrix<double, 3, 1>; SrcXprType = Eigen::Product<Eigen::Matrix<CppAD::AD<CppAD::cg::CG<double> >, 3, 3, 0, 3, 3>, Eigen::Matrix<CppAD::AD<CppAD::cg::CG<double> >, 3, 1, 0, 3, 1>, 0>; Functor = Eigen::internal::assign_op<double, CppAD::AD<CppAD::cg::CG<double> > >]’
/usr/local/include/eigen3/Eigen/src/Core/AssignEvaluator.h:879:31:   [ skipping 2 instantiation contexts, use -ftemplate-backtrace-limit=0 to disable ]
/usr/local/include/eigen3/Eigen/src/Core/PlainObjectBase.h:732:41:   required from ‘Derived& Eigen::PlainObjectBase<Derived>::_set_noalias(const Eigen::DenseBase<OtherDerived>&) [with OtherDerived = Eigen::Product<Eigen::Matrix<CppAD::AD<CppAD::cg::CG<double> >, 3, 3, 0, 3, 3>, Eigen::Matrix<CppAD::AD<CppAD::cg::CG<double> >, 3, 1, 0, 3, 1>, 0>; Derived = Eigen::Matrix<double, 3, 1>]’
/usr/local/include/eigen3/Eigen/src/Core/PlainObjectBase.h:537:19:   required from ‘Eigen::PlainObjectBase<Derived>::PlainObjectBase(const Eigen::DenseBase<OtherDerived>&) [with OtherDerived = Eigen::Product<Eigen::Matrix<CppAD::AD<CppAD::cg::CG<double> >, 3, 3, 0, 3, 3>, Eigen::Matrix<CppAD::AD<CppAD::cg::CG<double> >, 3, 1, 0, 3, 1>, 0>; Derived = Eigen::Matrix<double, 3, 1>]’
/usr/local/include/eigen3/Eigen/src/Core/Matrix.h:377:29:   required from ‘Eigen::Matrix<_Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols>::Matrix(const Eigen::EigenBase<OtherDerived>&) [with OtherDerived = Eigen::Product<Eigen::Matrix<CppAD::AD<CppAD::cg::CG<double> >, 3, 3, 0, 3, 3>, Eigen::Matrix<CppAD::AD<CppAD::cg::CG<double> >, 3, 1, 0, 3, 1>, 0>; _Scalar = double; int _Rows = 3; int _Cols = 1; int _Options = 0; int _MaxRows = 3; int _MaxCols = 1]’
/usr/local/include/pinocchio/algorithm/frames-derivatives.hxx:56:33:   required from ‘void pinocchio::getFrameVelocityDerivatives(const pinocchio::ModelTpl<Scalar, Options, JointCollectionTpl>&, pinocchio::DataTpl<Scalar, Options, JointCollectionTpl>&, typename pinocchio::ModelTpl<Scalar, Options, JointCollectionTpl>::FrameIndex, pinocchio::ReferenceFrame, const Eigen::MatrixBase<Mat>&, const Eigen::MatrixBase<MatRet>&) [with Scalar = CppAD::AD<CppAD::cg::CG<double> >; int Options = 0; JointCollectionTpl = pinocchio::JointCollectionDefaultTpl; Matrix6xOut1 = Eigen::Block<Eigen::Matrix<CppAD::AD<CppAD::cg::CG<double> >, -1, -1, 0, -1, -1>, -1, -1, true>; Matrix6xOut2 = Eigen::Block<Eigen::Matrix<CppAD::AD<CppAD::cg::CG<double> >, -1, -1, 0, -1, -1>, -1, -1, true>; typename pinocchio::ModelTpl<Scalar, Options, JointCollectionTpl>::FrameIndex = long unsigned int]’
/home/cmastalli/devel/crocoddyl/include/crocoddyl/multibody/costs/frame-velocity.hxx:75:41:   required from ‘void crocoddyl::CostModelFrameVelocityTpl<Scalar>::calcDiff(const boost::shared_ptr<crocoddyl::CostDataAbstractTpl<_Scalar> >&, const Eigen::Ref<const typename crocoddyl::MathBaseTpl<_Scalar>::VectorXs>&, const Eigen::Ref<const typename crocoddyl::MathBaseTpl<_Scalar>::VectorXs>&) [with _Scalar = CppAD::AD<CppAD::cg::CG<double> >; typename Eigen::internal::conditional<const typename crocoddyl::MathBaseTpl<_Scalar>::VectorXs:: IsVectorAtCompileTime, Eigen::InnerStride<1>, Eigen::OuterStride<> >::type = Eigen::InnerStride<1>; typename crocoddyl::MathBaseTpl<_Scalar>::VectorXs = Eigen::Matrix<CppAD::AD<CppAD::cg::CG<double> >, -1, 1, 0, -1, 1>]’
/home/cmastalli/devel/crocoddyl/unittest/test_codegen.cpp:372:107:   required from here
/usr/local/include/eigen3/Eigen/src/Core/functors/AssignmentFunctors.h:24:102: error: cannot convert ‘const CppAD::AD<CppAD::cg::CG<double> >’ to ‘double’ in assignment
   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void assignCoeff(DstScalar& a, const SrcScalar& b) const { a = b; }
```

@proyan and @jcarpent could you let me know more about this issue?

@proyan if the problem is in Crocoddyl, could you push the solution to this branch?

(I used the latest devel branch in Pinocchio, this commit: https://github.com/stack-of-tasks/pinocchio/commit/8883f0974ba0c5131afc1e86fa35c6f161a28ecf)
