### PR TITLE
quasiStatic with multithreading support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ jobs:
   allow_failures:
     - dist: bionic
       env: CMAKE_BUILD_TYPE=Debug DIST=bionic CTEST_OUTPUT_ON_FAILURE=1
+    - dist: xenial
+      env: CMAKE_BUILD_TYPE=Debug DIST=xenial CTEST_OUTPUT_ON_FAILURE=1 CMAKE_CXX_STANDARD=11
 
 before_install:
   - echo "deb [arch=amd64] http://robotpkg.openrobots.org/wip/packages/debian/pub $(lsb_release -sc) robotpkg" | sudo tee -a /etc/apt/sources.list.d/robotpkg.list && echo "deb [arch=amd64] http://robotpkg.openrobots.org/packages/debian/pub $(lsb_release -sc) robotpkg" | sudo tee -a /etc/apt/sources.list.d/robotpkg.list && curl http://robotpkg.openrobots.org/packages/debian/robotpkg.key | sudo apt-key add -

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os: [
 ]
 
 jobs:
+  fast_finish: true
   include:
     - dist: bionic
       env: CMAKE_BUILD_TYPE=Debug DIST=bionic CTEST_OUTPUT_ON_FAILURE=1
@@ -15,6 +16,9 @@ jobs:
       env: CMAKE_BUILD_TYPE=Release DIST=xenial CTEST_OUTPUT_ON_FAILURE=1 CMAKE_CXX_STANDARD=11
     - dist: bionic
       env: CHECK_CLANG_FORMAT=1
+  allow_failures:
+    - dist: bionic
+      env: CMAKE_BUILD_TYPE=Debug DIST=bionic CTEST_OUTPUT_ON_FAILURE=1
 
 before_install:
   - echo "deb [arch=amd64] http://robotpkg.openrobots.org/wip/packages/debian/pub $(lsb_release -sc) robotpkg" | sudo tee -a /etc/apt/sources.list.d/robotpkg.list && echo "deb [arch=amd64] http://robotpkg.openrobots.org/packages/debian/pub $(lsb_release -sc) robotpkg" | sudo tee -a /etc/apt/sources.list.d/robotpkg.list && curl http://robotpkg.openrobots.org/packages/debian/robotpkg.key | sudo apt-key add -

--- a/bindings/python/crocoddyl/core/optctrl/shooting.cpp
+++ b/bindings/python/crocoddyl/core/optctrl/shooting.cpp
@@ -66,6 +66,10 @@ void exposeShootingProblem() {
            "Integrate the dynamics given a control sequence.\n\n"
            "Rollout the dynamics give a sequence of control commands\n"
            ":param us: time-discrete control sequence (size T)")
