### PR TITLE
 Missed bindings for the quasiStatic function in differential action models

### DIFF
--- a/bindings/python/crocoddyl/core/diff-action-base.cpp
+++ b/bindings/python/crocoddyl/core/diff-action-base.cpp
@@ -58,6 +58,17 @@ void exposeDifferentialActionAbstract() {
            "allocated. This function returns the allocated data for a predefined\n"
            "DAM.\n"
            ":return DAM data.")
+      .def("quasiStatic", &DifferentialActionModelAbstract_wrap::quasiStatic_x,
+           DifferentialActionModel_quasiStatic_wraps(
+               bp::args("self", "data", "x", "maxiter", "tol"),
+               "Compute the quasic-static control given a state.\n\n"
+               "It runs an iterative Newton step in order to compute the quasic-static regime\n"
+               "given a state configuration.\n"
+               ":param data: action data\n"
+               ":param x: discrete-time state vector\n"
+               ":param maxiter: maximum allowed number of iterations\n"
+               ":param tol: stopping tolerance criteria (default 1e-9)\n"
+               ":return u: quasic-static control"))
       .add_property("nu",
                     bp::make_function(&DifferentialActionModelAbstract_wrap::get_nu,
                                       bp::return_value_policy<bp::return_by_value>()),

--- a/bindings/python/crocoddyl/core/diff-action-base.hpp
+++ b/bindings/python/crocoddyl/core/diff-action-base.hpp
@@ -60,6 +60,9 @@ class DifferentialActionModelAbstract_wrap : public DifferentialActionModelAbstr
   }
 };
 
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(DifferentialActionModel_quasiStatic_wraps,
+                                       DifferentialActionModelAbstract::quasiStatic_x, 2, 4)
+
 }  // namespace python
 }  // namespace crocoddyl
 

--- a/bindings/python/crocoddyl/crocoddyl.cpp
+++ b/bindings/python/crocoddyl/crocoddyl.cpp
@@ -22,11 +22,13 @@ BOOST_PYTHON_MODULE(libcrocoddyl_pywrap) {
 
   typedef double Scalar;
   typedef Eigen::Matrix<Scalar, 6, 1> Vector6;
+  // typedef Eigen::Matrix<Scalar, 4, 6> Matrix46;
   typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 3> MatrixX3;
   typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 1> VectorX;
   typedef Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> MatrixX;
 
   eigenpy::enableEigenPySpecific<Vector6>();
+  // eigenpy::enableEigenPySpecific<Matrix46>();
   eigenpy::enableEigenPySpecific<MatrixX3>();
 
   // Register converters between std::vector and Python list

--- a/include/crocoddyl/core/diff-action-base.hpp
+++ b/include/crocoddyl/core/diff-action-base.hpp
@@ -134,6 +134,21 @@ class DifferentialActionModelAbstractTpl {
   virtual void quasiStatic(const boost::shared_ptr<DifferentialActionDataAbstract>& data, Eigen::Ref<VectorXs> u,
                            const Eigen::Ref<const VectorXs>& x, const std::size_t& maxiter = 100,
                            const Scalar& tol = Scalar(1e-9));
+
+  /**
+   * @copybrief quasicStatic()
+   *
+   * @copydetails quasicStatic()
+   *
+   * @param[in] data    Differential action data
+   * @param[in] x       State point (velocity has to be zero)
+   * @param[in] maxiter Maximum allowed number of iterations
+   * @param[in] tol     Tolerance
+   * @return Quasic static commands
+   */
+  VectorXs quasiStatic_x(const boost::shared_ptr<DifferentialActionDataAbstract>& data, const VectorXs& x,
+                         const std::size_t& maxiter = 100, const Scalar& tol = Scalar(1e-9));
+
   /**
    * @brief Return the dimension of the control input
    */

--- a/include/crocoddyl/core/diff-action-base.hxx
+++ b/include/crocoddyl/core/diff-action-base.hxx
@@ -63,6 +63,16 @@ void DifferentialActionModelAbstractTpl<Scalar>::quasiStatic(
 }
 
 template <typename Scalar>
+typename MathBaseTpl<Scalar>::VectorXs DifferentialActionModelAbstractTpl<Scalar>::quasiStatic_x(
+    const boost::shared_ptr<DifferentialActionDataAbstract>& data, const VectorXs& x, const std::size_t& maxiter,
+    const Scalar& tol) {
+  VectorXs u(nu_);
+  u.setZero();
+  quasiStatic(data, u, x, maxiter, tol);
+  return u;
+}
+
+template <typename Scalar>
 void DifferentialActionModelAbstractTpl<Scalar>::calcDiff(
     const boost::shared_ptr<DifferentialActionDataAbstract>& data, const Eigen::Ref<const VectorXs>& x) {
   calcDiff(data, x, unone_);


### PR DESCRIPTION
After #809, we could derive `quasiStatic` function of differential action models as well. However, the mentioned PR did not include the Python bindings for this case.