### PR TITLE
DDP objects change size when the actionmodels.nu size < nu_max. Fix this bug

### DIFF
--- a/include/crocoddyl/core/optctrl/shooting.hxx
+++ b/include/crocoddyl/core/optctrl/shooting.hxx
@@ -144,8 +144,9 @@ Scalar ShootingProblemTpl<Scalar>::calc(const std::vector<VectorXs>& xs, const s
 #pragma omp parallel for
 #endif
   for (std::size_t i = 0; i < T_; ++i) {
-    if (running_models_[i]->get_nu() != 0) {
-      running_models_[i]->calc(running_datas_[i], xs[i], us[i]);
+    const std::size_t& nu = running_models_[i]->get_nu();
+    if (nu != 0) {
+      running_models_[i]->calc(running_datas_[i], xs[i], us[i].head(nu));
     } else {
       running_models_[i]->calc(running_datas_[i], xs[i]);
     }
@@ -176,7 +177,8 @@ Scalar ShootingProblemTpl<Scalar>::calcDiff(const std::vector<VectorXs>& xs, con
 #endif
   for (std::size_t i = 0; i < T_; ++i) {
     if (running_models_[i]->get_nu() != 0) {
-      running_models_[i]->calcDiff(running_datas_[i], xs[i], us[i]);
+      const std::size_t& nu = running_models_[i]->get_nu();
+      running_models_[i]->calcDiff(running_datas_[i], xs[i], us[i].head(nu));
     } else {
       running_models_[i]->calcDiff(running_datas_[i], xs[i]);
     }

--- a/include/crocoddyl/core/optctrl/shooting.hxx
+++ b/include/crocoddyl/core/optctrl/shooting.hxx
@@ -210,10 +210,10 @@ void ShootingProblemTpl<Scalar>::rollout(const std::vector<VectorXs>& us, std::v
     const boost::shared_ptr<ActionModelAbstract>& model = running_models_[i];
     const boost::shared_ptr<ActionDataAbstract>& data = running_datas_[i];
     const VectorXs& x = xs[i];
-
+    const std::size_t& nu = running_models_[i]->get_nu();
     if (model->get_nu() != 0) {
       const VectorXs& u = us[i];
-      model->calc(data, x, u);
+      model->calc(data, x, u.head(nu));
     } else {
       model->calc(data, x);
     }
@@ -246,7 +246,8 @@ void ShootingProblemTpl<Scalar>::quasiStatic(std::vector<VectorXs>& us, const st
 #pragma omp parallel for
 #endif
   for (std::size_t i = 0; i < T_; ++i) {
-    running_models_[i]->quasiStatic(running_datas_[i], us[i], xs[i]);
+    const std::size_t& nu = running_models_[i]->get_nu();
+    running_models_[i]->quasiStatic(running_datas_[i], us[i].head(nu), xs[i]);
   }
 }
 

--- a/src/core/solvers/box-ddp.cpp
+++ b/src/core/solvers/box-ddp.cpp
@@ -44,32 +44,34 @@ void SolverBoxDDP::allocateData() {
 }
 
 void SolverBoxDDP::computeGains(const std::size_t& t) {
-  if (problem_->get_runningModels()[t]->get_nu() > 0) {
+  const std::size_t& nu = problem_->get_runningModels()[t]->get_nu();
+  if (nu > 0) {
     if (!problem_->get_runningModels()[t]->get_has_control_limits() || !is_feasible_) {
       // No control limits on this model: Use vanilla DDP
       SolverDDP::computeGains(t);
       return;
     }
 
-    du_lb_ = problem_->get_runningModels()[t]->get_u_lb() - us_[t];
-    du_ub_ = problem_->get_runningModels()[t]->get_u_ub() - us_[t];
+    du_lb_.head(nu) = problem_->get_runningModels()[t]->get_u_lb() - us_[t].head(nu);
+    du_ub_.head(nu) = problem_->get_runningModels()[t]->get_u_ub() - us_[t].head(nu);
 
-    const BoxQPSolution& boxqp_sol = qp_.solve(Quu_[t], Qu_[t], du_lb_, du_ub_, k_[t]);
+    const BoxQPSolution& boxqp_sol = qp_.solve(Quu_[t].topLeftCorner(nu,nu), Qu_[t].head(nu),
+                                               du_lb_.head(nu), du_ub_.head(nu), k_[t].head(nu));
 
     // Compute controls
-    Quu_inv_[t].setZero();
+    Quu_inv_[t].topLeftCorner(nu,nu).setZero();
     for (std::size_t i = 0; i < boxqp_sol.free_idx.size(); ++i) {
       for (std::size_t j = 0; j < boxqp_sol.free_idx.size(); ++j) {
         Quu_inv_[t](boxqp_sol.free_idx[i], boxqp_sol.free_idx[j]) = boxqp_sol.Hff_inv(i, j);
       }
     }
-    K_[t].noalias() = Quu_inv_[t] * Qxu_[t].transpose();
-    k_[t].noalias() = -boxqp_sol.x;
+    K_[t].topRows(nu).noalias() = Quu_inv_[t].topLeftCorner(nu,nu) * Qxu_[t].leftCols(nu).transpose();
+    k_[t].topRows(nu).noalias() = -boxqp_sol.x;
 
     // The box-QP clamped the gradient direction; this is important for accounting
     // the algorithm advancement (i.e. stopping criteria)
     for (std::size_t i = 0; i < boxqp_sol.clamped_idx.size(); ++i) {
-      Qu_[t](boxqp_sol.clamped_idx[i]) = 0.;
+      Qu_[t].head(nu)(boxqp_sol.clamped_idx[i]) = 0.;
     }
   }
 }
@@ -87,15 +89,16 @@ void SolverBoxDDP::forwardPass(const double& steplength) {
   for (std::size_t t = 0; t < T; ++t) {
     const boost::shared_ptr<ActionModelAbstract>& m = models[t];
     const boost::shared_ptr<ActionDataAbstract>& d = datas[t];
-
+    const std::size_t& nu = m->get_nu();
+    
     xs_try_[t] = xnext_;
     m->get_state()->diff(xs_[t], xs_try_[t], dx_[t]);
-    if (m->get_nu() != 0) {
-      us_try_[t].noalias() = us_[t] - k_[t] * steplength - K_[t] * dx_[t];
+    if (nu != 0) {
+      us_try_[t].head(nu).noalias() = us_[t].head(nu) - k_[t].head(nu) * steplength - K_[t].topRows(nu) * dx_[t];
       if (m->get_has_control_limits()) {  // clamp control
-        us_try_[t] = us_try_[t].cwiseMax(m->get_u_lb()).cwiseMin(m->get_u_ub());
+        us_try_[t].head(nu) = us_try_[t].head(nu).cwiseMax(m->get_u_lb()).cwiseMin(m->get_u_ub());
       }
-      m->calc(d, xs_try_[t], us_try_[t]);
+      m->calc(d, xs_try_[t], us_try_[t].head(nu));
     } else {
       m->calc(d, xs_try_[t]);
     }

--- a/src/core/solvers/box-ddp.cpp
+++ b/src/core/solvers/box-ddp.cpp
@@ -55,17 +55,17 @@ void SolverBoxDDP::computeGains(const std::size_t& t) {
     du_lb_.head(nu) = problem_->get_runningModels()[t]->get_u_lb() - us_[t].head(nu);
     du_ub_.head(nu) = problem_->get_runningModels()[t]->get_u_ub() - us_[t].head(nu);
 
-    const BoxQPSolution& boxqp_sol = qp_.solve(Quu_[t].topLeftCorner(nu,nu), Qu_[t].head(nu),
-                                               du_lb_.head(nu), du_ub_.head(nu), k_[t].head(nu));
+    const BoxQPSolution& boxqp_sol =
+        qp_.solve(Quu_[t].topLeftCorner(nu, nu), Qu_[t].head(nu), du_lb_.head(nu), du_ub_.head(nu), k_[t].head(nu));
 
     // Compute controls
-    Quu_inv_[t].topLeftCorner(nu,nu).setZero();
+    Quu_inv_[t].topLeftCorner(nu, nu).setZero();
     for (std::size_t i = 0; i < boxqp_sol.free_idx.size(); ++i) {
       for (std::size_t j = 0; j < boxqp_sol.free_idx.size(); ++j) {
         Quu_inv_[t](boxqp_sol.free_idx[i], boxqp_sol.free_idx[j]) = boxqp_sol.Hff_inv(i, j);
       }
     }
-    K_[t].topRows(nu).noalias() = Quu_inv_[t].topLeftCorner(nu,nu) * Qxu_[t].leftCols(nu).transpose();
+    K_[t].topRows(nu).noalias() = Quu_inv_[t].topLeftCorner(nu, nu) * Qxu_[t].leftCols(nu).transpose();
     k_[t].topRows(nu).noalias() = -boxqp_sol.x;
 
     // The box-QP clamped the gradient direction; this is important for accounting
@@ -90,7 +90,7 @@ void SolverBoxDDP::forwardPass(const double& steplength) {
     const boost::shared_ptr<ActionModelAbstract>& m = models[t];
     const boost::shared_ptr<ActionDataAbstract>& d = datas[t];
     const std::size_t& nu = m->get_nu();
-    
+
     xs_try_[t] = xnext_;
     m->get_state()->diff(xs_[t], xs_try_[t], dx_[t]);
     if (nu != 0) {

--- a/src/core/solvers/box-fddp.cpp
+++ b/src/core/solvers/box-fddp.cpp
@@ -55,17 +55,17 @@ void SolverBoxFDDP::computeGains(const std::size_t& t) {
     du_lb_.head(nu) = problem_->get_runningModels()[t]->get_u_lb() - us_[t].head(nu);
     du_ub_.head(nu) = problem_->get_runningModels()[t]->get_u_ub() - us_[t].head(nu);
 
-    const BoxQPSolution& boxqp_sol = qp_.solve(Quu_[t].topLeftCorner(nu,nu), Qu_[t].head(nu),
-                                               du_lb_.head(nu), du_ub_.head(nu), k_[t].head(nu));
+    const BoxQPSolution& boxqp_sol =
+        qp_.solve(Quu_[t].topLeftCorner(nu, nu), Qu_[t].head(nu), du_lb_.head(nu), du_ub_.head(nu), k_[t].head(nu));
 
     // Compute controls
-    Quu_inv_[t].topLeftCorner(nu,nu).setZero();
+    Quu_inv_[t].topLeftCorner(nu, nu).setZero();
     for (std::size_t i = 0; i < boxqp_sol.free_idx.size(); ++i) {
       for (std::size_t j = 0; j < boxqp_sol.free_idx.size(); ++j) {
         Quu_inv_[t](boxqp_sol.free_idx[i], boxqp_sol.free_idx[j]) = boxqp_sol.Hff_inv(i, j);
       }
     }
-    K_[t].topRows(nu).noalias() = Quu_inv_[t].topLeftCorner(nu,nu) * Qxu_[t].leftCols(nu).transpose();
+    K_[t].topRows(nu).noalias() = Quu_inv_[t].topLeftCorner(nu, nu) * Qxu_[t].leftCols(nu).transpose();
     k_[t].topRows(nu).noalias() = -boxqp_sol.x;
 
     // The box-QP clamped the gradient direction; this is important for accounting

--- a/src/core/solvers/box-fddp.cpp
+++ b/src/core/solvers/box-fddp.cpp
@@ -44,32 +44,34 @@ void SolverBoxFDDP::allocateData() {
 }
 
 void SolverBoxFDDP::computeGains(const std::size_t& t) {
-  if (problem_->get_runningModels()[t]->get_nu() > 0) {
+  const std::size_t& nu = problem_->get_runningModels()[t]->get_nu();
+  if (nu > 0) {
     if (!problem_->get_runningModels()[t]->get_has_control_limits() || !is_feasible_) {
       // No control limits on this model: Use vanilla DDP
       SolverFDDP::computeGains(t);
       return;
     }
 
-    du_lb_ = problem_->get_runningModels()[t]->get_u_lb() - us_[t];
-    du_ub_ = problem_->get_runningModels()[t]->get_u_ub() - us_[t];
+    du_lb_.head(nu) = problem_->get_runningModels()[t]->get_u_lb() - us_[t].head(nu);
+    du_ub_.head(nu) = problem_->get_runningModels()[t]->get_u_ub() - us_[t].head(nu);
 
-    const BoxQPSolution& boxqp_sol = qp_.solve(Quu_[t], Qu_[t], du_lb_, du_ub_, k_[t]);
+    const BoxQPSolution& boxqp_sol = qp_.solve(Quu_[t].topLeftCorner(nu,nu), Qu_[t].head(nu),
+                                               du_lb_.head(nu), du_ub_.head(nu), k_[t].head(nu));
 
     // Compute controls
-    Quu_inv_[t].setZero();
+    Quu_inv_[t].topLeftCorner(nu,nu).setZero();
     for (std::size_t i = 0; i < boxqp_sol.free_idx.size(); ++i) {
       for (std::size_t j = 0; j < boxqp_sol.free_idx.size(); ++j) {
         Quu_inv_[t](boxqp_sol.free_idx[i], boxqp_sol.free_idx[j]) = boxqp_sol.Hff_inv(i, j);
       }
     }
-    K_[t].noalias() = Quu_inv_[t] * Qxu_[t].transpose();
-    k_[t].noalias() = -boxqp_sol.x;
+    K_[t].topRows(nu).noalias() = Quu_inv_[t].topLeftCorner(nu,nu) * Qxu_[t].leftCols(nu).transpose();
+    k_[t].topRows(nu).noalias() = -boxqp_sol.x;
 
     // The box-QP clamped the gradient direction; this is important for accounting
     // the algorithm advancement (i.e. stopping criteria)
     for (std::size_t i = 0; i < boxqp_sol.clamped_idx.size(); ++i) {
-      Qu_[t](boxqp_sol.clamped_idx[i]) = 0.;
+      Qu_[t].head(nu)(boxqp_sol.clamped_idx[i]) = 0.;
     }
   }
 }
@@ -88,15 +90,16 @@ void SolverBoxFDDP::forwardPass(const double& steplength) {
     for (std::size_t t = 0; t < T; ++t) {
       const boost::shared_ptr<ActionModelAbstract>& m = models[t];
       const boost::shared_ptr<ActionDataAbstract>& d = datas[t];
+      const std::size_t& nu = m->get_nu();
 
       xs_try_[t] = xnext_;
       m->get_state()->diff(xs_[t], xs_try_[t], dx_[t]);
-      if (m->get_nu() != 0) {
-        us_try_[t].noalias() = us_[t] - k_[t] * steplength - K_[t] * dx_[t];
+      if (nu != 0) {
+        us_try_[t].head(nu).noalias() = us_[t].head(nu) - k_[t].head(nu) * steplength - K_[t].topRows(nu) * dx_[t];
         if (m->get_has_control_limits()) {  // clamp control
-          us_try_[t] = us_try_[t].cwiseMax(m->get_u_lb()).cwiseMin(m->get_u_ub());
+          us_try_[t].head(nu) = us_try_[t].head(nu).cwiseMax(m->get_u_lb()).cwiseMin(m->get_u_ub());
         }
-        m->calc(d, xs_try_[t], us_try_[t]);
+        m->calc(d, xs_try_[t], us_try_[t].head(nu));
       } else {
         m->calc(d, xs_try_[t]);
       }
@@ -124,15 +127,15 @@ void SolverBoxFDDP::forwardPass(const double& steplength) {
     for (std::size_t t = 0; t < T; ++t) {
       const boost::shared_ptr<ActionModelAbstract>& m = models[t];
       const boost::shared_ptr<ActionDataAbstract>& d = datas[t];
-
+      const std::size_t& nu = m->get_nu();
       m->get_state()->integrate(xnext_, fs_[t] * (steplength - 1), xs_try_[t]);
       m->get_state()->diff(xs_[t], xs_try_[t], dx_[t]);
-      if (m->get_nu() != 0) {
-        us_try_[t].noalias() = us_[t] - k_[t] * steplength - K_[t] * dx_[t];
+      if (nu != 0) {
+        us_try_[t].head(nu).noalias() = us_[t].head(nu) - k_[t].head(nu) * steplength - K_[t].topRows(nu) * dx_[t];
         if (m->get_has_control_limits()) {  // clamp control
-          us_try_[t] = us_try_[t].cwiseMax(m->get_u_lb()).cwiseMin(m->get_u_ub());
+          us_try_[t].head(nu) = us_try_[t].head(nu).cwiseMax(m->get_u_lb()).cwiseMin(m->get_u_ub());
         }
-        m->calc(d, xs_try_[t], us_try_[t]);
+        m->calc(d, xs_try_[t], us_try_[t].head(nu));
       } else {
         m->calc(d, xs_try_[t]);
       }

--- a/src/core/solvers/ddp.cpp
+++ b/src/core/solvers/ddp.cpp
@@ -319,9 +319,12 @@ void SolverDDP::computeGains(const std::size_t& t) {
       throw_pretty("backward_error");
     }
     K_[t].topRows(nu).noalias() = Qxu_[t].leftCols(nu).transpose();
-    Quu_llt_[t].solveInPlace(K_[t].topRows(nu));
+
+    Eigen::Block<Eigen::MatrixXd> K = K_[t].topRows(nu);
+    Quu_llt_[t].solveInPlace(K);
     k_[t].head(nu) = Qu_[t].head(nu);
-    Quu_llt_[t].solveInPlace(k_[t].head(nu));
+    Eigen::VectorBlock<Eigen::VectorXd, Eigen::Dynamic> k = k_[t].head(nu);
+    Quu_llt_[t].solveInPlace(k);
   }
 }
 

--- a/src/core/solvers/ddp.cpp
+++ b/src/core/solvers/ddp.cpp
@@ -135,8 +135,9 @@ double SolverDDP::stoppingCriteria() {
   const std::size_t& T = this->problem_->get_T();
   const std::vector<boost::shared_ptr<ActionModelAbstract> >& models = problem_->get_runningModels();
   for (std::size_t t = 0; t < T; ++t) {
-    if (models[t]->get_nu() != 0) {
-      stop_ += Qu_[t].squaredNorm();
+    const std::size_t& nu = models[t]->get_nu();
+    if (nu != 0) {
+      stop_ += Qu_[t].head(nu).squaredNorm();
     }
   }
   return stop_;
@@ -147,9 +148,10 @@ const Eigen::Vector2d& SolverDDP::expectedImprovement() {
   const std::size_t& T = this->problem_->get_T();
   const std::vector<boost::shared_ptr<ActionModelAbstract> >& models = problem_->get_runningModels();
   for (std::size_t t = 0; t < T; ++t) {
-    if (models[t]->get_nu() != 0) {
-      d_[0] += Qu_[t].dot(k_[t]);
-      d_[1] -= k_[t].dot(Quuk_[t]);
+    const std::size_t& nu = models[t]->get_nu();
+    if (nu != 0) {
+      d_[0] += Qu_[t].head(nu).dot(k_[t].head(nu));
+      d_[1] -= k_[t].head(nu).dot(Quuk_[t].head(nu));
     }
   }
   return d_;
@@ -216,16 +218,16 @@ void SolverDDP::backwardPass() {
     Qxx_[t].noalias() += FxTVxx_p_ * d->Fx;
     Qx_[t].noalias() += d->Fx.transpose() * Vx_p;
     if (nu != 0) {
-      Qxu_[t] = d->Lxu;
-      Quu_[t] = d->Luu;
-      Qu_[t] = d->Lu;
-      FuTVxx_p_[t].noalias() = d->Fu.transpose() * Vxx_p;
-      Qxu_[t].noalias() += FxTVxx_p_ * d->Fu;
-      Quu_[t].noalias() += FuTVxx_p_[t] * d->Fu;
-      Qu_[t].noalias() += d->Fu.transpose() * Vx_p;
+      Qxu_[t].leftCols(nu) = d->Lxu;
+      Quu_[t].topLeftCorner(nu,nu) = d->Luu;
+      Qu_[t].head(nu) = d->Lu;
+      FuTVxx_p_[t].topRows(nu).noalias() = d->Fu.transpose() * Vxx_p;
+      Qxu_[t].leftCols(nu).noalias() += FxTVxx_p_ * d->Fu;
+      Quu_[t].topLeftCorner(nu,nu).noalias() += FuTVxx_p_[t].topRows(nu) * d->Fu;
+      Qu_[t].head(nu).noalias() += d->Fu.transpose() * Vx_p;
 
       if (!std::isnan(ureg_)) {
-        Quu_[t].diagonal().array() += ureg_;
+        Quu_[t].diagonal().head(nu).array() += ureg_;
       }
     }
 
@@ -235,13 +237,14 @@ void SolverDDP::backwardPass() {
     Vxx_[t] = Qxx_[t];
     if (nu != 0) {
       if (std::isnan(ureg_)) {
-        Vx_[t].noalias() -= K_[t].transpose() * Qu_[t];
+        Vx_[t].noalias() -= K_[t].topRows(nu).transpose() * Qu_[t].head(nu);
       } else {
-        Quuk_[t].noalias() = Quu_[t] * k_[t];
-        Vx_[t].noalias() += K_[t].transpose() * Quuk_[t];
-        Vx_[t].noalias() -= 2 * (K_[t].transpose() * Qu_[t]);
+        Quuk_[t].head(nu).noalias() =
+          Quu_[t].topLeftCorner(nu,nu) * k_[t].head(nu);
+        Vx_[t].noalias() += K_[t].topRows(nu).transpose() * Quuk_[t].head(nu);
+        Vx_[t].noalias() -= 2 * (K_[t].topRows(nu).transpose() * Qu_[t].head(nu));
       }
-      Vxx_[t].noalias() -= Qxu_[t] * K_[t];
+      Vxx_[t].noalias() -= Qxu_[t].leftCols(nu) * K_[t].topRows(nu);
     }
     Vxx_[t] = 0.5 * (Vxx_[t] + Vxx_[t].transpose()).eval();
 
@@ -278,10 +281,12 @@ void SolverDDP::forwardPass(const double& steplength) {
 
     m->get_state()->diff(xs_[t], xs_try_[t], dx_[t]);
     if (m->get_nu() != 0) {
-      us_try_[t].noalias() = us_[t];
-      us_try_[t].noalias() -= k_[t] * steplength;
-      us_try_[t].noalias() -= K_[t] * dx_[t];
-      m->calc(d, xs_try_[t], us_try_[t]);
+      const std::size_t& nu = m->get_nu();
+      
+      us_try_[t].head(nu).noalias() = us_[t].head(nu);
+      us_try_[t].head(nu).noalias() -= k_[t].head(nu) * steplength;
+      us_try_[t].head(nu).noalias() -= K_[t].topRows(nu) * dx_[t];
+      m->calc(d, xs_try_[t], us_try_[t].head(nu));
     } else {
       m->calc(d, xs_try_[t]);
     }
@@ -307,16 +312,17 @@ void SolverDDP::forwardPass(const double& steplength) {
 }
 
 void SolverDDP::computeGains(const std::size_t& t) {
-  if (problem_->get_runningModels()[t]->get_nu() > 0) {
-    Quu_llt_[t].compute(Quu_[t]);
+  const std::size_t& nu = problem_->get_runningModels()[t]->get_nu();
+  if (nu > 0) {
+    Quu_llt_[t].compute(Quu_[t].topLeftCorner(nu,nu));
     const Eigen::ComputationInfo& info = Quu_llt_[t].info();
     if (info != Eigen::Success) {
       throw_pretty("backward_error");
     }
-    K_[t] = Qxu_[t].transpose();
-    Quu_llt_[t].solveInPlace(K_[t]);
-    k_[t] = Qu_[t];
-    Quu_llt_[t].solveInPlace(k_[t]);
+    K_[t].topRows(nu).noalias() = Qxu_[t].leftCols(nu).transpose();
+    Quu_llt_[t].solveInPlace(K_[t].topRows(nu));
+    k_[t].head(nu) = Qu_[t].head(nu);
+    Quu_llt_[t].solveInPlace(k_[t].head(nu));
   }
 }
 
@@ -382,7 +388,7 @@ void SolverDDP::allocateData() {
     dx_[t] = Eigen::VectorXd::Zero(ndx);
 
     FuTVxx_p_[t] = Eigen::MatrixXd::Zero(nu, ndx);
-    Quu_llt_[t] = Eigen::LLT<Eigen::MatrixXd>(nu);
+    Quu_llt_[t] = Eigen::LLT<Eigen::MatrixXd>(model->get_nu());
     Quuk_[t] = Eigen::VectorXd(nu);
   }
   Vxx_.back() = Eigen::MatrixXd::Zero(ndx, ndx);

--- a/src/core/solvers/ddp.cpp
+++ b/src/core/solvers/ddp.cpp
@@ -219,11 +219,11 @@ void SolverDDP::backwardPass() {
     Qx_[t].noalias() += d->Fx.transpose() * Vx_p;
     if (nu != 0) {
       Qxu_[t].leftCols(nu) = d->Lxu;
-      Quu_[t].topLeftCorner(nu,nu) = d->Luu;
+      Quu_[t].topLeftCorner(nu, nu) = d->Luu;
       Qu_[t].head(nu) = d->Lu;
       FuTVxx_p_[t].topRows(nu).noalias() = d->Fu.transpose() * Vxx_p;
       Qxu_[t].leftCols(nu).noalias() += FxTVxx_p_ * d->Fu;
-      Quu_[t].topLeftCorner(nu,nu).noalias() += FuTVxx_p_[t].topRows(nu) * d->Fu;
+      Quu_[t].topLeftCorner(nu, nu).noalias() += FuTVxx_p_[t].topRows(nu) * d->Fu;
       Qu_[t].head(nu).noalias() += d->Fu.transpose() * Vx_p;
 
       if (!std::isnan(ureg_)) {
@@ -239,8 +239,7 @@ void SolverDDP::backwardPass() {
       if (std::isnan(ureg_)) {
         Vx_[t].noalias() -= K_[t].topRows(nu).transpose() * Qu_[t].head(nu);
       } else {
-        Quuk_[t].head(nu).noalias() =
-          Quu_[t].topLeftCorner(nu,nu) * k_[t].head(nu);
+        Quuk_[t].head(nu).noalias() = Quu_[t].topLeftCorner(nu, nu) * k_[t].head(nu);
         Vx_[t].noalias() += K_[t].topRows(nu).transpose() * Quuk_[t].head(nu);
         Vx_[t].noalias() -= 2 * (K_[t].topRows(nu).transpose() * Qu_[t].head(nu));
       }
@@ -282,7 +281,7 @@ void SolverDDP::forwardPass(const double& steplength) {
     m->get_state()->diff(xs_[t], xs_try_[t], dx_[t]);
     if (m->get_nu() != 0) {
       const std::size_t& nu = m->get_nu();
-      
+
       us_try_[t].head(nu).noalias() = us_[t].head(nu);
       us_try_[t].head(nu).noalias() -= k_[t].head(nu) * steplength;
       us_try_[t].head(nu).noalias() -= K_[t].topRows(nu) * dx_[t];
@@ -314,7 +313,7 @@ void SolverDDP::forwardPass(const double& steplength) {
 void SolverDDP::computeGains(const std::size_t& t) {
   const std::size_t& nu = problem_->get_runningModels()[t]->get_nu();
   if (nu > 0) {
-    Quu_llt_[t].compute(Quu_[t].topLeftCorner(nu,nu));
+    Quu_llt_[t].compute(Quu_[t].topLeftCorner(nu, nu));
     const Eigen::ComputationInfo& info = Quu_llt_[t].info();
     if (info != Eigen::Success) {
       throw_pretty("backward_error");

--- a/src/core/solvers/fddp.cpp
+++ b/src/core/solvers/fddp.cpp
@@ -134,9 +134,10 @@ void SolverFDDP::updateExpectedImprovement() {
   }
   const std::vector<boost::shared_ptr<ActionModelAbstract> >& models = problem_->get_runningModels();
   for (std::size_t t = 0; t < T; ++t) {
-    if (models[t]->get_nu() != 0) {
-      dg_ += Qu_[t].dot(k_[t]);
-      dq_ -= k_[t].dot(Quuk_[t]);
+    const std::size_t& nu = models[t]->get_nu();
+    if (nu != 0) {
+      dg_ += Qu_[t].head(nu).dot(k_[t].head(nu));
+      dq_ -= k_[t].head(nu).dot(Quuk_[t].head(nu));
     }
     if (!is_feasible_) {
       dg_ -= Vx_[t].dot(fs_[t]);
@@ -160,12 +161,13 @@ void SolverFDDP::forwardPass(const double& steplength) {
     for (std::size_t t = 0; t < T; ++t) {
       const boost::shared_ptr<ActionModelAbstract>& m = models[t];
       const boost::shared_ptr<ActionDataAbstract>& d = datas[t];
-
+      const std::size_t& nu = m->get_nu();
+      
       xs_try_[t] = xnext_;
       m->get_state()->diff(xs_[t], xs_try_[t], dx_[t]);
-      if (m->get_nu() != 0) {
-        us_try_[t].noalias() = us_[t] - k_[t] * steplength - K_[t] * dx_[t];
-        m->calc(d, xs_try_[t], us_try_[t]);
+      if (nu != 0) {
+        us_try_[t].head(nu).noalias() = us_[t].head(nu) - k_[t].head(nu) * steplength - K_[t].topRows(nu) * dx_[t];
+        m->calc(d, xs_try_[t], us_try_[t].head(nu));
       } else {
         m->calc(d, xs_try_[t]);
       }
@@ -193,11 +195,12 @@ void SolverFDDP::forwardPass(const double& steplength) {
     for (std::size_t t = 0; t < T; ++t) {
       const boost::shared_ptr<ActionModelAbstract>& m = models[t];
       const boost::shared_ptr<ActionDataAbstract>& d = datas[t];
+      const std::size_t& nu = m->get_nu();
       m->get_state()->integrate(xnext_, fs_[t] * (steplength - 1), xs_try_[t]);
       m->get_state()->diff(xs_[t], xs_try_[t], dx_[t]);
-      if (m->get_nu() != 0) {
-        us_try_[t].noalias() = us_[t] - k_[t] * steplength - K_[t] * dx_[t];
-        m->calc(d, xs_try_[t], us_try_[t]);
+      if (nu != 0) {
+        us_try_[t].head(nu).noalias() = us_[t].head(nu) - k_[t].head(nu) * steplength - K_[t].topRows(nu) * dx_[t];
+        m->calc(d, xs_try_[t], us_try_[t].head(nu));
       } else {
         m->calc(d, xs_try_[t]);
       }

--- a/src/core/solvers/fddp.cpp
+++ b/src/core/solvers/fddp.cpp
@@ -162,7 +162,7 @@ void SolverFDDP::forwardPass(const double& steplength) {
       const boost::shared_ptr<ActionModelAbstract>& m = models[t];
       const boost::shared_ptr<ActionDataAbstract>& d = datas[t];
       const std::size_t& nu = m->get_nu();
-      
+
       xs_try_[t] = xnext_;
       m->get_state()->diff(xs_[t], xs_try_[t], dx_[t]);
       if (nu != 0) {

--- a/src/core/solvers/kkt.cpp
+++ b/src/core/solvers/kkt.cpp
@@ -257,7 +257,7 @@ void SolverKKT::allocateData() {
   nu_ = 0;
   const std::size_t& nx = problem_->get_nx();
   const std::size_t& ndx = problem_->get_ndx();
-  //const std::size_t& nu = problem_->get_nu_max();
+  // const std::size_t& nu = problem_->get_nu_max();
   for (std::size_t t = 0; t < T; ++t) {
     if (t == 0) {
       xs_try_[t] = problem_->get_x0();

--- a/src/core/solvers/kkt.cpp
+++ b/src/core/solvers/kkt.cpp
@@ -257,13 +257,14 @@ void SolverKKT::allocateData() {
   nu_ = 0;
   const std::size_t& nx = problem_->get_nx();
   const std::size_t& ndx = problem_->get_ndx();
-  const std::size_t& nu = problem_->get_nu_max();
+  //const std::size_t& nu = problem_->get_nu_max();
   for (std::size_t t = 0; t < T; ++t) {
     if (t == 0) {
       xs_try_[t] = problem_->get_x0();
     } else {
       xs_try_[t] = Eigen::VectorXd::Constant(nx, NAN);
     }
+    const std::size_t& nu = problem_->get_runningModels()[t]->get_nu();
     us_try_[t] = Eigen::VectorXd::Constant(nu, NAN);
     dxs_[t] = Eigen::VectorXd::Zero(ndx);
     dus_[t] = Eigen::VectorXd::Zero(nu);

--- a/src/core/solvers/kkt.cpp
+++ b/src/core/solvers/kkt.cpp
@@ -257,7 +257,6 @@ void SolverKKT::allocateData() {
   nu_ = 0;
   const std::size_t& nx = problem_->get_nx();
   const std::size_t& ndx = problem_->get_ndx();
-  // const std::size_t& nu = problem_->get_nu_max();
   for (std::size_t t = 0; t < T; ++t) {
     if (t == 0) {
       xs_try_[t] = problem_->get_x0();

--- a/unittest/factory/action.cpp
+++ b/unittest/factory/action.cpp
@@ -39,17 +39,25 @@ std::ostream& operator<<(std::ostream& os, ActionModelTypes::Type type) {
 ActionModelFactory::ActionModelFactory() {}
 ActionModelFactory::~ActionModelFactory() {}
 
-boost::shared_ptr<crocoddyl::ActionModelAbstract> ActionModelFactory::create(ActionModelTypes::Type type) const {
+  boost::shared_ptr<crocoddyl::ActionModelAbstract> ActionModelFactory::create(ActionModelTypes::Type type, bool secondInstance) const {
   boost::shared_ptr<crocoddyl::ActionModelAbstract> action;
   switch (type) {
     case ActionModelTypes::ActionModelUnicycle:
       action = boost::make_shared<crocoddyl::ActionModelUnicycle>();
       break;
     case ActionModelTypes::ActionModelLQRDriftFree:
-      action = boost::make_shared<crocoddyl::ActionModelLQR>(80, 40, true);
+      if(secondInstance) {
+          action = boost::make_shared<crocoddyl::ActionModelLQR>(80, 40, true);
+        } else {
+        action = boost::make_shared<crocoddyl::ActionModelLQR>(80, 20, true);
+      }
       break;
     case ActionModelTypes::ActionModelLQR:
-      action = boost::make_shared<crocoddyl::ActionModelLQR>(80, 40, false);
+      if(secondInstance) {
+          action = boost::make_shared<crocoddyl::ActionModelLQR>(80, 40, false);
+        } else {
+        action = boost::make_shared<crocoddyl::ActionModelLQR>(80, 20, false);
+      }
       break;
     default:
       throw_pretty(__FILE__ ": Wrong ActionModelTypes::Type given");

--- a/unittest/factory/action.cpp
+++ b/unittest/factory/action.cpp
@@ -39,23 +39,24 @@ std::ostream& operator<<(std::ostream& os, ActionModelTypes::Type type) {
 ActionModelFactory::ActionModelFactory() {}
 ActionModelFactory::~ActionModelFactory() {}
 
-  boost::shared_ptr<crocoddyl::ActionModelAbstract> ActionModelFactory::create(ActionModelTypes::Type type, bool secondInstance) const {
+boost::shared_ptr<crocoddyl::ActionModelAbstract> ActionModelFactory::create(ActionModelTypes::Type type,
+                                                                             bool secondInstance) const {
   boost::shared_ptr<crocoddyl::ActionModelAbstract> action;
   switch (type) {
     case ActionModelTypes::ActionModelUnicycle:
       action = boost::make_shared<crocoddyl::ActionModelUnicycle>();
       break;
     case ActionModelTypes::ActionModelLQRDriftFree:
-      if(secondInstance) {
-          action = boost::make_shared<crocoddyl::ActionModelLQR>(80, 40, true);
-        } else {
+      if (secondInstance) {
+        action = boost::make_shared<crocoddyl::ActionModelLQR>(80, 40, true);
+      } else {
         action = boost::make_shared<crocoddyl::ActionModelLQR>(80, 20, true);
       }
       break;
     case ActionModelTypes::ActionModelLQR:
-      if(secondInstance) {
-          action = boost::make_shared<crocoddyl::ActionModelLQR>(80, 40, false);
-        } else {
+      if (secondInstance) {
+        action = boost::make_shared<crocoddyl::ActionModelLQR>(80, 40, false);
+      } else {
         action = boost::make_shared<crocoddyl::ActionModelLQR>(80, 20, false);
       }
       break;

--- a/unittest/factory/action.hpp
+++ b/unittest/factory/action.hpp
@@ -39,7 +39,8 @@ class ActionModelFactory {
   explicit ActionModelFactory();
   ~ActionModelFactory();
 
-  boost::shared_ptr<crocoddyl::ActionModelAbstract> create(ActionModelTypes::Type type, bool secondInstance=false) const;
+  boost::shared_ptr<crocoddyl::ActionModelAbstract> create(ActionModelTypes::Type type,
+                                                           bool secondInstance = false) const;
 };
 
 }  // namespace unittest

--- a/unittest/factory/action.hpp
+++ b/unittest/factory/action.hpp
@@ -39,7 +39,7 @@ class ActionModelFactory {
   explicit ActionModelFactory();
   ~ActionModelFactory();
 
-  boost::shared_ptr<crocoddyl::ActionModelAbstract> create(ActionModelTypes::Type type) const;
+  boost::shared_ptr<crocoddyl::ActionModelAbstract> create(ActionModelTypes::Type type, bool secondInstance=false) const;
 };
 
 }  // namespace unittest

--- a/unittest/factory/solver.cpp
+++ b/unittest/factory/solver.cpp
@@ -56,14 +56,14 @@ boost::shared_ptr<crocoddyl::SolverAbstract> SolverFactory::create(SolverTypes::
   boost::shared_ptr<crocoddyl::ActionModelAbstract> model = ActionModelFactory().create(action_type);
   boost::shared_ptr<crocoddyl::ActionModelAbstract> model2 = ActionModelFactory().create(action_type, true);
   std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstract> > running_models;
-  const int halfway = int(T/2);
-  for(int i=0; i<halfway; ++i) {
+  const int halfway = int(T / 2);
+  for (int i = 0; i < halfway; ++i) {
     running_models.push_back(model);
   }
-  for(int i=0; i<T-halfway; ++i) {
+  for (int i = 0; i < T - halfway; ++i) {
     running_models.push_back(model2);
   }
-  
+
   boost::shared_ptr<crocoddyl::ShootingProblem> problem =
       boost::make_shared<crocoddyl::ShootingProblem>(model->get_state()->zero(), running_models, model);
 

--- a/unittest/factory/solver.cpp
+++ b/unittest/factory/solver.cpp
@@ -54,7 +54,16 @@ boost::shared_ptr<crocoddyl::SolverAbstract> SolverFactory::create(SolverTypes::
                                                                    size_t T) const {
   boost::shared_ptr<crocoddyl::SolverAbstract> solver;
   boost::shared_ptr<crocoddyl::ActionModelAbstract> model = ActionModelFactory().create(action_type);
-  std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstract> > running_models(T, model);
+  boost::shared_ptr<crocoddyl::ActionModelAbstract> model2 = ActionModelFactory().create(action_type, true);
+  std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstract> > running_models;
+  const int halfway = int(T/2);
+  for(int i=0; i<halfway; ++i) {
+    running_models.push_back(model);
+  }
+  for(int i=0; i<T-halfway; ++i) {
+    running_models.push_back(model2);
+  }
+  
   boost::shared_ptr<crocoddyl::ShootingProblem> problem =
       boost::make_shared<crocoddyl::ShootingProblem>(model->get_state()->zero(), running_models, model);
 

--- a/unittest/test_solvers.cpp
+++ b/unittest/test_solvers.cpp
@@ -103,8 +103,10 @@ void test_solver_against_kkt_solver(SolverTypes::Type solver_type, ActionModelTy
 
   // check solutions against each other
   for (unsigned int t = 0; t < T; ++t) {
+    const boost::shared_ptr<crocoddyl::ActionModelAbstract>& model = solver->get_problem()->get_runningModels()[t];
+    const std::size_t& nu = model->get_nu();
     BOOST_CHECK((solver->get_xs()[t] - kkt.get_xs()[t]).isMuchSmallerThan(1.0, 1e-9));
-    BOOST_CHECK((solver->get_us()[t] - kkt.get_us()[t]).isMuchSmallerThan(1.0, 1e-9));
+    BOOST_CHECK((solver->get_us()[t].head(nu) - kkt.get_us()[t]).isMuchSmallerThan(1.0, 1e-9));
   }
   BOOST_CHECK((solver->get_xs()[T] - kkt.get_xs()[T]).isMuchSmallerThan(1.0, 1e-9));
 }

--- a/unittest/test_solvers.cpp
+++ b/unittest/test_solvers.cpp
@@ -68,9 +68,6 @@ void test_solver_against_kkt_solver(SolverTypes::Type solver_type, ActionModelTy
   boost::shared_ptr<crocoddyl::SolverAbstract> solver =
       boost::static_pointer_cast<crocoddyl::SolverKKT>(solver_factory.create(solver_type, action_type, T));
 
-  //boost::shared_ptr<crocoddyl::SolverAbstract> solverMultipleActions =
-  //  boost::static_pointer_cast<crocoddyl::SolverKKTMultipleActions>(solver_factory.create(solver_type, action_type, T));
-
   // Get the pointer to the problem so we can create the equivalent kkt solver.
   const boost::shared_ptr<crocoddyl::ShootingProblem>& problem = solver->get_problem();
 

--- a/unittest/test_solvers.cpp
+++ b/unittest/test_solvers.cpp
@@ -68,6 +68,9 @@ void test_solver_against_kkt_solver(SolverTypes::Type solver_type, ActionModelTy
   boost::shared_ptr<crocoddyl::SolverAbstract> solver =
       boost::static_pointer_cast<crocoddyl::SolverKKT>(solver_factory.create(solver_type, action_type, T));
 
+  //boost::shared_ptr<crocoddyl::SolverAbstract> solverMultipleActions =
+  //  boost::static_pointer_cast<crocoddyl::SolverKKTMultipleActions>(solver_factory.create(solver_type, action_type, T));
+
   // Get the pointer to the problem so we can create the equivalent kkt solver.
   const boost::shared_ptr<crocoddyl::ShootingProblem>& problem = solver->get_problem();
 


### PR DESCRIPTION
This PR deals with a bug introduced with #787 . 

All ddp (and derived classes) objects that depend on the action model nu (e.g. `ddp.k`, `ddp.Qu` etc) are stored in an std::vector<>. This std::vector is initialized with each object having a size nu_max (number of rows or number of cols). 

In the `ddp.solve()`, we are assigning to these objects directly from the problem models. For e.g., in https://github.com/loco-3d/crocoddyl/blob/devel/src/core/solvers/ddp.cpp#L221, `Qu` (which is size `nu_max`) is being assigned to an object `d->Lu` (which is size `nu`). Since `nu_max`> `nu`, we haven't had any segfaults yet. But this is problematic implementation.

This PR fixes this bug. 

TODO: 
~~1) Box-DDP and Box-FDDP solvers~~
~~2) KKT solver~~
~~3) add multiple nu action models in unittests~~