### PR TITLE
[solver/ddp] if gaps are zero, solution is feasible

### DIFF
--- a/bindings/python/crocoddyl/core/solvers/ddp.cpp
+++ b/bindings/python/crocoddyl/core/solvers/ddp.cpp
@@ -119,6 +119,10 @@ void exposeSolverDDP() {
                     bp::make_function(&SolverDDP::get_th_grad, bp::return_value_policy<bp::copy_const_reference>()),
                     bp::make_function(&SolverDDP::set_th_grad),
                     "threshold for accepting step which gradients is lower than this value")
+      .add_property("th_gaptol",
+                    bp::make_function(&SolverDDP::get_th_gaptol, bp::return_value_policy<bp::copy_const_reference>()),
+                    bp::make_function(&SolverDDP::set_th_gaptol),
+                    "threshold for accepting a gap as non-zero")
       .add_property("alphas",
                     bp::make_function(&SolverDDP::get_alphas, bp::return_value_policy<bp::copy_const_reference>()),
                     bp::make_function(&SolverDDP::set_alphas), "list of step length (alpha) values");

--- a/include/crocoddyl/core/solvers/ddp.hpp
+++ b/include/crocoddyl/core/solvers/ddp.hpp
@@ -186,6 +186,11 @@ class SolverDDP : public SolverAbstract {
   const double& get_th_grad() const;
 
   /**
+   * @brief Return the threshold for accepting a gap as non-zero
+   */
+  const double& get_th_gaptol() const;
+  
+  /**
    * @brief Return the Hessian of the Value function \f$V_{\mathbf{xx}_s}\f$
    */
   const std::vector<Eigen::MatrixXd>& get_Vxx() const;
@@ -270,6 +275,11 @@ class SolverDDP : public SolverAbstract {
    */
   void set_th_grad(const double& th_grad);
 
+  /**
+   * @brief Modify the threshold for accepting a gap as non-zero
+   */
+  void set_th_gaptol(const double& th_gaptol);
+  
  protected:
   double regfactor_;  //!< Regularization factor used to decrease / increase it
   double regmin_;     //!< Minimum allowed regularization value
@@ -300,6 +310,7 @@ class SolverDDP : public SolverAbstract {
   std::vector<Eigen::VectorXd> Quuk_;                  //!< Quuk term
   std::vector<double> alphas_;                         //!< Set of step lengths using by the line-search procedure
   double th_grad_;     //!< Tolerance of the expected gradient used for testing the step
+  double th_gaptol_;   //!< Threshold limit to check non-zero gaps
   double th_stepdec_;  //!< Step-length threshold used to decrease regularization
   double th_stepinc_;  //!< Step-length threshold used to increase regularization
   bool was_feasible_;  //!< Label that indicates in the previous iterate was feasible

--- a/src/core/solvers/ddp.cpp
+++ b/src/core/solvers/ddp.cpp
@@ -19,6 +19,7 @@ SolverDDP::SolverDDP(boost::shared_ptr<ShootingProblem> problem)
       regmax_(1e9),
       cost_try_(0.),
       th_grad_(1e-12),
+      th_gaptol_(1e-9),
       th_stepdec_(0.5),
       th_stepinc_(0.01),
       was_feasible_(false) {
@@ -171,7 +172,7 @@ double SolverDDP::calcDiff() {
       const boost::shared_ptr<ActionDataAbstract>& d = datas[t];
       model->get_state()->diff(xs_[t + 1], d->xnext, fs_[t + 1]);
       if(could_be_feasible) {
-        if (fs_[t + 1].lpNorm<Eigen::Infinity>() >= 1e-9) {
+        if (fs_[t + 1].lpNorm<Eigen::Infinity>() >= th_gaptol_) {
           could_be_feasible = false;
         }
       }
@@ -406,6 +407,8 @@ const double& SolverDDP::get_th_stepinc() const { return th_stepinc_; }
 
 const double& SolverDDP::get_th_grad() const { return th_grad_; }
 
+const double& SolverDDP::get_th_gaptol() const { return th_gaptol_; }
+
 const std::vector<Eigen::MatrixXd>& SolverDDP::get_Vxx() const { return Vxx_; }
 
 const std::vector<Eigen::VectorXd>& SolverDDP::get_Vx() const { return Vx_; }
@@ -494,4 +497,13 @@ void SolverDDP::set_th_grad(const double& th_grad) {
   th_grad_ = th_grad;
 }
 
+void SolverDDP::set_th_gaptol(const double& th_gaptol) {
+  if (0. > th_gaptol) {
+    throw_pretty("Invalid argument: "
+                 << "th_gaptol value has to be positive.");
+  }
+  th_gaptol_ = th_gaptol;
+}
+
+  
 }  // namespace crocoddyl

--- a/src/core/solvers/ddp.cpp
+++ b/src/core/solvers/ddp.cpp
@@ -164,11 +164,16 @@ double SolverDDP::calcDiff() {
     const std::size_t& T = problem_->get_T();
     const std::vector<boost::shared_ptr<ActionModelAbstract> >& models = problem_->get_runningModels();
     const std::vector<boost::shared_ptr<ActionDataAbstract> >& datas = problem_->get_runningDatas();
+
+    bool could_be_feasible = true;
     for (std::size_t t = 0; t < T; ++t) {
       const boost::shared_ptr<ActionModelAbstract>& model = models[t];
       const boost::shared_ptr<ActionDataAbstract>& d = datas[t];
       model->get_state()->diff(xs_[t + 1], d->xnext, fs_[t + 1]);
+      if (fs_[t + 1].lpNorm<Eigen::Infinity>() >= 1e-9) could_be_feasible = false;
     }
+    is_feasible_ = could_be_feasible;
+
   } else if (!was_feasible_) {  // closing the gaps
     for (std::vector<Eigen::VectorXd>::iterator it = fs_.begin(); it != fs_.end(); ++it) {
       it->setZero();

--- a/src/core/solvers/ddp.cpp
+++ b/src/core/solvers/ddp.cpp
@@ -170,7 +170,11 @@ double SolverDDP::calcDiff() {
       const boost::shared_ptr<ActionModelAbstract>& model = models[t];
       const boost::shared_ptr<ActionDataAbstract>& d = datas[t];
       model->get_state()->diff(xs_[t + 1], d->xnext, fs_[t + 1]);
-      if (fs_[t + 1].lpNorm<Eigen::Infinity>() >= 1e-9) could_be_feasible = false;
+      if(could_be_feasible) {
+        if (fs_[t + 1].lpNorm<Eigen::Infinity>() >= 1e-9) {
+          could_be_feasible = false;
+        }
+      }
     }
     is_feasible_ = could_be_feasible;
 


### PR DESCRIPTION
This comes from a problem that is documented here: https://gitlab.laas.fr/aparag/warmStart/-/blob/master/unicycle/Feasible%20warmstart.ipynb

If the solver is being started with isFeasible=False. This boolean is only updated to true when you make a full step. And if for some reason, this doesn't happen (which normally should not occur), this boolean remains False. We don't set this boolean on the basis of the gaps. we set it on the basis of the user input.