### PR TITLE
SolverAbstract: Throw exception if the candidate xs/us have the wrong dimensions

### DIFF
--- a/bindings/python/crocoddyl/core/optctrl/shooting.cpp
+++ b/bindings/python/crocoddyl/core/optctrl/shooting.cpp
@@ -118,7 +118,7 @@ void exposeShootingProblem() {
                     "dimension of the tangent space of the state manifold")
       .add_property("nu_max",
                     bp::make_function(&ShootingProblem::get_nu_max, bp::return_value_policy<bp::return_by_value>()),
-                    "dimension of the maximun control vector");
+                    "dimension of the maximum control vector");
 }
 
 }  // namespace python

--- a/bindings/python/crocoddyl/core/solver-base.cpp
+++ b/bindings/python/crocoddyl/core/solver-base.cpp
@@ -41,7 +41,7 @@ void exposeSolverAbstract() {
            "during the numerical optimization.\n"
            ":param init_xs: initial guess for state trajectory with T+1 elements (default [])\n"
            ":param init_us: initial guess for control trajectory with T elements (default []).\n"
-           ":param maxiter: maximun allowed number of iterations (default 100).\n"
+           ":param maxiter: maximum allowed number of iterations (default 100).\n"
            ":param isFeasible: true if the init_xs are obtained from integrating the init_us (rollout) (default "
            "False).\n"
            ":param regInit: initial guess for the regularization value. Very low\n"

--- a/bindings/python/crocoddyl/core/solvers/ddp.cpp
+++ b/bindings/python/crocoddyl/core/solvers/ddp.cpp
@@ -39,7 +39,7 @@ void exposeSolverDDP() {
                "during the numerical optimization.\n"
                ":param init_xs: initial guess for state trajectory with T+1 elements (default []).\n"
                ":param init_us: initial guess for control trajectory with T elements (default []) (default []).\n"
-               ":param maxiter: maximun allowed number of iterations (default 100).\n"
+               ":param maxiter: maximum allowed number of iterations (default 100).\n"
                ":param isFeasible: true if the init_xs are obtained from integrating the init_us (rollout) (default "
                "False).\n"
                ":param regInit: initial guess for the regularization value. Very low values are typical\n"

--- a/bindings/python/crocoddyl/core/solvers/fddp.cpp
+++ b/bindings/python/crocoddyl/core/solvers/fddp.cpp
@@ -38,7 +38,7 @@ void exposeSolverFDDP() {
                "during the numerical optimization.\n"
                ":param init_xs: initial guess for state trajectory with T+1 elements (default [])\n"
                ":param init_us: initial guess for control trajectory with T elements (default []).\n"
-               ":param maxiter: maximun allowed number of iterations (default 100).\n"
+               ":param maxiter: maximum allowed number of iterations (default 100).\n"
                ":param isFeasible: true if the init_xs are obtained from integrating the init_us (rollout) (default "
                "False).\n"
                ":param regInit: initial guess for the regularization value. Very low values are typical\n"

--- a/include/crocoddyl/core/optctrl/shooting.hpp
+++ b/include/crocoddyl/core/optctrl/shooting.hpp
@@ -219,7 +219,7 @@ class ShootingProblemTpl {
   const std::size_t& get_ndx() const;
 
   /**
-   * @brief Return the maximun dimension of the control vector
+   * @brief Return the maximum dimension of the control vector
    */
   const std::size_t& get_nu_max() const;
 
@@ -233,7 +233,7 @@ class ShootingProblemTpl {
   std::vector<boost::shared_ptr<ActionDataAbstract> > running_datas_;    //!< Running action data
   std::size_t nx_;                                                       //!< State dimension
   std::size_t ndx_;                                                      //!< State rate dimension
-  std::size_t nu_max_;                                                   //!< Maximun control dimension
+  std::size_t nu_max_;                                                   //!< Maximum control dimension
 
  private:
   void allocateData();

--- a/include/crocoddyl/core/optctrl/shooting.hxx
+++ b/include/crocoddyl/core/optctrl/shooting.hxx
@@ -277,7 +277,7 @@ void ShootingProblemTpl<Scalar>::circularAppend(boost::shared_ptr<ActionModelAbs
   }
   if (model->get_nu() > nu_max_) {
     throw_pretty("Invalid argument: "
-                 << "nu node is not bigger than the maximun nu")
+                 << "nu node is greater than the maximum nu")
   }
 
   for (std::size_t i = 0; i < T_ - 1; ++i) {
@@ -300,7 +300,7 @@ void ShootingProblemTpl<Scalar>::circularAppend(boost::shared_ptr<ActionModelAbs
   }
   if (model->get_nu() > nu_max_) {
     throw_pretty("Invalid argument: "
-                 << "nu node is not bigger than the maximun nu")
+                 << "nu node is greater than the maximum nu")
   }
 
   for (std::size_t i = 0; i < T_ - 1; ++i) {
@@ -333,7 +333,7 @@ void ShootingProblemTpl<Scalar>::updateNode(std::size_t i, boost::shared_ptr<Act
   }
   if (model->get_nu() > nu_max_) {
     throw_pretty("Invalid argument: "
-                 << "nu node is not bigger than the maximun nu")
+                 << "nu node is greater than the maximum nu")
   }
 
   if (i == T_) {
@@ -361,7 +361,7 @@ void ShootingProblemTpl<Scalar>::updateModel(std::size_t i, boost::shared_ptr<Ac
   }
   if (model->get_nu() > nu_max_) {
     throw_pretty("Invalid argument: "
-                 << "nu node is not bigger than the maximun nu")
+                 << "nu node is greater than the maximum nu")
   }
 
   if (i == T_ + 1) {
@@ -440,7 +440,7 @@ void ShootingProblemTpl<Scalar>::set_runningModels(
     }
     if (model->get_nu() > nu_max_) {
       throw_pretty("Invalid argument: "
-                   << "nu node is not bigger than the maximun nu")
+                   << "nu node is greater than the maximum nu")
     }
   }
 

--- a/include/crocoddyl/core/solver-base.hpp
+++ b/include/crocoddyl/core/solver-base.hpp
@@ -68,12 +68,12 @@ class SolverAbstract {
    *
    * @param[in]  init_xs     initial guess for state trajectory with \f$T+1\f$ elements (default [])
    * @param[in]  init_us     initial guess for control trajectory with \f$T\f$ elements (default [])
-   * @param[in]  maxiter     maximun allowed number of iterations (default 100)
+   * @param[in]  maxiter     maximum allowed number of iterations (default 100)
    * @param[in]  isFeasible  true if the \p init_xs are obtained from integrating the \p init_us (rollout) (default
    * false)
    * @param[in]  regInit     initial guess for the regularization value. Very low values are typical used with very
    * good guess points (init_xs, init_us)
-   * @return A boolean that describes if convergence was reached.")
+   * @return A boolean that describes if convergence was reached.
    */
   virtual bool solve(const std::vector<Eigen::VectorXd>& init_xs = DEFAULT_VECTOR,
                      const std::vector<Eigen::VectorXd>& init_us = DEFAULT_VECTOR, const std::size_t& maxiter = 100,

--- a/include/crocoddyl/multibody/friction-cone.hxx
+++ b/include/crocoddyl/multibody/friction-cone.hxx
@@ -71,7 +71,7 @@ void FrictionConeTpl<Scalar>::update(const Vector3s& normal, const Scalar& mu, b
   }
   if (max_nforce < Scalar(0.)) {
     max_nforce_ = std::numeric_limits<Scalar>::max();
-    std::cerr << "Warning: max_nforce has to be a positive value, set to maximun value" << std::endl;
+    std::cerr << "Warning: max_nforce has to be a positive value, set to maximum value" << std::endl;
   }
 
   Scalar theta = Scalar(2) * M_PI / static_cast<Scalar>(nf_);

--- a/src/core/solver-base.cpp
+++ b/src/core/solver-base.cpp
@@ -49,8 +49,9 @@ void SolverAbstract::setCandidate(const std::vector<Eigen::VectorXd>& xs_warm,
     }
     xs_.back() = problem_->get_terminalModel()->get_state()->zero();
   } else {
-    assert_pretty(xs_warm.size() == T + 1,
-                  "Warm start state has wrong dimension, got " << xs_warm.size() << " expecting " << (T + 1));
+    if (xs_warm.size() != T + 1) {
+      throw_pretty("Warm start state has wrong dimension, got " << xs_warm.size() << " expecting " << (T + 1));
+    }
     std::copy(xs_warm.begin(), xs_warm.end(), xs_.begin());
   }
 
@@ -59,8 +60,9 @@ void SolverAbstract::setCandidate(const std::vector<Eigen::VectorXd>& xs_warm,
       us_[t] = Eigen::VectorXd::Zero(problem_->get_nu_max());
     }
   } else {
-    assert_pretty(us_warm.size() == T,
-                  "Warm start control has wrong dimension, got " << us_warm.size() << " expecting " << T);
+    if (us_warm.size() != T) {
+      throw_pretty("Warm start control has wrong dimension, got " << us_warm.size() << " expecting " << T);
+    }
     std::copy(us_warm.begin(), us_warm.end(), us_.begin());
   }
   is_feasible_ = is_feasible;

--- a/unittest/python/crocoddyl/solver.py
+++ b/unittest/python/crocoddyl/solver.py
@@ -31,7 +31,7 @@ class SolverAbstract:
         From an initial guess init_xs,init_us (feasible or not), iterate over computeDirection and tryStep until
         stoppingCriteria is below threshold. It also describes the globalization strategy used during the numerical
         optimization.
-        :param maxiter: maximun allowed number of iterations.
+        :param maxiter: maximum allowed number of iterations.
         :param init_xs: initial guess for state trajectory with T+1 elements.
         :param init_us: initial guess for control trajectory with T elements.
         :param isFeasible: true if the init_xs are obtained from integrating the init_us (rollout).


### PR DESCRIPTION
This caught me out again hard :cry:. I checked and I believe this was the last `assert_pretty` that could have unintended consequences.

assert_pretty is silent in Release mode. Passing in a wrong-sized xs/us
will be copied and messes up the entire memory resulting in optimisation
rubbish. Moving these checks to if / throw_pretty resolves this issue.