### PR TITLE
[WIP] Travis: Enable ccache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: cpp
 os: [
   "linux"
 ]
+cache: ccache
 
 jobs:
   fast_finish: true


### PR DESCRIPTION
To explore options to speed-up build or re-use caches (cf. [travis docs](https://docs.travis-ci.com/user/caching/)).

Relates to #832 

Other options:
- Use a job to build the artefacts & cache, then use another job to recall the artefacts and run the tests/examples/benchmarks