### PR TITLE
Fixing quasiStatic for cases where we have inactive contacts

### DIFF
--- a/include/crocoddyl/multibody/actions/free-fwddyn.hxx
+++ b/include/crocoddyl/multibody/actions/free-fwddyn.hxx
@@ -164,7 +164,7 @@ void DifferentialActionModelFreeFwdDynamicsTpl<Scalar>::quasiStatic(
   actuation_->calc(d->multibody.actuation, x_tmp, VectorXs::Zero(nu_));
   actuation_->calcDiff(d->multibody.actuation, x_tmp, VectorXs::Zero(nu_));
 
-  u = pseudoInverse(d->multibody.actuation->dtau_du) * d->pinocchio.tau;
+  u.noalias() = pseudoInverse(d->multibody.actuation->dtau_du) * d->pinocchio.tau;
   d->pinocchio.tau.setZero();
 }
 

--- a/unittest/factory/diff_action.cpp
+++ b/unittest/factory/diff_action.cpp
@@ -8,8 +8,6 @@
 
 #include "diff_action.hpp"
 #include "crocoddyl/core/actions/diff-lqr.hpp"
-#include "crocoddyl/multibody/actions/free-fwddyn.hpp"
-#include "crocoddyl/multibody/actions/contact-fwddyn.hpp"
 #include "crocoddyl/multibody/states/multibody.hpp"
 #include "crocoddyl/multibody/actuations/full.hpp"
 #include "crocoddyl/multibody/actuations/floating-base.hpp"
@@ -104,9 +102,10 @@ boost::shared_ptr<crocoddyl::DifferentialActionModelAbstract> DifferentialAction
   return action;
 }
 
-boost::shared_ptr<crocoddyl::DifferentialActionModelAbstract> DifferentialActionModelFactory::create_freeFwdDynamics(
-    StateModelTypes::Type state_type, ActuationModelTypes::Type actuation_type) const {
-  boost::shared_ptr<crocoddyl::DifferentialActionModelAbstract> action;
+boost::shared_ptr<crocoddyl::DifferentialActionModelFreeFwdDynamics>
+DifferentialActionModelFactory::create_freeFwdDynamics(StateModelTypes::Type state_type,
+                                                       ActuationModelTypes::Type actuation_type) const {
+  boost::shared_ptr<crocoddyl::DifferentialActionModelFreeFwdDynamics> action;
   boost::shared_ptr<crocoddyl::StateMultibody> state;
   boost::shared_ptr<crocoddyl::ActuationModelAbstract> actuation;
   boost::shared_ptr<crocoddyl::CostModelSum> cost;
@@ -129,9 +128,9 @@ boost::shared_ptr<crocoddyl::DifferentialActionModelAbstract> DifferentialAction
   return action;
 }
 
-boost::shared_ptr<crocoddyl::DifferentialActionModelAbstract>
+boost::shared_ptr<crocoddyl::DifferentialActionModelContactFwdDynamics>
 DifferentialActionModelFactory::create_contactFwdDynamics(StateModelTypes::Type state_type, bool with_friction) const {
-  boost::shared_ptr<crocoddyl::DifferentialActionModelAbstract> action;
+  boost::shared_ptr<crocoddyl::DifferentialActionModelContactFwdDynamics> action;
   boost::shared_ptr<crocoddyl::StateMultibody> state;
   boost::shared_ptr<crocoddyl::ActuationModelFloatingBase> actuation;
   boost::shared_ptr<crocoddyl::ContactModelMultiple> contact;

--- a/unittest/factory/diff_action.hpp
+++ b/unittest/factory/diff_action.hpp
@@ -15,6 +15,8 @@
 #include "contact.hpp"
 #include "crocoddyl/core/diff-action-base.hpp"
 #include "crocoddyl/core/numdiff/diff-action.hpp"
+#include "crocoddyl/multibody/actions/free-fwddyn.hpp"
+#include "crocoddyl/multibody/actions/contact-fwddyn.hpp"
 
 namespace crocoddyl {
 namespace unittest {
@@ -54,10 +56,10 @@ class DifferentialActionModelFactory {
   boost::shared_ptr<crocoddyl::DifferentialActionModelAbstract> create(DifferentialActionModelTypes::Type type) const;
 
  private:
-  boost::shared_ptr<crocoddyl::DifferentialActionModelAbstract> create_freeFwdDynamics(
+  boost::shared_ptr<crocoddyl::DifferentialActionModelFreeFwdDynamics> create_freeFwdDynamics(
       StateModelTypes::Type state_type, ActuationModelTypes::Type actuation_type) const;
 
-  boost::shared_ptr<crocoddyl::DifferentialActionModelAbstract> create_contactFwdDynamics(
+  boost::shared_ptr<crocoddyl::DifferentialActionModelContactFwdDynamics> create_contactFwdDynamics(
       StateModelTypes::Type state_type, bool with_friction = true) const;
 };
 

--- a/unittest/test_diff_actions.cpp
+++ b/unittest/test_diff_actions.cpp
@@ -78,11 +78,26 @@ void test_quasi_static(DifferentialActionModelTypes::Type action_type) {
   x.tail(model->get_state()->get_nv()).setZero();
   Eigen::VectorXd u = Eigen::VectorXd::Zero(model->get_nu());
   model->quasiStatic(data, u, x);
-
   model->calc(data, x, u);
 
-  // Checking that calc returns a cost value
+  // Checking that the acceleration is zero as supposed to be in a quasi static condition
   BOOST_CHECK(data->xout.norm() <= 1e-8);
+
+  // Check for inactive contacts
+  if (action_type == DifferentialActionModelTypes::DifferentialActionModelContactFwdDynamics_HyQ ||
+      action_type == DifferentialActionModelTypes::DifferentialActionModelContactFwdDynamicsWithFriction_HyQ ||
+      action_type == DifferentialActionModelTypes::DifferentialActionModelContactFwdDynamics_Talos ||
+      action_type == DifferentialActionModelTypes::DifferentialActionModelContactFwdDynamicsWithFriction_Talos) {
+    boost::shared_ptr<crocoddyl::DifferentialActionModelContactFwdDynamics> m =
+        boost::static_pointer_cast<crocoddyl::DifferentialActionModelContactFwdDynamics>(model);
+    m->get_contacts()->changeContactStatus("lf", false);
+
+    model->quasiStatic(data, u, x);
+    model->calc(data, x, u);
+
+    // Checking that the acceleration is zero as supposed to be in a quasi static condition
+    BOOST_CHECK(data->xout.norm() <= 1e-8);
+  }
 }
 
 void test_partial_derivatives_against_numdiff(DifferentialActionModelTypes::Type action_type) {


### PR DESCRIPTION
This PR fixes an issue coming from #809. This happens disappear due to lack of unittest code.
So this PR also includes the needed unittest code.

Before merging this PR, I would like to discuss the possibility of removing the memory allocation in `quasiStatic`. The benefits of doing that is we could parallelize this routine. Indeed, I am interested in create a `quasiStatic` methon inside `ShootingProblem`.
@proyan do you have any concern with it?