+      .def("quasiStatic", &ShootingProblem::quasiStatic_xs, bp::args("self", "xs"),
+           "Compute the quasi static commands given a state trajectory.\n\n"
+           "Generally speaking, it uses Newton-Raphson method for computing the quasi static commands.\n"
+           ":param xs: time-discrete state trajectory (size T)")
       .def<void (ShootingProblem::*)(boost::shared_ptr<ActionModelAbstract>, boost::shared_ptr<ActionDataAbstract>)>(
           "circularAppend", &ShootingProblem::circularAppend, bp::args("self", "model", "data"),
           "Circular append the model and data onto the end running node.\n\n"

--- a/examples/bipedal_walk.py
+++ b/examples/bipedal_walk.py
@@ -66,10 +66,7 @@ for i, phase in enumerate(GAITPHASES):
 
     # Solving the problem with the DDP solver
     xs = [talos_legs.model.defaultState] * (ddp[i].problem.T + 1)
-    us = [
-        m.quasiStatic(d, talos_legs.model.defaultState)
-        for m, d in list(zip(ddp[i].problem.runningModels, ddp[i].problem.runningDatas))
-    ]
+    us = ddp[i].problem.quasiStatic([talos_legs.model.defaultState] * ddp[i].problem.T)
     ddp[i].solve(xs, us, 100, False, 0.1)
 
     # Defining the final state as initial one for the next phase

--- a/examples/bipedal_walk_ubound.py
+++ b/examples/bipedal_walk_ubound.py
@@ -69,10 +69,7 @@ for i, phase in enumerate(GAITPHASES):
 
     # Solving the problem with the DDP solver
     xs = [talos_legs.model.defaultState] * (ddp[i].problem.T + 1)
-    us = [
-        m.quasiStatic(d, talos_legs.model.defaultState)
-        for m, d in list(zip(ddp[i].problem.runningModels, ddp[i].problem.runningDatas))
-    ]
+    us = ddp[i].problem.quasiStatic([talos_legs.model.defaultState] * ddp[i].problem.T)
     ddp[i].solve(xs, us, 100, False, 0.1)
 
     # Defining the final state as initial one for the next phase

--- a/examples/boxfddp_vs_boxddp.py
+++ b/examples/boxfddp_vs_boxddp.py
@@ -72,10 +72,7 @@ else:
 
 # Solving the problem with the both solvers
 xs = [anymal.model.defaultState] * (boxfddp.problem.T + 1)
-us = [
-    m.quasiStatic(d, anymal.model.defaultState)
-    for m, d in list(zip(boxfddp.problem.runningModels, boxfddp.problem.runningDatas))
-]
+us = boxddp.problem.quasiStatic([anymal.model.defaultState] * boxddp.problem.T)
 
 print('*** SOLVE with Box-FDDP ***')
 boxfddp.th_stop = 1e-7

--- a/examples/humanoid_manipulation.py
+++ b/examples/humanoid_manipulation.py
@@ -138,7 +138,7 @@ else:
 
 # Solving it with the DDP algorithm
 xs = [rmodel.defaultState] * (ddp.problem.T + 1)
-us = [m.quasiStatic(d, rmodel.defaultState) for m, d in list(zip(ddp.problem.runningModels, ddp.problem.runningDatas))]
+us = ddp.problem.quasiStatic([rmodel.defaultState] * ddp.problem.T)
 ddp.solve(xs, us, 500, False, 0.1)
 
 # Visualizing the solution in gepetto-viewer

--- a/examples/humanoid_manipulation_ubound.py
+++ b/examples/humanoid_manipulation_ubound.py
@@ -141,7 +141,7 @@ else:
 
 # Solving it with the DDP algorithm
 xs = [rmodel.defaultState] * (ddp.problem.T + 1)
-us = [m.quasiStatic(d, rmodel.defaultState) for m, d in list(zip(ddp.problem.runningModels, ddp.problem.runningDatas))]
+us = ddp.problem.quasiStatic([rmodel.defaultState] * ddp.problem.T)
 ddp.solve(xs, us, 500, False, 1e-9)
 
 # Visualizing the solution in gepetto-viewer

--- a/examples/humanoid_taichi.py
+++ b/examples/humanoid_taichi.py
@@ -173,7 +173,7 @@ else:
 
 # Solving it with the DDP algorithm
 xs = [rmodel.defaultState] * (ddp.problem.T + 1)
-us = [m.quasiStatic(d, rmodel.defaultState) for m, d in list(zip(ddp.problem.runningModels, ddp.problem.runningDatas))]
+us = ddp.problem.quasiStatic([rmodel.defaultState] * ddp.problem.T)
 ddp.th_stop = 1e-7
 ddp.solve(xs, us, 500, False, 1e-9)
 

--- a/examples/quadrupedal_gaits.py
+++ b/examples/quadrupedal_gaits.py
@@ -117,10 +117,7 @@ for i, phase in enumerate(GAITPHASES):
 
     # Solving the problem with the DDP solver
     xs = [anymal.model.defaultState] * (ddp[i].problem.T + 1)
-    us = [
-        m.quasiStatic(d, anymal.model.defaultState)
-        for m, d in list(zip(ddp[i].problem.runningModels, ddp[i].problem.runningDatas))
-    ]
+    us = ddp[i].problem.quasiStatic([anymal.model.defaultState] * ddp[i].problem.T)
     ddp[i].solve(xs, us, 100, False, 0.1)
 
     # Defining the final state as initial one for the next phase

--- a/examples/quadrupedal_walk_ubound.py
+++ b/examples/quadrupedal_walk_ubound.py
@@ -56,10 +56,7 @@ else:
     boxddp.setCallbacks([crocoddyl.CallbackVerbose()])
 
 xs = [robot_model.defaultState] * (boxddp.problem.T + 1)
-us = [
-    m.quasiStatic(d, robot_model.defaultState)
-    for m, d in list(zip(boxddp.problem.runningModels, boxddp.problem.runningDatas))
-]
+us = boxddp.problem.quasiStatic([anymal.model.defaultState] * boxddp.problem.T)
 
 # Solve the DDP problem
 boxddp.solve(xs, us, 100, False, 0.1)

--- a/include/crocoddyl/core/action-base.hxx
+++ b/include/crocoddyl/core/action-base.hxx
@@ -48,6 +48,12 @@ void ActionModelAbstractTpl<Scalar>::quasiStatic(const boost::shared_ptr<ActionD
     throw_pretty("Invalid argument: "
                  << "x has wrong dimension (it should be " + std::to_string(state_->get_nx()) + ")");
   }
+#ifndef NDEBUG
+  const Eigen::VectorBlock<const Eigen::Ref<const VectorXs>, Eigen::Dynamic> v = x.tail(state_->get_nv());
+#endif
+
+  // Check the velocity input is zero
+  assert_pretty(v.isZero(), "The velocity input should be zero for quasi-static to work.");
 
   const std::size_t& ndx = state_->get_ndx();
   VectorXs dx = VectorXs::Zero(ndx);

--- a/include/crocoddyl/core/action-base.hxx
+++ b/include/crocoddyl/core/action-base.hxx
@@ -48,12 +48,8 @@ void ActionModelAbstractTpl<Scalar>::quasiStatic(const boost::shared_ptr<ActionD
     throw_pretty("Invalid argument: "
                  << "x has wrong dimension (it should be " + std::to_string(state_->get_nx()) + ")");
   }
-#ifndef NDEBUG
-  const Eigen::VectorBlock<const Eigen::Ref<const VectorXs>, Eigen::Dynamic> v = x.tail(state_->get_nv());
-#endif
-
   // Check the velocity input is zero
-  assert_pretty(v.isZero(), "The velocity input should be zero for quasi-static to work.");
+  assert_pretty(x.tail(state_->get_nv()).isZero(), "The velocity input should be zero for quasi-static to work.");
 
   const std::size_t& ndx = state_->get_ndx();
   VectorXs dx = VectorXs::Zero(ndx);

--- a/include/crocoddyl/core/optctrl/shooting.hpp
+++ b/include/crocoddyl/core/optctrl/shooting.hpp
@@ -112,10 +112,10 @@ class ShootingProblemTpl {
   /**
    * @brief Compute the quasic static commands given a state trajectory
    *
-   * @param[in] xs  time-discrete state trajectory \f$\mathbf{x_{s}}\f$ (size \f$T+1\f$)
    * @param[out] us  time-discrete control sequence \f$\mathbf{u_{s}}\f$ (size \f$T\f$)
+   * @param[in]  xs  time-discrete state trajectory \f$\mathbf{x_{s}}\f$ (size \f$T+1\f$)
    */
-  void quasiStatic(const std::vector<VectorXs>& xs, std::vector<VectorXs>& us);
+  void quasiStatic(std::vector<VectorXs>& us, const std::vector<VectorXs>& xs);
 
   /**
    * @copybrief quasiStatic

--- a/include/crocoddyl/core/optctrl/shooting.hpp
+++ b/include/crocoddyl/core/optctrl/shooting.hpp
@@ -105,8 +105,25 @@ class ShootingProblemTpl {
    * @copybrief rollout
    *
    * @param[in] us  time-discrete control sequence \f$\mathbf{u_{s}}\f$ (size \f$T\f$)
+   * @return the time-discrete state trajectory \f$\mathbf{x_{s}}\f$ (size \f$T+1\f$)
    */
   std::vector<VectorXs> rollout_us(const std::vector<VectorXs>& us);
+
+  /**
+   * @brief Compute the quasic static commands given a state trajectory
+   *
+   * @param[in] xs  time-discrete state trajectory \f$\mathbf{x_{s}}\f$ (size \f$T+1\f$)
+   * @param[out] us  time-discrete control sequence \f$\mathbf{u_{s}}\f$ (size \f$T\f$)
+   */
+  void quasiStatic(const std::vector<VectorXs>& xs, std::vector<VectorXs>& us);
+
+  /**
+   * @copybrief quasiStatic
+   *
+   * @param[in] xs  time-discrete state trajectory \f$\mathbf{x_{s}}\f$ (size \f$T+1\f$)
+   * @return the time-discrete quasic static commands \f$\mathbf{u_{s}}\f$ (size \f$T\f$)
+   */
+  std::vector<VectorXs> quasiStatic_xs(const std::vector<VectorXs>& xs);
 
   /**
    * @brief Circular append of the model and data onto the end running node

--- a/include/crocoddyl/core/optctrl/shooting.hxx
+++ b/include/crocoddyl/core/optctrl/shooting.hxx
@@ -253,6 +253,9 @@ std::vector<typename MathBaseTpl<Scalar>::VectorXs> ShootingProblemTpl<Scalar>::
     const std::vector<VectorXs>& xs) {
   std::vector<VectorXs> us;
   us.resize(T_);
+  for (std::size_t i = 0; i < T_; ++i) {
+    us[i] = VectorXs::Zero(running_models_[i]->get_nu());
+  }
   quasiStatic(us, xs);
   return us;
 }

--- a/include/crocoddyl/core/optctrl/shooting.hxx
+++ b/include/crocoddyl/core/optctrl/shooting.hxx
@@ -230,7 +230,7 @@ std::vector<typename MathBaseTpl<Scalar>::VectorXs> ShootingProblemTpl<Scalar>::
 }
 
 template <typename Scalar>
-void ShootingProblemTpl<Scalar>::quasiStatic(const std::vector<VectorXs>& us, std::vector<VectorXs>& xs) {
+void ShootingProblemTpl<Scalar>::quasiStatic(std::vector<VectorXs>& us, const std::vector<VectorXs>& xs) {
   if (xs.size() != T_) {
     throw_pretty("Invalid argument: "
                  << "xs has wrong dimension (it should be " + std::to_string(T_) + ")");
@@ -244,7 +244,7 @@ void ShootingProblemTpl<Scalar>::quasiStatic(const std::vector<VectorXs>& us, st
 #pragma omp parallel for
 #endif
   for (std::size_t i = 0; i < T_; ++i) {
-    running_models_[i]->quasiStatic(running_datas_[i], xs[i], us[i]);
+    running_models_[i]->quasiStatic(running_datas_[i], us[i], xs[i]);
   }
 }
 
@@ -253,7 +253,7 @@ std::vector<typename MathBaseTpl<Scalar>::VectorXs> ShootingProblemTpl<Scalar>::
     const std::vector<VectorXs>& xs) {
   std::vector<VectorXs> us;
   us.resize(T_);
-  quasiStatic(xs, us);
+  quasiStatic(us, xs);
   return us;
 }
 

--- a/include/crocoddyl/core/optctrl/shooting.hxx
+++ b/include/crocoddyl/core/optctrl/shooting.hxx
@@ -171,12 +171,10 @@ Scalar ShootingProblemTpl<Scalar>::calcDiff(const std::vector<VectorXs>& xs, con
                  << "us has wrong dimension (it should be " + std::to_string(T_) + ")");
   }
 
-  std::size_t i;
-
 #ifdef CROCODDYL_WITH_MULTITHREADING
 #pragma omp parallel for
 #endif
-  for (i = 0; i < T_; ++i) {
+  for (std::size_t i = 0; i < T_; ++i) {
     if (running_models_[i]->get_nu() != 0) {
       running_models_[i]->calcDiff(running_datas_[i], xs[i], us[i]);
     } else {
@@ -229,6 +227,34 @@ std::vector<typename MathBaseTpl<Scalar>::VectorXs> ShootingProblemTpl<Scalar>::
   xs.resize(T_ + 1);
   rollout(us, xs);
   return xs;
+}
+
+template <typename Scalar>
+void ShootingProblemTpl<Scalar>::quasiStatic(const std::vector<VectorXs>& us, std::vector<VectorXs>& xs) {
+  if (xs.size() != T_) {
+    throw_pretty("Invalid argument: "
+                 << "xs has wrong dimension (it should be " + std::to_string(T_) + ")");
+  }
+  if (us.size() != T_) {
+    throw_pretty("Invalid argument: "
+                 << "us has wrong dimension (it should be " + std::to_string(T_) + ")");
+  }
+
+#ifdef CROCODDYL_WITH_MULTITHREADING
+#pragma omp parallel for
+#endif
+  for (std::size_t i = 0; i < T_; ++i) {
+    running_models_[i]->quasiStatic(running_datas_[i], xs[i], us[i]);
+  }
+}
+
+template <typename Scalar>
+std::vector<typename MathBaseTpl<Scalar>::VectorXs> ShootingProblemTpl<Scalar>::quasiStatic_xs(
+    const std::vector<VectorXs>& xs) {
+  std::vector<VectorXs> us;
+  us.resize(T_);
+  quasiStatic(xs, us);
+  return us;
 }
 
 template <typename Scalar>

--- a/include/crocoddyl/multibody/actions/contact-fwddyn.hpp
+++ b/include/crocoddyl/multibody/actions/contact-fwddyn.hpp
@@ -104,11 +104,15 @@ struct DifferentialActionDataContactFwdDynamicsTpl : public DifferentialActionDa
         Kinv(model->get_state()->get_nv() + model->get_contacts()->get_nc_total(),
              model->get_state()->get_nv() + model->get_contacts()->get_nc_total()),
         df_dx(model->get_contacts()->get_nc_total(), model->get_state()->get_ndx()),
-        df_du(model->get_contacts()->get_nc_total(), model->get_nu()) {
+        df_du(model->get_contacts()->get_nc_total(), model->get_nu()),
+        x_static(model->get_state()->get_nx()),
+        J_static(model->get_state()->get_nv(), model->get_nu() + model->get_contacts()->get_nc_total()) {
     costs->shareMemory(this);
     Kinv.setZero();
     df_dx.setZero();
     df_du.setZero();
+    x_static.setZero();
+    J_static.setZero();
     pinocchio.lambda_c.resize(model->get_contacts()->get_nc_total());
     pinocchio.lambda_c.setZero();
   }
@@ -119,6 +123,8 @@ struct DifferentialActionDataContactFwdDynamicsTpl : public DifferentialActionDa
   MatrixXs Kinv;
   MatrixXs df_dx;
   MatrixXs df_du;
+  VectorXs x_static;
+  MatrixXs J_static;
 
   using Base::cost;
   using Base::Fu;

--- a/include/crocoddyl/multibody/actions/contact-fwddyn.hpp
+++ b/include/crocoddyl/multibody/actions/contact-fwddyn.hpp
@@ -105,14 +105,14 @@ struct DifferentialActionDataContactFwdDynamicsTpl : public DifferentialActionDa
              model->get_state()->get_nv() + model->get_contacts()->get_nc_total()),
         df_dx(model->get_contacts()->get_nc_total(), model->get_state()->get_ndx()),
         df_du(model->get_contacts()->get_nc_total(), model->get_nu()),
-        x_static(model->get_state()->get_nx()),
-        J_static(model->get_state()->get_nv(), model->get_nu() + model->get_contacts()->get_nc_total()) {
+        tmp_xstatic(model->get_state()->get_nx()),
+        tmp_Jstatic(model->get_state()->get_nv(), model->get_nu() + model->get_contacts()->get_nc_total()) {
     costs->shareMemory(this);
     Kinv.setZero();
     df_dx.setZero();
     df_du.setZero();
-    x_static.setZero();
-    J_static.setZero();
+    tmp_xstatic.setZero();
+    tmp_Jstatic.setZero();
     pinocchio.lambda_c.resize(model->get_contacts()->get_nc_total());
     pinocchio.lambda_c.setZero();
   }
@@ -123,8 +123,8 @@ struct DifferentialActionDataContactFwdDynamicsTpl : public DifferentialActionDa
   MatrixXs Kinv;
   MatrixXs df_dx;
   MatrixXs df_du;
-  VectorXs x_static;
-  MatrixXs J_static;
+  VectorXs tmp_xstatic;
+  MatrixXs tmp_Jstatic;
 
   using Base::cost;
   using Base::Fu;

--- a/include/crocoddyl/multibody/actions/contact-fwddyn.hxx
+++ b/include/crocoddyl/multibody/actions/contact-fwddyn.hxx
@@ -194,14 +194,14 @@ void DifferentialActionModelContactFwdDynamicsTpl<Scalar>::quasiStatic(
   pinocchio::computeJointJacobians(pinocchio_, d->pinocchio, q);
   d->pinocchio.tau = pinocchio::rnea(pinocchio_, d->pinocchio, q, VectorXs::Zero(nv), VectorXs::Zero(nv));
 
-  d->x_static.head(state_->get_nq()) = q;
-  actuation_->calc(d->multibody.actuation, d->x_static, VectorXs::Zero(nu_));
-  actuation_->calcDiff(d->multibody.actuation, d->x_static, VectorXs::Zero(nu_));
-  contacts_->calc(d->multibody.contacts, d->x_static);
+  d->tmp_xstatic.head(state_->get_nq()) = q;
+  actuation_->calc(d->multibody.actuation, d->tmp_xstatic, VectorXs::Zero(nu_));
+  actuation_->calcDiff(d->multibody.actuation, d->tmp_xstatic, VectorXs::Zero(nu_));
+  contacts_->calc(d->multibody.contacts, d->tmp_xstatic);
   // Allocates memory
-  d->J_static.resize(nv, nu_ + nc);
-  d->J_static << d->multibody.actuation->dtau_du, d->multibody.contacts->Jc.topRows(nc).transpose();
-  u.noalias() = (pseudoInverse(d->J_static) * d->pinocchio.tau).head(nu_);
+  d->tmp_Jstatic.resize(nv, nu_ + nc);
+  d->tmp_Jstatic << d->multibody.actuation->dtau_du, d->multibody.contacts->Jc.topRows(nc).transpose();
+  u.noalias() = (pseudoInverse(d->tmp_Jstatic) * d->pinocchio.tau).head(nu_);
   d->pinocchio.tau.setZero();
 }
 

--- a/include/crocoddyl/multibody/actions/contact-fwddyn.hxx
+++ b/include/crocoddyl/multibody/actions/contact-fwddyn.hxx
@@ -181,12 +181,9 @@ void DifferentialActionModelContactFwdDynamicsTpl<Scalar>::quasiStatic(
   DifferentialActionDataContactFwdDynamicsTpl<Scalar>* d =
       static_cast<DifferentialActionDataContactFwdDynamicsTpl<Scalar>*>(data.get());
   const Eigen::VectorBlock<const Eigen::Ref<const VectorXs>, Eigen::Dynamic> q = x.head(state_->get_nq());
-#ifndef NDEBUG
-  const Eigen::VectorBlock<const Eigen::Ref<const VectorXs>, Eigen::Dynamic> v = x.tail(state_->get_nv());
-#endif
 
   // Check the velocity input is zero
-  assert_pretty(v.isZero(), "The velocity input should be zero for quasi-static to work.");
+  assert_pretty(x.tail(state_->get_nv()).isZero(), "The velocity input should be zero for quasi-static to work.");
 
   const std::size_t& nv = state_->get_nv();
   const std::size_t& nc = contacts_->get_nc();

--- a/include/crocoddyl/multibody/actions/free-fwddyn.hpp
+++ b/include/crocoddyl/multibody/actions/free-fwddyn.hpp
@@ -98,12 +98,12 @@ struct DifferentialActionDataFreeFwdDynamicsTpl : public DifferentialActionDataA
         Minv(model->get_state()->get_nv(), model->get_state()->get_nv()),
         u_drift(model->get_nu()),
         dtau_dx(model->get_nu(), model->get_state()->get_ndx()),
-        x_static(model->get_state()->get_nx()) {
+        tmp_xstatic(model->get_state()->get_nx()) {
     costs->shareMemory(this);
     Minv.setZero();
     u_drift.setZero();
     dtau_dx.setZero();
-    x_static.setZero();
+    tmp_xstatic.setZero();
   }
 
   pinocchio::DataTpl<Scalar> pinocchio;
@@ -112,7 +112,7 @@ struct DifferentialActionDataFreeFwdDynamicsTpl : public DifferentialActionDataA
   MatrixXs Minv;
   VectorXs u_drift;
   MatrixXs dtau_dx;
-  VectorXs x_static;
+  VectorXs tmp_xstatic;
 
   using Base::cost;
   using Base::Fu;

--- a/include/crocoddyl/multibody/actions/free-fwddyn.hpp
+++ b/include/crocoddyl/multibody/actions/free-fwddyn.hpp
@@ -97,11 +97,13 @@ struct DifferentialActionDataFreeFwdDynamicsTpl : public DifferentialActionDataA
         costs(model->get_costs()->createData(&multibody)),
         Minv(model->get_state()->get_nv(), model->get_state()->get_nv()),
         u_drift(model->get_nu()),
-        dtau_dx(model->get_nu(), model->get_state()->get_ndx()) {
+        dtau_dx(model->get_nu(), model->get_state()->get_ndx()),
+        x_static(model->get_state()->get_nx()) {
     costs->shareMemory(this);
     Minv.setZero();
     u_drift.setZero();
     dtau_dx.setZero();
+    x_static.setZero();
   }
 
   pinocchio::DataTpl<Scalar> pinocchio;
@@ -110,6 +112,7 @@ struct DifferentialActionDataFreeFwdDynamicsTpl : public DifferentialActionDataA
   MatrixXs Minv;
   VectorXs u_drift;
   MatrixXs dtau_dx;
+  VectorXs x_static;
 
   using Base::cost;
   using Base::Fu;

--- a/include/crocoddyl/multibody/actions/free-fwddyn.hxx
+++ b/include/crocoddyl/multibody/actions/free-fwddyn.hxx
@@ -158,11 +158,9 @@ void DifferentialActionModelFreeFwdDynamicsTpl<Scalar>::quasiStatic(
   d->pinocchio.tau =
       pinocchio::rnea(pinocchio_, d->pinocchio, q, VectorXs::Zero(state_->get_nv()), VectorXs::Zero(state_->get_nv()));
 
-  VectorXs x_tmp(state_->get_nq() + state_->get_nv());
-  x_tmp << q, VectorXs::Zero(state_->get_nv());
-
-  actuation_->calc(d->multibody.actuation, x_tmp, VectorXs::Zero(nu_));
-  actuation_->calcDiff(d->multibody.actuation, x_tmp, VectorXs::Zero(nu_));
+  d->x_static.head(state_->get_nq()) = q;
+  actuation_->calc(d->multibody.actuation, d->x_static, VectorXs::Zero(nu_));
+  actuation_->calcDiff(d->multibody.actuation, d->x_static, VectorXs::Zero(nu_));
 
   u.noalias() = pseudoInverse(d->multibody.actuation->dtau_du) * d->pinocchio.tau;
   d->pinocchio.tau.setZero();

--- a/include/crocoddyl/multibody/actions/free-fwddyn.hxx
+++ b/include/crocoddyl/multibody/actions/free-fwddyn.hxx
@@ -148,12 +148,9 @@ void DifferentialActionModelFreeFwdDynamicsTpl<Scalar>::quasiStatic(
   // Static casting the data
   Data* d = static_cast<Data*>(data.get());
   const Eigen::VectorBlock<const Eigen::Ref<const VectorXs>, Eigen::Dynamic> q = x.head(state_->get_nq());
-#ifndef NDEBUG
-  const Eigen::VectorBlock<const Eigen::Ref<const VectorXs>, Eigen::Dynamic> v = x.tail(state_->get_nv());
-#endif
 
   // Check the velocity input is zero
-  assert_pretty(v.isZero(), "The velocity input should be zero for quasi-static to work.");
+  assert_pretty(x.tail(state_->get_nv()).isZero(), "The velocity input should be zero for quasi-static to work.");
 
   d->pinocchio.tau =
       pinocchio::rnea(pinocchio_, d->pinocchio, q, VectorXs::Zero(state_->get_nv()), VectorXs::Zero(state_->get_nv()));

--- a/include/crocoddyl/multibody/actions/free-fwddyn.hxx
+++ b/include/crocoddyl/multibody/actions/free-fwddyn.hxx
@@ -158,9 +158,9 @@ void DifferentialActionModelFreeFwdDynamicsTpl<Scalar>::quasiStatic(
   d->pinocchio.tau =
       pinocchio::rnea(pinocchio_, d->pinocchio, q, VectorXs::Zero(state_->get_nv()), VectorXs::Zero(state_->get_nv()));
 
-  d->x_static.head(state_->get_nq()) = q;
-  actuation_->calc(d->multibody.actuation, d->x_static, VectorXs::Zero(nu_));
-  actuation_->calcDiff(d->multibody.actuation, d->x_static, VectorXs::Zero(nu_));
+  d->tmp_xstatic.head(state_->get_nq()) = q;
+  actuation_->calc(d->multibody.actuation, d->tmp_xstatic, VectorXs::Zero(nu_));
+  actuation_->calcDiff(d->multibody.actuation, d->tmp_xstatic, VectorXs::Zero(nu_));
 
   u.noalias() = pseudoInverse(d->multibody.actuation->dtau_du) * d->pinocchio.tau;
   d->pinocchio.tau.setZero();

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -31,6 +31,7 @@ SET(${PROJECT_NAME}_CPP_TESTS
   test_actions
   # test_integrators
   test_diff_actions
+  test_problem
   test_friction_cone
   test_boxqp
   test_solvers

--- a/unittest/factory/diff_action.hpp
+++ b/unittest/factory/diff_action.hpp
@@ -6,8 +6,8 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifndef CROCODDYL_ACTION_FACTORY_HPP_
-#define CROCODDYL_ACTION_FACTORY_HPP_
+#ifndef CROCODDYL_DIFF_ACTION_FACTORY_HPP_
+#define CROCODDYL_DIFF_ACTION_FACTORY_HPP_
 
 #include "state.hpp"
 #include "actuation.hpp"
@@ -66,4 +66,4 @@ class DifferentialActionModelFactory {
 }  // namespace unittest
 }  // namespace crocoddyl
 
-#endif  // CROCODDYL_ACTION_FACTORY_HPP_
+#endif  // CROCODDYL_DIFF_ACTION_FACTORY_HPP_

--- a/unittest/test_problem.cpp
+++ b/unittest/test_problem.cpp
@@ -129,12 +129,8 @@ void test_calcDiff(ActionModelTypes::Type action_model_type) {
   model->calc(data, xs.back());
   model->calcDiff(data, xs.back());
   BOOST_CHECK((problem.get_terminalData()->Fx - data->Fx).isMuchSmallerThan(1.0, 1e-7));
-  BOOST_CHECK((problem.get_terminalData()->Fu - data->Fu).isMuchSmallerThan(1.0, 1e-7));
   BOOST_CHECK((problem.get_terminalData()->Lx - data->Lx).isMuchSmallerThan(1.0, 1e-7));
-  BOOST_CHECK((problem.get_terminalData()->Lu - data->Lu).isMuchSmallerThan(1.0, 1e-7));
   BOOST_CHECK((problem.get_terminalData()->Lxx - data->Lxx).isMuchSmallerThan(1.0, 1e-7));
-  BOOST_CHECK((problem.get_terminalData()->Lxu - data->Lxu).isMuchSmallerThan(1.0, 1e-7));
-  BOOST_CHECK((problem.get_terminalData()->Luu - data->Luu).isMuchSmallerThan(1.0, 1e-7));
 }
 
 void test_calcDiff_diffAction(DifferentialActionModelTypes::Type action_model_type) {
@@ -178,12 +174,8 @@ void test_calcDiff_diffAction(DifferentialActionModelTypes::Type action_model_ty
   model->calc(data, xs.back());
   model->calcDiff(data, xs.back());
   BOOST_CHECK((problem.get_terminalData()->Fx - data->Fx).isMuchSmallerThan(1.0, 1e-7));
-  BOOST_CHECK((problem.get_terminalData()->Fu - data->Fu).isMuchSmallerThan(1.0, 1e-7));
   BOOST_CHECK((problem.get_terminalData()->Lx - data->Lx).isMuchSmallerThan(1.0, 1e-7));
-  BOOST_CHECK((problem.get_terminalData()->Lu - data->Lu).isMuchSmallerThan(1.0, 1e-7));
   BOOST_CHECK((problem.get_terminalData()->Lxx - data->Lxx).isMuchSmallerThan(1.0, 1e-7));
-  BOOST_CHECK((problem.get_terminalData()->Lxu - data->Lxu).isMuchSmallerThan(1.0, 1e-7));
-  BOOST_CHECK((problem.get_terminalData()->Luu - data->Luu).isMuchSmallerThan(1.0, 1e-7));
 }
 
 void test_rollout(ActionModelTypes::Type action_model_type) {

--- a/unittest/test_problem.cpp
+++ b/unittest/test_problem.cpp
@@ -1,0 +1,345 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2020, University of Edinburgh
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#define BOOST_TEST_NO_MAIN
+#define BOOST_TEST_ALTERNATIVE_INIT_API
+
+#include "crocoddyl/core/optctrl/shooting.hpp"
+#include "crocoddyl/core/integrator/euler.hpp"
+#include "factory/action.hpp"
+#include "factory/diff_action.hpp"
+#include "unittest_common.hpp"
+
+using namespace boost::unit_test;
+using namespace crocoddyl::unittest;
+
+//----------------------------------------------------------------------------//
+
+void test_calc(ActionModelTypes::Type action_model_type) {
+  // create the model
+  ActionModelFactory factory;
+  const boost::shared_ptr<crocoddyl::ActionModelAbstract>& model = factory.create(action_model_type);
+
+  // create the shooting problem
+  std::size_t T = 20;
+  const Eigen::VectorXd& x0 = model->get_state()->rand();
+  std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstract> > models(T, model);
+  crocoddyl::ShootingProblem problem(x0, models, model);
+
+  // create random trajectory
+  std::vector<Eigen::VectorXd> xs(T + 1);
+  std::vector<Eigen::VectorXd> us(T);
+  for (std::size_t i = 0; i < T; ++i) {
+    xs[i] = model->get_state()->rand();
+    us[i] = Eigen::VectorXd::Random(model->get_nu());
+  }
+  xs.back() = model->get_state()->rand();
+
+  // check the state and cost in each node
+  problem.calc(xs, us);
+  for (std::size_t i = 0; i < T; ++i) {
+    const boost::shared_ptr<crocoddyl::ActionDataAbstract>& data = model->createData();
+    model->calc(data, xs[i], us[i]);
+    BOOST_CHECK(problem.get_runningDatas()[i]->cost == data->cost);
+    BOOST_CHECK((problem.get_runningDatas()[i]->xnext - data->xnext).isMuchSmallerThan(1.0, 1e-7));
+  }
+  const boost::shared_ptr<crocoddyl::ActionDataAbstract>& data = model->createData();
+  model->calc(data, xs.back());
+  BOOST_CHECK(problem.get_terminalData()->cost == data->cost);
+  BOOST_CHECK((problem.get_terminalData()->xnext - data->xnext).isMuchSmallerThan(1.0, 1e-7));
+}
+
+void test_calc_diffAction(DifferentialActionModelTypes::Type action_model_type) {
+  // create the model
+  DifferentialActionModelFactory factory;
+  const boost::shared_ptr<crocoddyl::DifferentialActionModelAbstract>& diffModel = factory.create(action_model_type);
+  const boost::shared_ptr<crocoddyl::ActionModelAbstract>& model =
+      boost::make_shared<crocoddyl::IntegratedActionModelEuler>(diffModel);
+
+  // create the shooting problem
+  std::size_t T = 20;
+  const Eigen::VectorXd& x0 = model->get_state()->rand();
+  std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstract> > models(T, model);
+  crocoddyl::ShootingProblem problem(x0, models, model);
+
+  // create random trajectory
+  std::vector<Eigen::VectorXd> xs(T + 1);
+  std::vector<Eigen::VectorXd> us(T);
+  for (std::size_t i = 0; i < T; ++i) {
+    xs[i] = model->get_state()->rand();
+    us[i] = Eigen::VectorXd::Random(model->get_nu());
+  }
+  xs.back() = model->get_state()->rand();
+
+  // check the state and cost in each node
+  problem.calc(xs, us);
+  for (std::size_t i = 0; i < T; ++i) {
+    const boost::shared_ptr<crocoddyl::ActionDataAbstract>& data = model->createData();
+    model->calc(data, xs[i], us[i]);
+    BOOST_CHECK(problem.get_runningDatas()[i]->cost == data->cost);
+    BOOST_CHECK((problem.get_runningDatas()[i]->xnext - data->xnext).isMuchSmallerThan(1.0, 1e-7));
+  }
+  const boost::shared_ptr<crocoddyl::ActionDataAbstract>& data = model->createData();
+  model->calc(data, xs.back());
+  BOOST_CHECK(problem.get_terminalData()->cost == data->cost);
+  BOOST_CHECK((problem.get_terminalData()->xnext - data->xnext).isMuchSmallerThan(1.0, 1e-7));
+}
+
+void test_calcDiff(ActionModelTypes::Type action_model_type) {
+  // create the model
+  ActionModelFactory factory;
+  const boost::shared_ptr<crocoddyl::ActionModelAbstract>& model = factory.create(action_model_type);
+
+  // create the shooting problem
+  std::size_t T = 20;
+  const Eigen::VectorXd& x0 = model->get_state()->rand();
+  std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstract> > models(T, model);
+  crocoddyl::ShootingProblem problem(x0, models, model);
+
+  // create random trajectory
+  std::vector<Eigen::VectorXd> xs(T + 1);
+  std::vector<Eigen::VectorXd> us(T);
+  for (std::size_t i = 0; i < T; ++i) {
+    xs[i] = model->get_state()->rand();
+    us[i] = Eigen::VectorXd::Random(model->get_nu());
+  }
+  xs.back() = model->get_state()->rand();
+
+  // check the state and cost in each node
+  problem.calc(xs, us);
+  problem.calcDiff(xs, us);
+  for (std::size_t i = 0; i < T; ++i) {
+    const boost::shared_ptr<crocoddyl::ActionDataAbstract>& data = model->createData();
+    model->calc(data, xs[i], us[i]);
+    model->calcDiff(data, xs[i], us[i]);
+    BOOST_CHECK((problem.get_runningDatas()[i]->Fx - data->Fx).isMuchSmallerThan(1.0, 1e-7));
+    BOOST_CHECK((problem.get_runningDatas()[i]->Fu - data->Fu).isMuchSmallerThan(1.0, 1e-7));
+    BOOST_CHECK((problem.get_runningDatas()[i]->Lx - data->Lx).isMuchSmallerThan(1.0, 1e-7));
+    BOOST_CHECK((problem.get_runningDatas()[i]->Lu - data->Lu).isMuchSmallerThan(1.0, 1e-7));
+    BOOST_CHECK((problem.get_runningDatas()[i]->Lxx - data->Lxx).isMuchSmallerThan(1.0, 1e-7));
+    BOOST_CHECK((problem.get_runningDatas()[i]->Lxu - data->Lxu).isMuchSmallerThan(1.0, 1e-7));
+    BOOST_CHECK((problem.get_runningDatas()[i]->Luu - data->Luu).isMuchSmallerThan(1.0, 1e-7));
+  }
+  const boost::shared_ptr<crocoddyl::ActionDataAbstract>& data = model->createData();
+  model->calc(data, xs.back());
+  model->calcDiff(data, xs.back());
+  BOOST_CHECK((problem.get_terminalData()->Fx - data->Fx).isMuchSmallerThan(1.0, 1e-7));
+  BOOST_CHECK((problem.get_terminalData()->Fu - data->Fu).isMuchSmallerThan(1.0, 1e-7));
+  BOOST_CHECK((problem.get_terminalData()->Lx - data->Lx).isMuchSmallerThan(1.0, 1e-7));
+  BOOST_CHECK((problem.get_terminalData()->Lu - data->Lu).isMuchSmallerThan(1.0, 1e-7));
+  BOOST_CHECK((problem.get_terminalData()->Lxx - data->Lxx).isMuchSmallerThan(1.0, 1e-7));
+  BOOST_CHECK((problem.get_terminalData()->Lxu - data->Lxu).isMuchSmallerThan(1.0, 1e-7));
+  BOOST_CHECK((problem.get_terminalData()->Luu - data->Luu).isMuchSmallerThan(1.0, 1e-7));
+}
+
+void test_calcDiff_diffAction(DifferentialActionModelTypes::Type action_model_type) {
+  // create the model
+  DifferentialActionModelFactory factory;
+  const boost::shared_ptr<crocoddyl::DifferentialActionModelAbstract>& diffModel = factory.create(action_model_type);
+  const boost::shared_ptr<crocoddyl::ActionModelAbstract>& model =
+      boost::make_shared<crocoddyl::IntegratedActionModelEuler>(diffModel);
+
+  // create the shooting problem
+  std::size_t T = 20;
+  const Eigen::VectorXd& x0 = model->get_state()->rand();
+  std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstract> > models(T, model);
+  crocoddyl::ShootingProblem problem(x0, models, model);
+
+  // create random trajectory
+  std::vector<Eigen::VectorXd> xs(T + 1);
+  std::vector<Eigen::VectorXd> us(T);
+  for (std::size_t i = 0; i < T; ++i) {
+    xs[i] = model->get_state()->rand();
+    us[i] = Eigen::VectorXd::Random(model->get_nu());
+  }
+  xs.back() = model->get_state()->rand();
+
+  // check the state and cost in each node
+  problem.calc(xs, us);
+  problem.calcDiff(xs, us);
+  for (std::size_t i = 0; i < T; ++i) {
+    const boost::shared_ptr<crocoddyl::ActionDataAbstract>& data = model->createData();
+    model->calc(data, xs[i], us[i]);
+    model->calcDiff(data, xs[i], us[i]);
+    BOOST_CHECK((problem.get_runningDatas()[i]->Fx - data->Fx).isMuchSmallerThan(1.0, 1e-7));
+    BOOST_CHECK((problem.get_runningDatas()[i]->Fu - data->Fu).isMuchSmallerThan(1.0, 1e-7));
+    BOOST_CHECK((problem.get_runningDatas()[i]->Lx - data->Lx).isMuchSmallerThan(1.0, 1e-7));
+    BOOST_CHECK((problem.get_runningDatas()[i]->Lu - data->Lu).isMuchSmallerThan(1.0, 1e-7));
+    BOOST_CHECK((problem.get_runningDatas()[i]->Lxx - data->Lxx).isMuchSmallerThan(1.0, 1e-7));
+    BOOST_CHECK((problem.get_runningDatas()[i]->Lxu - data->Lxu).isMuchSmallerThan(1.0, 1e-7));
+    BOOST_CHECK((problem.get_runningDatas()[i]->Luu - data->Luu).isMuchSmallerThan(1.0, 1e-7));
+  }
+  const boost::shared_ptr<crocoddyl::ActionDataAbstract>& data = model->createData();
+  model->calc(data, xs.back());
+  model->calcDiff(data, xs.back());
+  BOOST_CHECK((problem.get_terminalData()->Fx - data->Fx).isMuchSmallerThan(1.0, 1e-7));
+  BOOST_CHECK((problem.get_terminalData()->Fu - data->Fu).isMuchSmallerThan(1.0, 1e-7));
+  BOOST_CHECK((problem.get_terminalData()->Lx - data->Lx).isMuchSmallerThan(1.0, 1e-7));
+  BOOST_CHECK((problem.get_terminalData()->Lu - data->Lu).isMuchSmallerThan(1.0, 1e-7));
+  BOOST_CHECK((problem.get_terminalData()->Lxx - data->Lxx).isMuchSmallerThan(1.0, 1e-7));
+  BOOST_CHECK((problem.get_terminalData()->Lxu - data->Lxu).isMuchSmallerThan(1.0, 1e-7));
+  BOOST_CHECK((problem.get_terminalData()->Luu - data->Luu).isMuchSmallerThan(1.0, 1e-7));
+}
+
+void test_rollout(ActionModelTypes::Type action_model_type) {
+  // create the model
+  ActionModelFactory factory;
+  const boost::shared_ptr<crocoddyl::ActionModelAbstract>& model = factory.create(action_model_type);
+
+  // create the shooting problem
+  std::size_t T = 20;
+  const Eigen::VectorXd& x0 = model->get_state()->rand();
+  std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstract> > models(T, model);
+  crocoddyl::ShootingProblem problem(x0, models, model);
+
+  // create random trajectory
+  std::vector<Eigen::VectorXd> xs(T + 1);
+  std::vector<Eigen::VectorXd> us(T);
+  for (std::size_t i = 0; i < T; ++i) {
+    xs[i] = model->get_state()->zero();
+    us[i] = Eigen::VectorXd::Random(model->get_nu());
+  }
+  xs.back() = model->get_state()->zero();
+
+  // check the state and cost in each node
+  problem.rollout(us, xs);
+  for (std::size_t i = 0; i < T; ++i) {
+    const boost::shared_ptr<crocoddyl::ActionDataAbstract>& data = model->createData();
+    model->calc(data, xs[i], us[i]);
+    BOOST_CHECK((xs[i + 1] - data->xnext).isMuchSmallerThan(1.0, 1e-7));
+  }
+}
+
+void test_rollout_diffAction(DifferentialActionModelTypes::Type action_model_type) {
+  // create the model
+  DifferentialActionModelFactory factory;
+  const boost::shared_ptr<crocoddyl::DifferentialActionModelAbstract>& diffModel = factory.create(action_model_type);
+  const boost::shared_ptr<crocoddyl::ActionModelAbstract>& model =
+      boost::make_shared<crocoddyl::IntegratedActionModelEuler>(diffModel);
+
+  // create the shooting problem
+  std::size_t T = 20;
+  const Eigen::VectorXd& x0 = model->get_state()->rand();
+  std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstract> > models(T, model);
+  crocoddyl::ShootingProblem problem(x0, models, model);
+
+  // create random trajectory
+  std::vector<Eigen::VectorXd> xs(T + 1);
+  std::vector<Eigen::VectorXd> us(T);
+  for (std::size_t i = 0; i < T; ++i) {
+    xs[i] = model->get_state()->zero();
+    us[i] = Eigen::VectorXd::Random(model->get_nu());
+  }
+  xs.back() = model->get_state()->zero();
+
+  // check the state and cost in each node
+  problem.rollout(us, xs);
+  for (std::size_t i = 0; i < T; ++i) {
+    const boost::shared_ptr<crocoddyl::ActionDataAbstract>& data = model->createData();
+    model->calc(data, xs[i], us[i]);
+    BOOST_CHECK((xs[i + 1] - data->xnext).isMuchSmallerThan(1.0, 1e-7));
+  }
+}
+
+void test_quasiStatic(ActionModelTypes::Type action_model_type) {
+  // create the model
+  ActionModelFactory factory;
+  const boost::shared_ptr<crocoddyl::ActionModelAbstract>& model = factory.create(action_model_type);
+
+  // create the shooting problem
+  std::size_t T = 20;
+  const Eigen::VectorXd& x0 = model->get_state()->rand();
+  std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstract> > models(T, model);
+  crocoddyl::ShootingProblem problem(x0, models, model);
+
+  // create random trajectory
+  std::vector<Eigen::VectorXd> xs(T);
+  std::vector<Eigen::VectorXd> us(T);
+  for (std::size_t i = 0; i < T; ++i) {
+    xs[i] = model->get_state()->rand();
+    us[i] = Eigen::VectorXd::Zero(model->get_nu());
+  }
+
+  // check the state and cost in each node
+  problem.quasiStatic(us, xs);
+  for (std::size_t i = 0; i < T; ++i) {
+    const boost::shared_ptr<crocoddyl::ActionDataAbstract>& data = model->createData();
+    Eigen::VectorXd u(model->get_nu());
+    model->quasiStatic(data, u, xs[i]);
+    BOOST_CHECK((u - us[i]).isMuchSmallerThan(1.0, 1e-7));
+  }
+}
+
+void test_quasiStatic_diffAction(DifferentialActionModelTypes::Type action_model_type) {
+  // create the model
+  DifferentialActionModelFactory factory;
+  const boost::shared_ptr<crocoddyl::DifferentialActionModelAbstract>& diffModel = factory.create(action_model_type);
+  const boost::shared_ptr<crocoddyl::ActionModelAbstract>& model =
+      boost::make_shared<crocoddyl::IntegratedActionModelEuler>(diffModel);
+
+  // create the shooting problem
+  std::size_t T = 20;
+  const Eigen::VectorXd& x0 = model->get_state()->rand();
+  std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstract> > models(T, model);
+  crocoddyl::ShootingProblem problem(x0, models, model);
+
+  // create random trajectory
+  std::vector<Eigen::VectorXd> xs(T);
+  std::vector<Eigen::VectorXd> us(T);
+  for (std::size_t i = 0; i < T; ++i) {
+    xs[i] = model->get_state()->rand();
+    us[i] = Eigen::VectorXd::Zero(model->get_nu());
+  }
+
+  // check the state and cost in each node
+  problem.quasiStatic(us, xs);
+  for (std::size_t i = 0; i < T; ++i) {
+    const boost::shared_ptr<crocoddyl::ActionDataAbstract>& data = model->createData();
+    Eigen::VectorXd u(model->get_nu());
+    model->quasiStatic(data, u, xs[i]);
+    BOOST_CHECK((u - us[i]).isMuchSmallerThan(1.0, 1e-7));
+  }
+}
+
+//----------------------------------------------------------------------------//
+
+void register_action_model_unit_tests(ActionModelTypes::Type action_model_type) {
+  boost::test_tools::output_test_stream test_name;
+  test_name << "test_" << action_model_type;
+  std::cout << "Running " << test_name.str() << std::endl;
+  test_suite* ts = BOOST_TEST_SUITE(test_name.str());
+  ts->add(BOOST_TEST_CASE(boost::bind(&test_calc, action_model_type)));
+  ts->add(BOOST_TEST_CASE(boost::bind(&test_calcDiff, action_model_type)));
+  ts->add(BOOST_TEST_CASE(boost::bind(&test_quasiStatic, action_model_type)));
+  ts->add(BOOST_TEST_CASE(boost::bind(&test_rollout, action_model_type)));
+  framework::master_test_suite().add(ts);
+}
+
+void register_diff_action_model_unit_tests(DifferentialActionModelTypes::Type action_model_type) {
+  boost::test_tools::output_test_stream test_name;
+  test_name << "test_" << action_model_type;
+  std::cout << "Running " << test_name.str() << std::endl;
+  test_suite* ts = BOOST_TEST_SUITE(test_name.str());
+  ts->add(BOOST_TEST_CASE(boost::bind(&test_calc_diffAction, action_model_type)));
+  ts->add(BOOST_TEST_CASE(boost::bind(&test_calcDiff_diffAction, action_model_type)));
+  ts->add(BOOST_TEST_CASE(boost::bind(&test_quasiStatic_diffAction, action_model_type)));
+  ts->add(BOOST_TEST_CASE(boost::bind(&test_rollout_diffAction, action_model_type)));
+  framework::master_test_suite().add(ts);
+}
+
+bool init_function() {
+  for (size_t i = 0; i < ActionModelTypes::all.size(); ++i) {
+    register_action_model_unit_tests(ActionModelTypes::all[i]);
+  }
+  for (size_t i = 0; i < DifferentialActionModelTypes::all.size(); ++i) {
+    register_diff_action_model_unit_tests(DifferentialActionModelTypes::all[i]);
+  }
+  return true;
+}
+
+int main(int argc, char** argv) { return ::boost::unit_test::unit_test_main(&init_function, argc, argv); }

--- a/unittest/test_problem.cpp
+++ b/unittest/test_problem.cpp
@@ -254,6 +254,7 @@ void test_quasiStatic(ActionModelTypes::Type action_model_type) {
   std::vector<Eigen::VectorXd> us(T);
   for (std::size_t i = 0; i < T; ++i) {
     xs[i] = model->get_state()->rand();
+    xs[i].tail(model->get_state()->get_nv()) *= 0;
     us[i] = Eigen::VectorXd::Zero(model->get_nu());
   }
 
@@ -261,7 +262,7 @@ void test_quasiStatic(ActionModelTypes::Type action_model_type) {
   problem.quasiStatic(us, xs);
   for (std::size_t i = 0; i < T; ++i) {
     const boost::shared_ptr<crocoddyl::ActionDataAbstract>& data = model->createData();
-    Eigen::VectorXd u(model->get_nu());
+    Eigen::VectorXd u = Eigen::VectorXd::Zero(model->get_nu());
     model->quasiStatic(data, u, xs[i]);
     BOOST_CHECK((u - us[i]).isMuchSmallerThan(1.0, 1e-7));
   }
@@ -285,6 +286,7 @@ void test_quasiStatic_diffAction(DifferentialActionModelTypes::Type action_model
   std::vector<Eigen::VectorXd> us(T);
   for (std::size_t i = 0; i < T; ++i) {
     xs[i] = model->get_state()->rand();
+    xs[i].tail(model->get_state()->get_nv()) *= 0;
     us[i] = Eigen::VectorXd::Zero(model->get_nu());
   }
 
@@ -292,7 +294,7 @@ void test_quasiStatic_diffAction(DifferentialActionModelTypes::Type action_model
   problem.quasiStatic(us, xs);
   for (std::size_t i = 0; i < T; ++i) {
     const boost::shared_ptr<crocoddyl::ActionDataAbstract>& data = model->createData();
-    Eigen::VectorXd u(model->get_nu());
+    Eigen::VectorXd u = Eigen::VectorXd::Zero(model->get_nu());
     model->quasiStatic(data, u, xs[i]);
     BOOST_CHECK((u - us[i]).isMuchSmallerThan(1.0, 1e-7));
   }


### PR DESCRIPTION
This PR proposes a multithreading support for computing the quasi-static commands along a state trajectory. This function helps us to compute faster a warm-start.

To do so, we need to define data for the `quasiStatic` functions defined in free / contact forward dynamics.
Note that the `ShootingProblem::quasiStatic` is bound in Python.