### PR TITLE
Cleaned up and fixed minor issues in the documentiobn of cost related classes

### DIFF
--- a/bindings/python/crocoddyl/core/cost-base.cpp
+++ b/bindings/python/crocoddyl/core/cost-base.cpp
@@ -100,7 +100,7 @@ void exposeCostAbstract() {
                     "shared data")
       .add_property("activation",
                     bp::make_getter(&CostDataAbstract::activation, bp::return_value_policy<bp::return_by_value>()),
-                    "terminal data")
+                    "activation data")
       .add_property("cost", bp::make_getter(&CostDataAbstract::cost, bp::return_value_policy<bp::return_by_value>()),
                     bp::make_setter(&CostDataAbstract::cost), "cost value")
       .add_property("Lx", bp::make_getter(&CostDataAbstract::Lx, bp::return_internal_reference<>()),

--- a/bindings/python/crocoddyl/core/cost-base.cpp
+++ b/bindings/python/crocoddyl/core/cost-base.cpp
@@ -26,7 +26,7 @@ void exposeCostAbstract() {
       "and the control input u. The dimension of the residual vector is defined by nr, which belongs to\n"
       "the Euclidean space. On the other hand, the activation function builds a cost value based on the\n"
       "definition of the residual vector. The residual vector has to be specialized in a derived classes.",
-      bp::init<boost::shared_ptr<StateAbstract>, boost::shared_ptr<ActivationModelAbstract>, int>(
+      bp::init<boost::shared_ptr<StateAbstract>, boost::shared_ptr<ActivationModelAbstract>, std::size_t>(
           bp::args("self", "state", "activation", "nu"),
           "Initialize the cost model.\n\n"
           ":param state: state description\n"
@@ -37,14 +37,14 @@ void exposeCostAbstract() {
           "Initialize the cost model.\n\n"
           ":param state: state description\n"
           ":param activation: Activation model"))
-      .def(bp::init<boost::shared_ptr<StateAbstract>, int, int>(
+      .def(bp::init<boost::shared_ptr<StateAbstract>, std::size_t, std::size_t>(
           bp::args("self", "state", "nr", "nu"),
           "Initialize the cost model.\n\n"
           "We use ActivationModelQuad as a default activation model (i.e. a=0.5*||r||^2).\n"
           ":param state: state description\n"
           ":param nr: dimension of residual vector\n"
           ":param nu: dimension of control vector (default state.nv)"))
-      .def(bp::init<boost::shared_ptr<StateAbstract>, int>(
+      .def(bp::init<boost::shared_ptr<StateAbstract>, std::size_t>(
           bp::args("self", "state", "nr"),
           "Initialize the cost model.\n\n"
           "We use ActivationModelQuad as a default activation model (i.e. a=0.5*||r||^2), and the default nu value is "

--- a/bindings/python/crocoddyl/core/cost-base.hpp
+++ b/bindings/python/crocoddyl/core/cost-base.hpp
@@ -10,6 +10,7 @@
 #define BINDINGS_PYTHON_CROCODDYL_CORE_COST_BASE_HPP_
 
 #include "crocoddyl/core/cost-base.hpp"
+#include "crocoddyl/core/utils/to-string.hpp"
 #include "crocoddyl/core/utils/exception.hpp"
 
 namespace crocoddyl {
@@ -32,15 +33,27 @@ class CostModelAbstract_wrap : public CostModelAbstract, public bp::wrapper<Cost
 
   void calc(const boost::shared_ptr<CostDataAbstract>& data, const Eigen::Ref<const Eigen::VectorXd>& x,
             const Eigen::Ref<const Eigen::VectorXd>& u) {
-    assert_pretty(static_cast<std::size_t>(x.size()) == state_->get_nx(), "x has wrong dimension");
-    assert_pretty((static_cast<std::size_t>(u.size()) == nu_ || nu_ == 0), "u has wrong dimension");
+    if (static_cast<std::size_t>(x.size()) != state_->get_nx()) {
+      throw_pretty("Invalid argument: "
+                   << "x has wrong dimension (it should be " + std::to_string(state_->get_nx()) + ")");
+    }
+    if (static_cast<std::size_t>(u.size()) != nu_) {
+      throw_pretty("Invalid argument: "
+                   << "u has wrong dimension (it should be " + std::to_string(nu_) + ")");
+    }
     return bp::call<void>(this->get_override("calc").ptr(), data, (Eigen::VectorXd)x, (Eigen::VectorXd)u);
   }
 
   void calcDiff(const boost::shared_ptr<CostDataAbstract>& data, const Eigen::Ref<const Eigen::VectorXd>& x,
                 const Eigen::Ref<const Eigen::VectorXd>& u) {
-    assert_pretty(static_cast<std::size_t>(x.size()) == state_->get_nx(), "x has wrong dimension");
-    assert_pretty((static_cast<std::size_t>(u.size()) == nu_ || nu_ == 0), "u has wrong dimension");
+    if (static_cast<std::size_t>(x.size()) != state_->get_nx()) {
+      throw_pretty("Invalid argument: "
+                   << "x has wrong dimension (it should be " + std::to_string(state_->get_nx()) + ")");
+    }
+    if (static_cast<std::size_t>(u.size()) != nu_) {
+      throw_pretty("Invalid argument: "
+                   << "u has wrong dimension (it should be " + std::to_string(nu_) + ")");
+    }
     return bp::call<void>(this->get_override("calcDiff").ptr(), data, (Eigen::VectorXd)x, (Eigen::VectorXd)u);
   }
 

--- a/bindings/python/crocoddyl/core/costs/cost-sum.cpp
+++ b/bindings/python/crocoddyl/core/costs/cost-sum.cpp
@@ -67,11 +67,11 @@ void exposeCostSum() {
                                                        ":param state: state description"))
       .def("addCost", &CostModelSum::addCost,
            CostModelSum_addCost_wrap(bp::args("self", "name", "cost", "weight", "active"),
-                                        "Add a cost item.\n\n"
-                                        ":param name: cost name\n"
-                                        ":param cost: cost model\n"
-                                        ":param weight: cost weight\n"
-                                        ":param active: True if the cost is activated (default true)"))
+                                     "Add a cost item.\n\n"
+                                     ":param name: cost name\n"
+                                     ":param cost: cost model\n"
+                                     ":param weight: cost weight\n"
+                                     ":param active: True if the cost is activated (default true)"))
       .def("removeCost", &CostModelSum::removeCost, bp::args("self", "name"),
            "Remove a cost item.\n\n"
            ":param name: cost name")

--- a/bindings/python/crocoddyl/core/costs/cost-sum.cpp
+++ b/bindings/python/crocoddyl/core/costs/cost-sum.cpp
@@ -59,8 +59,7 @@ void exposeCostSum() {
           "Initialize the total cost model.\n\n"
           "For this case the default nu is equals to model.nv.\n"
           ":param state: state description\n"
-          ":param nu: dimension of control vector\n"
-          ":param withResiduals: true if the cost function has residuals"))
+          ":param nu: dimension of control vector"))
       .def(bp::init<boost::shared_ptr<StateAbstract> >(bp::args("self", "state"),
                                                        "Initialize the total cost model.\n\n"
                                                        "For this case the default nu is equals to model.nv.\n"
@@ -104,7 +103,7 @@ void exposeCostSum() {
            ":return total cost data.")
       .add_property("state",
                     bp::make_function(&CostModelSum::get_state, bp::return_value_policy<bp::return_by_value>()),
-                    "state of the multibody system")
+                    "state description")
       .add_property("costs",
                     bp::make_function(&CostModelSum::get_costs, bp::return_value_policy<bp::return_by_value>()),
                     "stack of costs")

--- a/bindings/python/crocoddyl/core/costs/cost-sum.cpp
+++ b/bindings/python/crocoddyl/core/costs/cost-sum.cpp
@@ -20,7 +20,7 @@
 namespace crocoddyl {
 namespace python {
 
-BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(CostModelSum_addContact_wrap, CostModelSum::addCost, 3, 4)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(CostModelSum_addCost_wrap, CostModelSum::addCost, 3, 4)
 
 void exposeCostSum() {
   // Register custom converters between std::map and Python dict
@@ -46,7 +46,6 @@ void exposeCostSum() {
                     "cost model")
       .def_readwrite("weight", &CostItem::weight, "cost weight")
       .def_readwrite("active", &CostItem::active, "cost status");
-  ;
 
   bp::register_ptr_to_python<boost::shared_ptr<CostModelSum> >();
 
@@ -67,7 +66,7 @@ void exposeCostSum() {
                                                        "For this case the default nu is equals to model.nv.\n"
                                                        ":param state: state description"))
       .def("addCost", &CostModelSum::addCost,
-           CostModelSum_addContact_wrap(bp::args("self", "name", "cost", "weight", "active"),
+           CostModelSum_addCost_wrap(bp::args("self", "name", "cost", "weight", "active"),
                                         "Add a cost item.\n\n"
                                         ":param name: cost name\n"
                                         ":param cost: cost model\n"

--- a/include/crocoddyl/core/cost-base.hpp
+++ b/include/crocoddyl/core/cost-base.hpp
@@ -16,7 +16,6 @@
 #include "crocoddyl/core/state-base.hpp"
 #include "crocoddyl/core/data-collector-base.hpp"
 #include "crocoddyl/core/activation-base.hpp"
-#include "crocoddyl/core/utils/to-string.hpp"
 #include "crocoddyl/core/activations/quadratic.hpp"
 
 namespace crocoddyl {

--- a/include/crocoddyl/core/costs/cost-sum.hpp
+++ b/include/crocoddyl/core/costs/cost-sum.hpp
@@ -38,7 +38,7 @@ struct CostItemTpl {
 };
 
 /**
- * @brief Sumation of individual cost models
+ * @brief Summation of individual cost models
  *
  * This class serves to manage a set of added cost models. The cost functions might active or inactive, with this
  * approach we avoid dynamic allocation of memory. Each cost model is added through `addCost`, where the weight and its

--- a/include/crocoddyl/core/costs/cost-sum.hpp
+++ b/include/crocoddyl/core/costs/cost-sum.hpp
@@ -123,7 +123,7 @@ class CostModelSumTpl {
    * @param[in] x     State point \f$\mathbf{x}\in\mathbb{R}^{ndx}\f$
    * @param[in] u     Control input \f$\mathbf{u}\in\mathbb{R}^{nu}\f$
    */
-  void calc(const boost::shared_ptr<CostDataSumTpl<Scalar> >& data, const Eigen::Ref<const VectorXs>& x,
+  void calc(const boost::shared_ptr<CostDataSum>& data, const Eigen::Ref<const VectorXs>& x,
             const Eigen::Ref<const VectorXs>& u);
 
   /**
@@ -133,7 +133,7 @@ class CostModelSumTpl {
    * @param[in] x     State point \f$\mathbf{x}\in\mathbb{R}^{ndx}\f$
    * @param[in] u     Control input \f$\mathbf{u}\in\mathbb{R}^{nu}\f$
    */
-  void calcDiff(const boost::shared_ptr<CostDataSumTpl<Scalar> >& data, const Eigen::Ref<const VectorXs>& x,
+  void calcDiff(const boost::shared_ptr<CostDataSum>& data, const Eigen::Ref<const VectorXs>& x,
                 const Eigen::Ref<const VectorXs>& u);
 
   /**
@@ -146,7 +146,7 @@ class CostModelSumTpl {
    * @param data  Data collector
    * @return the cost data
    */
-  boost::shared_ptr<CostDataSumTpl<Scalar> > createData(DataCollectorAbstract* const data);
+  boost::shared_ptr<CostDataSum> createData(DataCollectorAbstract* const data);
 
   /**
    * @copybrief calc()
@@ -154,7 +154,7 @@ class CostModelSumTpl {
    * @param[in] data  Cost data
    * @param[in] x     State point
    */
-  void calc(const boost::shared_ptr<CostDataSumTpl<Scalar> >& data, const Eigen::Ref<const VectorXs>& x);
+  void calc(const boost::shared_ptr<CostDataSum>& data, const Eigen::Ref<const VectorXs>& x);
 
   /**
    * @copybrief calcDiff()
@@ -162,7 +162,7 @@ class CostModelSumTpl {
    * @param[in] data  Cost data
    * @param[in] x     State point
    */
-  void calcDiff(const boost::shared_ptr<CostDataSumTpl<Scalar> >& data, const Eigen::Ref<const VectorXs>& x);
+  void calcDiff(const boost::shared_ptr<CostDataSum>& data, const Eigen::Ref<const VectorXs>& x);
 
   /**
    * @brief Return the state

--- a/include/crocoddyl/core/costs/cost-sum.hpp
+++ b/include/crocoddyl/core/costs/cost-sum.hpp
@@ -51,7 +51,7 @@ struct CostItemTpl {
  * \f$\mathbf{l_{xx}}\in\mathbb{R}^{ndx\times ndx}\f$, \f$\mathbf{l_{xu}}\in\mathbb{R}^{ndx\times nu}\f$,
  * \f$\mathbf{l_{uu}}\in\mathbb{R}^{nu\times nu}\f$ are the Jacobians and Hessians, respectively.
  *
- * \sa `StateAbstractTpl`, `ActivationModelAbstractTpl`, `calc()`, `calcDiff()`, `createData()`
+ * \sa `StateAbstractTpl`, `calc()`, `calcDiff()`, `createData()`
  */
 template <typename _Scalar>
 class CostModelSumTpl {
@@ -180,7 +180,7 @@ class CostModelSumTpl {
   const std::size_t& get_nu() const;
 
   /**
-   * @brief Return the dimension of the actived residual vector
+   * @brief Return the dimension of the active residual vector
    */
   const std::size_t& get_nr() const;
 


### PR DESCRIPTION
This PR basically cleans up a bit the code:
  - fixed minor things in the documentation
  - used throw_pretty in the Python bindings of cost-base (as done in other cases)
  - simplified a bit more the code (nothing dramatic)