### PR TITLE
DifferentialActionModelContactFwdDynamics type agnostic

### DIFF
--- a/benchmark/bipedal-timings.cpp
+++ b/benchmark/bipedal-timings.cpp
@@ -26,6 +26,7 @@
 #include "crocoddyl/multibody/costs/state.hpp"
 #include "crocoddyl/multibody/costs/control.hpp"
 #include "crocoddyl/multibody/actuations/full.hpp"
+#include "crocoddyl/multibody/actuations/floating-base.hpp"
 #include "crocoddyl/core/utils/callbacks.hpp"
 #include "crocoddyl/core/solvers/ddp.hpp"
 #include "crocoddyl/core/utils/timer.hpp"

--- a/benchmark/bipedal-timings.cpp
+++ b/benchmark/bipedal-timings.cpp
@@ -2,12 +2,9 @@
 // BSD 3-Clause License
 //
 // Copyright (C) 2018-2020, LAAS-CNRS
+// Copyright (C) 2020 CTU, INRIA
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
-//
-// Copyright (c) 2020 CNRS, INRIA
-//
-// Copyright (c) CTU
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <pinocchio/parsers/urdf.hpp>

--- a/benchmark/bipedal-timings.cpp
+++ b/benchmark/bipedal-timings.cpp
@@ -4,6 +4,10 @@
 // Copyright (C) 2018-2020, LAAS-CNRS
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
+//
+// Copyright (c) 2020 CNRS, INRIA
+//
+// Copyright (c) CTU
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <pinocchio/parsers/urdf.hpp>

--- a/bindings/python/crocoddyl/multibody/actions/contact-fwddyn.cpp
+++ b/bindings/python/crocoddyl/multibody/actions/contact-fwddyn.cpp
@@ -21,7 +21,7 @@ void exposeDifferentialActionContactFwdDynamics() {
       "is also a custom implementation in case of system with armatures. If you want to\n"
       "include the armature, you need to use setArmature(). On the other hand, the\n"
       "stack of cost functions are implemented in CostModelSum().",
-      bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActuationModelFloatingBase>,
+      bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActuationModelAbstract>,
                boost::shared_ptr<ContactModelMultiple>, boost::shared_ptr<CostModelSum>, bp::optional<double, bool> >(
           bp::args("self", "state", "actuation", "contacts", "costs", "inv_damping", "enable_force"),
           "Initialize the constrained forward-dynamics action model.\n\n"

--- a/bindings/python/crocoddyl/multibody/actions/contact-fwddyn.cpp
+++ b/bindings/python/crocoddyl/multibody/actions/contact-fwddyn.cpp
@@ -1,13 +1,10 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2018-2020, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2018-2020, LAAS-CNRS
+// Copyright (C) 2020 CTU, INRIA
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
-//
-// Copyright (c) 2020 CNRS, INRIA
-//
-// Copyright (c) CTU
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "python/crocoddyl/multibody/multibody.hpp"

--- a/bindings/python/crocoddyl/multibody/actions/contact-fwddyn.cpp
+++ b/bindings/python/crocoddyl/multibody/actions/contact-fwddyn.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2018-2020, LAAS-CNRS
+// Copyright (C) 2018-2020, LAAS-CNRS, University of Edinburgh
 // Copyright (C) 2020 CTU, INRIA
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.

--- a/bindings/python/crocoddyl/multibody/actions/contact-fwddyn.cpp
+++ b/bindings/python/crocoddyl/multibody/actions/contact-fwddyn.cpp
@@ -4,6 +4,10 @@
 // Copyright (C) 2018-2020, LAAS-CNRS, University of Edinburgh
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
+//
+// Copyright (c) 2020 CNRS, INRIA
+//
+// Copyright (c) CTU
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "python/crocoddyl/multibody/multibody.hpp"
@@ -29,7 +33,7 @@ void exposeDifferentialActionContactFwdDynamics() {
           "a good damping factor could be 1e-12. In addition, if you have cost based on forces,\n"
           "you need to enable the computation of the force Jacobians (i.e. enable_force=True)."
           ":param state: multibody state\n"
-          ":param actuation: floating-base actuation model\n"
+          ":param actuation: actuation model\n"
           ":param contacts: multiple contact model\n"
           ":param costs: stack of cost functions\n"
           ":param inv_damping: Damping factor for cholesky decomposition of JMinvJt (default 0.)\n"

--- a/include/crocoddyl/multibody/actions/contact-fwddyn.hpp
+++ b/include/crocoddyl/multibody/actions/contact-fwddyn.hpp
@@ -4,6 +4,10 @@
 // Copyright (C) 2018-2020, LAAS-CNRS, University of Edinburgh
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
+//
+// Copyright (c) 2020 CNRS, INRIA
+//
+// Copyright (c) CTU
 ///////////////////////////////////////////////////////////////////////////////
 
 #ifndef CROCODDYL_MULTIBODY_ACTIONS_CONTACT_FWDDYN_HPP_

--- a/include/crocoddyl/multibody/actions/contact-fwddyn.hpp
+++ b/include/crocoddyl/multibody/actions/contact-fwddyn.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2018-2020, LAAS-CNRS
+// Copyright (C) 2018-2020, LAAS-CNRS, University of Edinburgh
 // Copyright (C) 2020 CTU, INRIA
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.

--- a/include/crocoddyl/multibody/actions/contact-fwddyn.hpp
+++ b/include/crocoddyl/multibody/actions/contact-fwddyn.hpp
@@ -1,13 +1,10 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2018-2020, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2018-2020, LAAS-CNRS
+// Copyright (C) 2020 CTU, INRIA
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
-//
-// Copyright (c) 2020 CNRS, INRIA
-//
-// Copyright (c) CTU
 ///////////////////////////////////////////////////////////////////////////////
 
 #ifndef CROCODDYL_MULTIBODY_ACTIONS_CONTACT_FWDDYN_HPP_

--- a/include/crocoddyl/multibody/actions/contact-fwddyn.hpp
+++ b/include/crocoddyl/multibody/actions/contact-fwddyn.hpp
@@ -14,7 +14,7 @@
 #include "crocoddyl/multibody/fwd.hpp"
 #include "crocoddyl/core/diff-action-base.hpp"
 #include "crocoddyl/multibody/states/multibody.hpp"
-#include "crocoddyl/multibody/actuations/floating-base.hpp"
+#include "crocoddyl/core/actuation-base.hpp"
 #include "crocoddyl/multibody/contacts/multiple-contacts.hpp"
 #include "crocoddyl/multibody/data/contacts.hpp"
 #include "crocoddyl/multibody/costs/cost-sum.hpp"
@@ -33,13 +33,13 @@ class DifferentialActionModelContactFwdDynamicsTpl : public DifferentialActionMo
   typedef CostModelSumTpl<Scalar> CostModelSum;
   typedef StateMultibodyTpl<Scalar> StateMultibody;
   typedef ContactModelMultipleTpl<Scalar> ContactModelMultiple;
-  typedef ActuationModelFloatingBaseTpl<Scalar> ActuationModelFloatingBase;
+  typedef ActuationModelAbstractTpl<Scalar> ActuationModelAbstract;
   typedef DifferentialActionDataAbstractTpl<Scalar> DifferentialActionDataAbstract;
   typedef typename MathBase::VectorXs VectorXs;
   typedef typename MathBase::MatrixXs MatrixXs;
 
   DifferentialActionModelContactFwdDynamicsTpl(boost::shared_ptr<StateMultibody> state,
-                                               boost::shared_ptr<ActuationModelFloatingBase> actuation,
+                                               boost::shared_ptr<ActuationModelAbstract> actuation,
                                                boost::shared_ptr<ContactModelMultiple> contacts,
                                                boost::shared_ptr<CostModelSum> costs,
                                                const Scalar& JMinvJt_damping = Scalar(0.),
@@ -56,7 +56,7 @@ class DifferentialActionModelContactFwdDynamicsTpl : public DifferentialActionMo
                            const Eigen::Ref<const VectorXs>& x, const std::size_t& maxiter = 100,
                            const Scalar& tol = Scalar(1e-9));
 
-  const boost::shared_ptr<ActuationModelFloatingBase>& get_actuation() const;
+  const boost::shared_ptr<ActuationModelAbstract>& get_actuation() const;
   const boost::shared_ptr<ContactModelMultiple>& get_contacts() const;
   const boost::shared_ptr<CostModelSum>& get_costs() const;
   pinocchio::ModelTpl<Scalar>& get_pinocchio() const;
@@ -76,7 +76,7 @@ class DifferentialActionModelContactFwdDynamicsTpl : public DifferentialActionMo
   using Base::unone_;               //!< Neutral state
 
  private:
-  boost::shared_ptr<ActuationModelFloatingBase> actuation_;
+  boost::shared_ptr<ActuationModelAbstract> actuation_;
   boost::shared_ptr<ContactModelMultiple> contacts_;
   boost::shared_ptr<CostModelSum> costs_;
   pinocchio::ModelTpl<Scalar>& pinocchio_;

--- a/include/crocoddyl/multibody/actions/contact-fwddyn.hxx
+++ b/include/crocoddyl/multibody/actions/contact-fwddyn.hxx
@@ -22,7 +22,7 @@ namespace crocoddyl {
 
 template <typename Scalar>
 DifferentialActionModelContactFwdDynamicsTpl<Scalar>::DifferentialActionModelContactFwdDynamicsTpl(
-    boost::shared_ptr<StateMultibody> state, boost::shared_ptr<ActuationModelFloatingBase> actuation,
+    boost::shared_ptr<StateMultibody> state, boost::shared_ptr<ActuationModelAbstract> actuation,
     boost::shared_ptr<ContactModelMultiple> contacts, boost::shared_ptr<CostModelSum> costs,
     const Scalar& JMinvJt_damping, const bool& enable_force)
     : Base(state, actuation->get_nu(), costs->get_nr()),
@@ -219,7 +219,7 @@ pinocchio::ModelTpl<Scalar>& DifferentialActionModelContactFwdDynamicsTpl<Scalar
 }
 
 template <typename Scalar>
-const boost::shared_ptr<ActuationModelFloatingBaseTpl<Scalar> >&
+const boost::shared_ptr<ActuationModelAbstractTpl<Scalar> >&
 DifferentialActionModelContactFwdDynamicsTpl<Scalar>::get_actuation() const {
   return actuation_;
 }

--- a/include/crocoddyl/multibody/actions/contact-fwddyn.hxx
+++ b/include/crocoddyl/multibody/actions/contact-fwddyn.hxx
@@ -4,6 +4,10 @@
 // Copyright (C) 2018-2020, LAAS-CNRS, University of Edinburgh
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
+//
+// Copyright (c) 2020 CNRS, INRIA
+//
+// Copyright (c) CTU
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "crocoddyl/core/utils/exception.hpp"

--- a/include/crocoddyl/multibody/actions/contact-fwddyn.hxx
+++ b/include/crocoddyl/multibody/actions/contact-fwddyn.hxx
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2018-2020, LAAS-CNRS
+// Copyright (C) 2018-2020, LAAS-CNRS, University of Edinburgh
 // Copyright (C) 2020 CTU, INRIA
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.

--- a/include/crocoddyl/multibody/actions/contact-fwddyn.hxx
+++ b/include/crocoddyl/multibody/actions/contact-fwddyn.hxx
@@ -1,13 +1,10 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2018-2020, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2018-2020, LAAS-CNRS
+// Copyright (C) 2020 CTU, INRIA
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
-//
-// Copyright (c) 2020 CNRS, INRIA
-//
-// Copyright (c) CTU
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "crocoddyl/core/utils/exception.hpp"

--- a/unittest/factory/diff_action.cpp
+++ b/unittest/factory/diff_action.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2018-2020, LAAS-CNRS
+// Copyright (C) 2018-2020, University of Edinburgh
 // Copyright (C) 2020 CTU, INRIA
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.

--- a/unittest/factory/diff_action.cpp
+++ b/unittest/factory/diff_action.cpp
@@ -1,13 +1,10 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2018-2020, University of Edinburgh
+// Copyright (C) 2018-2020, LAAS-CNRS
+// Copyright (C) 2020 CTU, INRIA
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
-//
-// Copyright (c) 2020 CNRS, INRIA
-//
-// Copyright (c) CTU
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "diff_action.hpp"
@@ -94,25 +91,28 @@ boost::shared_ptr<crocoddyl::DifferentialActionModelAbstract> DifferentialAction
                                       ActuationModelTypes::ActuationModelSquashingFull);
       break;
     case DifferentialActionModelTypes::DifferentialActionModelContactFwdDynamics_TalosArm:
-      action = 
-          create_contactFwdDynamics(StateModelTypes::StateMultibody_TalosArm, ActuationModelTypes::ActuationModelFull, false);
+      action = create_contactFwdDynamics(StateModelTypes::StateMultibody_TalosArm,
+                                         ActuationModelTypes::ActuationModelFull, false);
       break;
     case DifferentialActionModelTypes::DifferentialActionModelContactFwdDynamics_HyQ:
-      action = 
-          create_contactFwdDynamics(StateModelTypes::StateMultibody_HyQ, ActuationModelTypes::ActuationModelFloatingBase, false);
+      action = create_contactFwdDynamics(StateModelTypes::StateMultibody_HyQ,
+                                         ActuationModelTypes::ActuationModelFloatingBase, false);
       break;
     case DifferentialActionModelTypes::DifferentialActionModelContactFwdDynamics_Talos:
-      action = 
-          create_contactFwdDynamics(StateModelTypes::StateMultibody_Talos, ActuationModelTypes::ActuationModelFloatingBase, false);
+      action = create_contactFwdDynamics(StateModelTypes::StateMultibody_Talos,
+                                         ActuationModelTypes::ActuationModelFloatingBase, false);
       break;
     case DifferentialActionModelTypes::DifferentialActionModelContactFwdDynamicsWithFriction_TalosArm:
-      action = create_contactFwdDynamics(StateModelTypes::StateMultibody_TalosArm, ActuationModelTypes::ActuationModelFull);
+      action =
+          create_contactFwdDynamics(StateModelTypes::StateMultibody_TalosArm, ActuationModelTypes::ActuationModelFull);
       break;
     case DifferentialActionModelTypes::DifferentialActionModelContactFwdDynamicsWithFriction_HyQ:
-      action = create_contactFwdDynamics(StateModelTypes::StateMultibody_HyQ, ActuationModelTypes::ActuationModelFloatingBase);
+      action = create_contactFwdDynamics(StateModelTypes::StateMultibody_HyQ,
+                                         ActuationModelTypes::ActuationModelFloatingBase);
       break;
     case DifferentialActionModelTypes::DifferentialActionModelContactFwdDynamicsWithFriction_Talos:
-      action = create_contactFwdDynamics(StateModelTypes::StateMultibody_Talos, ActuationModelTypes::ActuationModelFloatingBase);
+      action = create_contactFwdDynamics(StateModelTypes::StateMultibody_Talos,
+                                         ActuationModelTypes::ActuationModelFloatingBase);
       break;
     default:
       throw_pretty(__FILE__ ": Wrong DifferentialActionModelTypes::Type given");
@@ -148,8 +148,9 @@ DifferentialActionModelFactory::create_freeFwdDynamics(StateModelTypes::Type sta
 }
 
 boost::shared_ptr<crocoddyl::DifferentialActionModelContactFwdDynamics>
-DifferentialActionModelFactory::create_contactFwdDynamics(StateModelTypes::Type state_type, 
-        ActuationModelTypes::Type actuation_type, bool with_friction) const {
+DifferentialActionModelFactory::create_contactFwdDynamics(StateModelTypes::Type state_type,
+                                                          ActuationModelTypes::Type actuation_type,
+                                                          bool with_friction) const {
   boost::shared_ptr<crocoddyl::DifferentialActionModelContactFwdDynamics> action;
   boost::shared_ptr<crocoddyl::StateMultibody> state;
   boost::shared_ptr<crocoddyl::ActuationModelAbstract> actuation;
@@ -166,16 +167,18 @@ DifferentialActionModelFactory::create_contactFwdDynamics(StateModelTypes::Type 
       boost::make_shared<crocoddyl::ActivationModelQuadraticBarrier>(bounds);
   switch (state_type) {
     case StateModelTypes::StateMultibody_TalosArm:
-      contact->addContact("lf", boost::make_shared<crocoddyl::ContactModel3D>(
-                                    state,
-                                    crocoddyl::FrameTranslation(state->get_pinocchio()->getFrameId("gripper_left_fingertip_1_link"),
-                                                              Eigen::Vector3d::Zero()),
-                                    actuation->get_nu()));
+      contact->addContact(
+          "lf", boost::make_shared<crocoddyl::ContactModel3D>(
+                    state,
+                    crocoddyl::FrameTranslation(state->get_pinocchio()->getFrameId("gripper_left_fingertip_1_link"),
+                                                Eigen::Vector3d::Zero()),
+                    actuation->get_nu()));
       if (with_friction) {
         cost->addCost("lf_cone",
                       boost::make_shared<crocoddyl::CostModelContactFrictionCone>(
                           state, activation,
-                          crocoddyl::FrameFrictionCone(state->get_pinocchio()->getFrameId("gripper_left_fingertip_1_link"), cone),
+                          crocoddyl::FrameFrictionCone(
+                              state->get_pinocchio()->getFrameId("gripper_left_fingertip_1_link"), cone),
                           actuation->get_nu()),
                       0.1);
       }

--- a/unittest/factory/diff_action.cpp
+++ b/unittest/factory/diff_action.cpp
@@ -4,6 +4,10 @@
 // Copyright (C) 2018-2020, University of Edinburgh
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
+//
+// Copyright (c) 2020 CNRS, INRIA
+//
+// Copyright (c) CTU
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "diff_action.hpp"

--- a/unittest/factory/diff_action.hpp
+++ b/unittest/factory/diff_action.hpp
@@ -27,8 +27,10 @@ struct DifferentialActionModelTypes {
     DifferentialActionModelLQRDriftFree,
     DifferentialActionModelFreeFwdDynamics_TalosArm,
     DifferentialActionModelFreeFwdDynamics_TalosArm_Squashed,
+    DifferentialActionModelContactFwdDynamics_TalosArm,
     DifferentialActionModelContactFwdDynamics_HyQ,
     DifferentialActionModelContactFwdDynamics_Talos,
+    DifferentialActionModelContactFwdDynamicsWithFriction_TalosArm,
     DifferentialActionModelContactFwdDynamicsWithFriction_HyQ,
     DifferentialActionModelContactFwdDynamicsWithFriction_Talos,
     NbDifferentialActionModelTypes
@@ -60,7 +62,7 @@ class DifferentialActionModelFactory {
       StateModelTypes::Type state_type, ActuationModelTypes::Type actuation_type) const;
 
   boost::shared_ptr<crocoddyl::DifferentialActionModelContactFwdDynamics> create_contactFwdDynamics(
-      StateModelTypes::Type state_type, bool with_friction = true) const;
+      StateModelTypes::Type state_type, ActuationModelTypes::Type actuation_type, bool with_friction = true) const;
 };
 
 }  // namespace unittest

--- a/unittest/factory/diff_action.hpp
+++ b/unittest/factory/diff_action.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2018-2020, LAAS-CNRS
+// Copyright (C) 2018-2020, University of Edinburgh
 // Copyright (C) 2020 CTU, INRIA
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.

--- a/unittest/factory/diff_action.hpp
+++ b/unittest/factory/diff_action.hpp
@@ -1,13 +1,10 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2018-2020, University of Edinburgh
+// Copyright (C) 2018-2020, LAAS-CNRS
+// Copyright (C) 2020 CTU, INRIA
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
-//
-// Copyright (c) 2020 CNRS, INRIA
-//
-// Copyright (c) CTU
 ///////////////////////////////////////////////////////////////////////////////
 
 #ifndef CROCODDYL_DIFF_ACTION_FACTORY_HPP_

--- a/unittest/factory/diff_action.hpp
+++ b/unittest/factory/diff_action.hpp
@@ -4,6 +4,10 @@
 // Copyright (C) 2018-2020, University of Edinburgh
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
+//
+// Copyright (c) 2020 CNRS, INRIA
+//
+// Copyright (c) CTU
 ///////////////////////////////////////////////////////////////////////////////
 
 #ifndef CROCODDYL_DIFF_ACTION_FACTORY_HPP_


### PR DESCRIPTION
Hello,
This PR is related to issue #884. 
Changes:
- `DifferentialActionModelContactFwdDynamics` is type agnostic.
- benchmark/bipedal-timings.cpp was modified as it didn't have the `#include` floating base actuation model flag and was causing a compilation error due to change to `DifferentialActionModelContactFwdDynamics`.
- One unittest was added to test for `DifferentialActionModelContactFwdDynamics` with a `ActuationModelFull` instance (TalosArm is used for the test)