### PR TITLE
Fixed bug: the gap threshold was too big

### DIFF
--- a/src/core/solvers/ddp.cpp
+++ b/src/core/solvers/ddp.cpp
@@ -19,7 +19,7 @@ SolverDDP::SolverDDP(boost::shared_ptr<ShootingProblem> problem)
       regmax_(1e9),
       cost_try_(0.),
       th_grad_(1e-12),
-      th_gaptol_(1e-20),
+      th_gaptol_(1e-16),
       th_stepdec_(0.5),
       th_stepinc_(0.01),
       was_feasible_(false) {

--- a/src/core/solvers/ddp.cpp
+++ b/src/core/solvers/ddp.cpp
@@ -19,7 +19,7 @@ SolverDDP::SolverDDP(boost::shared_ptr<ShootingProblem> problem)
       regmax_(1e9),
       cost_try_(0.),
       th_grad_(1e-12),
-      th_gaptol_(1e-9),
+      th_gaptol_(1e-20),
       th_stepdec_(0.5),
       th_stepinc_(0.01),
       was_feasible_(false) {


### PR DESCRIPTION
The #848 introduces an automatic way of detecting if the gaps are zero.
If so, then the algorithm switches to a feasibility mode (i.e., runs DDP or Box-DDP).

The problem with #848 is that the introduced gap threshold was defined without taking care of the different examples.
If you inspect how the logs are changed, you will see that the humanoid problems switch to feas=1 from the first iteration.
To be concise, I would discuss only the taichi case.
After #848, then the solver behaviour changes to:

```bash
iter 	 cost 	      stop 	    grad 	  xreg 	      ureg 	 step 	 feas
   0  1.78178e+02  3.25380e+01  6.16363e+02  1.00000e-08  1.00000e-08   0.0039     1
   1  1.78178e+02  9.28629e+03  1.18098e+03  1.00000e-07  1.00000e-07   0.0020     1
   2  1.78178e+02  9.35243e+03  1.21551e+03  1.00000e-06  1.00000e-06   0.0020     1
   3  1.78178e+02  9.26675e+03  1.23487e+03  1.00000e-05  1.00000e-05   0.0020     1
   4  1.78178e+02  9.27260e+03  1.35957e+03  1.00000e-04  1.00000e-04   0.0020     1
   5  1.65348e+02  9.25037e+03  5.67232e+02  1.00000e-04  1.00000e-04   0.0156     1
   6  1.65348e+02  9.44208e+04  5.75215e+03  1.00000e-03  1.00000e-03   0.0020     1
   7  1.51725e+02  1.61723e+04  7.11440e+02  1.00000e-03  1.00000e-03   0.0156     1
   8  1.41365e+02  7.09845e+03  5.95268e+02  1.00000e-03  1.00000e-03   0.0156     1
   9  1.34031e+02  5.09730e+03  3.91887e+02  1.00000e-03  1.00000e-03   0.0156     1
iter 	 cost 	      stop 	    grad 	  xreg 	      ureg 	 step 	 feas
  10  1.30599e+02  4.81248e+03  3.73506e+02  1.00000e-02  1.00000e-02   0.0078     1
  11  1.08303e+02  5.02802e+03  1.99724e+02  1.00000e-02  1.00000e-02   0.1250     1
  12  9.98739e+01  3.83324e+03  1.51875e+02  1.00000e-02  1.00000e-02   0.0625     1
  13  9.59521e+01  3.30229e+03  1.30111e+02  1.00000e-02  1.00000e-02   0.0312     1
  14  9.53019e+01  3.10945e+03  1.20886e+02  1.00000e-02  1.00000e-02   0.0312     1
  15  9.21363e+01  4.08168e+03  1.07030e+02  1.00000e-02  1.00000e-02   0.0312     1
  16  8.93894e+01  4.04523e+03  9.81959e+01  1.00000e-02  1.00000e-02   0.0312     1
  17  8.70124e+01  4.18939e+03  8.31458e+01  1.00000e-02  1.00000e-02   0.0312     1
  18  8.64015e+01  4.46219e+03  7.32204e+01  1.00000e-02  1.00000e-02   0.0312     1
  19  8.06653e+01  2.01607e+04  6.11574e+01  1.00000e-02  1.00000e-02   0.1250     1
iter 	 cost 	      stop 	    grad 	  xreg 	      ureg 	 step 	 feas
  20  7.47742e+01  5.92646e+04  6.57824e+01  1.00000e-02  1.00000e-02   0.1250     1
  21  6.55950e+01  5.87568e+04  7.64976e+01  1.00000e-02  1.00000e-02   0.1250     1
  22  6.21516e+01  4.46356e+04  6.19162e+01  1.00000e-02  1.00000e-02   0.0625     1
  23  5.79942e+01  5.15662e+04  6.35569e+01  1.00000e-02  1.00000e-02   0.0625     1
  24  5.44310e+01  4.52354e+04  5.55810e+01  1.00000e-02  1.00000e-02   0.0625     1
  25  5.16736e+01  4.81350e+04  5.57663e+01  1.00000e-02  1.00000e-02   0.0625     1
  26  5.13940e+01  6.17243e+04  5.07549e+01  1.00000e-02  1.00000e-02   0.0312     1
  27  4.80993e+01  8.93424e+04  5.18081e+01  1.00000e-02  1.00000e-02   0.0625     1
  28  4.52283e+01  7.67937e+04  4.64514e+01  1.00000e-02  1.00000e-02   0.0625     1
  29  4.25227e+01  6.91269e+04  4.33650e+01  1.00000e-02  1.00000e-02   0.0625     1
iter 	 cost 	      stop 	    grad 	  xreg 	      ureg 	 step 	 feas
  30  3.99943e+01  6.16551e+04  4.05287e+01  1.00000e-02  1.00000e-02   0.0625     1
  31  3.76484e+01  5.49928e+04  3.76385e+01  1.00000e-02  1.00000e-02   0.0625     1
  32  3.54659e+01  4.90284e+04  3.49001e+01  1.00000e-02  1.00000e-02   0.0625     1
  33  3.34501e+01  4.35099e+04  3.23044e+01  1.00000e-02  1.00000e-02   0.0625     1
  34  3.16013e+01  3.86537e+04  2.98568e+01  1.00000e-02  1.00000e-02   0.0625     1
  35  2.86885e+01  3.44219e+04  2.74231e+01  1.00000e-02  1.00000e-02   0.1250     1
  36  2.57451e+01  3.22832e+04  2.37515e+01  1.00000e-02  1.00000e-02   0.1250     1
  37  2.33516e+01  2.48380e+04  1.94917e+01  1.00000e-02  1.00000e-02   0.1250     1
  38  2.14121e+01  1.92747e+04  1.58532e+01  1.00000e-02  1.00000e-02   0.1250     1
  39  1.86648e+01  1.48869e+04  1.28135e+01  1.00000e-02  1.00000e-02   0.2500     1
iter 	 cost 	      stop 	    grad 	  xreg 	      ureg 	 step 	 feas
  40  1.67087e+01  1.29764e+04  8.46929e+00  1.00000e-02  1.00000e-02   0.2500     1
  41  1.47140e+01  7.50107e+03  5.31374e+00  1.00000e-02  1.00000e-02   0.5000     1
  42  1.37752e+01  5.91613e+03  2.28933e+00  1.00000e-02  1.00000e-02   0.5000     1
  43  1.31003e+01  1.79911e+03  9.23475e-01  1.00000e-03  1.00000e-03   1.0000     1
  44  1.25287e+01  1.42377e+02  1.27907e+00  1.00000e-03  1.00000e-03   0.5000     1
  45  1.21362e+01  1.41671e+02  8.42689e-01  1.00000e-03  1.00000e-03   0.5000     1
  46  1.16584e+01  7.49878e+01  6.03895e-01  1.00000e-04  1.00000e-04   1.0000     1
  47  1.13923e+01  2.61274e+02  1.82797e+00  1.00000e-04  1.00000e-04   0.2500     1
  48  1.10940e+01  1.03232e+03  1.74798e+00  1.00000e-04  1.00000e-04   0.2500     1
  49  1.07851e+01  1.19249e+03  1.53252e+00  1.00000e-04  1.00000e-04   0.2500     1
iter 	 cost 	      stop 	    grad 	  xreg 	      ureg 	 step 	 feas
  50  1.03613e+01  9.92674e+02  1.24532e+00  1.00000e-04  1.00000e-04   0.5000     1
  51  1.02559e+01  1.65735e+03  9.43648e-01  1.00000e-04  1.00000e-04   0.5000     1
  52  9.89745e+00  6.56817e+02  1.15503e+00  1.00000e-05  1.00000e-05   1.0000     1
  53  9.59904e+00  2.39154e+03  2.65189e+00  1.00000e-05  1.00000e-05   0.2500     1
  54  9.03528e+00  1.48749e+03  2.61521e+00  1.00000e-05  1.00000e-05   0.2500     1
  55  8.37021e+00  9.46530e+02  1.95242e+00  1.00000e-05  1.00000e-05   0.5000     1
  56  7.84974e+00  8.56938e+02  1.36489e+00  1.00000e-05  1.00000e-05   0.5000     1
  57  7.60716e+00  3.33839e+02  8.25620e-01  1.00000e-06  1.00000e-06   1.0000     1
  58  7.44460e+00  9.03526e+02  1.32629e+00  1.00000e-06  1.00000e-06   0.5000     1
  59  6.96930e+00  2.68387e+02  1.07360e+00  1.00000e-07  1.00000e-07   1.0000     1
iter 	 cost 	      stop 	    grad 	  xreg 	      ureg 	 step 	 feas
  60  6.96785e+00  5.00552e+01  1.67807e-01  1.00000e-07  1.00000e-07   0.0156     1
  61  6.93786e+00  4.85325e+01  1.61532e-01  1.00000e-07  1.00000e-07   0.2500     1
  62  6.91892e+00  5.62545e+01  1.03663e-01  1.00000e-07  1.00000e-07   0.2500     1
  63  6.91230e+00  5.38180e+01  7.31778e-02  1.00000e-07  1.00000e-07   0.1250     1
  64  6.90666e+00  6.20123e+01  1.06187e-01  1.00000e-07  1.00000e-07   0.0625     1
  65  6.90162e+00  6.47538e+01  9.27043e-02  1.00000e-07  1.00000e-07   0.0625     1
  66  6.89780e+00  6.29806e+01  8.03674e-02  1.00000e-07  1.00000e-07   0.0625     1
  67  6.89385e+00  6.00505e+01  7.13738e-02  1.00000e-07  1.00000e-07   0.1250     1
  68  6.88754e+00  7.98426e+01  7.49398e-02  1.00000e-07  1.00000e-07   0.1250     1
  69  6.88085e+00  9.60009e+01  5.99048e-02  1.00000e-07  1.00000e-07   0.2500     1
iter 	 cost 	      stop 	    grad 	  xreg 	      ureg 	 step 	 feas
  70  6.88072e+00  1.50476e+02  4.60560e-02  1.00000e-06  1.00000e-06   0.0039     1
  71  6.87999e+00  1.49314e+02  4.31207e-02  1.00000e-06  1.00000e-06   0.1250     1
  72  6.87497e+00  1.30184e+02  4.10899e-02  1.00000e-06  1.00000e-06   0.5000     1
  73  6.87488e+00  1.87808e+02  3.16959e-02  1.00000e-05  1.00000e-05   0.0078     1
  74  6.87326e+00  1.84948e+02  2.98663e-02  1.00000e-05  1.00000e-05   0.1250     1
  75  6.86179e+00  1.43700e+02  2.66656e-02  1.00000e-06  1.00000e-06   1.0000     1
  76  6.86179e+00  2.20176e+01  9.22452e-03  1.00000e-05  1.00000e-05   0.0020     1
  77  6.86179e+00  2.20176e+01  7.87677e-03  1.00000e-04  1.00000e-04   0.0020     1
  78  6.86179e+00  2.20178e+01  5.98758e-03  1.00000e-03  1.00000e-03   0.0039     1
  79  6.85972e+00  2.18532e+01  4.87386e-03  1.00000e-04  1.00000e-04   1.0000     1
iter 	 cost 	      stop 	    grad 	  xreg 	      ureg 	 step 	 feas
  80  6.85785e+00  1.76895e-02  3.54826e-03  1.00000e-05  1.00000e-05   1.0000     1
  81  6.85418e+00  2.39579e-01  1.08532e-02  1.00000e-05  1.00000e-05   0.5000     1
  82  6.85323e+00  7.75446e+00  4.53758e-03  1.00000e-06  1.00000e-06   1.0000     1
  83  6.85240e+00  2.77798e-01  4.39553e-03  1.00000e-06  1.00000e-06   0.5000     1
  84  6.85078e+00  2.62595e+00  3.49184e-03  1.00000e-07  1.00000e-07   1.0000     1
  85  6.85020e+00  3.20694e-01  1.46641e-03  1.00000e-08  1.00000e-08   1.0000     1
  86  6.84886e+00  1.19706e-02  3.22519e-03  1.00000e-09  1.00000e-09   1.0000     1
  87  6.84838e+00  1.25781e+00  1.90607e-03  1.00000e-09  1.00000e-09   1.0000     1
  88  6.84786e+00  4.36496e+00  1.16788e-03  1.00000e-09  1.00000e-09   1.0000     1
  89  6.84282e+00  2.43261e-01  2.45599e-02  1.00000e-09  1.00000e-09   0.2500     1
iter 	 cost 	      stop 	    grad 	  xreg 	      ureg 	 step 	 feas
  90  6.84224e+00  1.67183e+01  4.71865e-02  1.00000e-09  1.00000e-09   0.0156     1
  91  6.84204e+00  2.15302e+01  4.59864e-02  1.00000e-09  1.00000e-09   0.0156     1
  92  6.84187e+00  3.74489e+01  4.55678e-02  1.00000e-08  1.00000e-08   0.0078     1
  93  6.84171e+00  4.23398e+01  4.52048e-02  1.00000e-07  1.00000e-07   0.0078     1
  94  6.84158e+00  4.75711e+01  4.48176e-02  1.00000e-06  1.00000e-06   0.0078     1
  95  6.84146e+00  5.30434e+01  4.38472e-02  1.00000e-05  1.00000e-05   0.0078     1
  96  6.84132e+00  5.84262e+01  3.84252e-02  1.00000e-04  1.00000e-04   0.0078     1
  97  6.84112e+00  6.19161e+01  2.29707e-02  1.00000e-04  1.00000e-04   0.0312     1
  98  6.84096e+00  7.25836e+01  2.30636e-02  1.00000e-04  1.00000e-04   0.0312     1
  99  6.84083e+00  8.33180e+01  2.32245e-02  1.00000e-04  1.00000e-04   0.0312     1
iter 	 cost 	      stop 	    grad 	  xreg 	      ureg 	 step 	 feas
 100  6.84073e+00  9.38822e+01  2.34331e-02  1.00000e-04  1.00000e-04   0.0312     1
 101  6.84064e+00  1.04092e+02  2.36790e-02  1.00000e-04  1.00000e-04   0.0312     1
 102  6.84045e+00  1.13802e+02  2.39501e-02  1.00000e-04  1.00000e-04   0.0156     1
 103  6.84025e+00  1.14117e+02  2.37751e-02  1.00000e-04  1.00000e-04   0.0156     1
 104  6.84006e+00  1.14334e+02  2.36014e-02  1.00000e-04  1.00000e-04   0.0156     1
 105  6.83987e+00  1.14456e+02  2.34288e-02  1.00000e-04  1.00000e-04   0.0156     1
 106  6.83968e+00  1.14485e+02  2.32570e-02  1.00000e-04  1.00000e-04   0.0156     1
 107  6.83949e+00  1.14424e+02  2.30860e-02  1.00000e-04  1.00000e-04   0.0156     1
 108  6.83942e+00  1.14276e+02  2.29155e-02  1.00000e-04  1.00000e-04   0.0312     1
 109  6.83923e+00  1.21377e+02  2.31785e-02  1.00000e-04  1.00000e-04   0.0156     1
iter 	 cost 	      stop 	    grad 	  xreg 	      ureg 	 step 	 feas
 110  6.83904e+00  1.20824e+02  2.30026e-02  1.00000e-04  1.00000e-04   0.0156     1
 111  6.83897e+00  1.20196e+02  2.28268e-02  1.00000e-04  1.00000e-04   0.0312     1
 112  6.83890e+00  1.25987e+02  2.30721e-02  1.00000e-04  1.00000e-04   0.0312     1
 113  6.83883e+00  1.31077e+02  2.33061e-02  1.00000e-04  1.00000e-04   0.0312     1
 114  6.83874e+00  1.35464e+02  2.35247e-02  1.00000e-04  1.00000e-04   0.0312     1
 115  6.83866e+00  1.39158e+02  2.37249e-02  1.00000e-04  1.00000e-04   0.0312     1
 116  6.83856e+00  1.42174e+02  2.39040e-02  1.00000e-04  1.00000e-04   0.0312     1
 117  6.83846e+00  1.44538e+02  2.40599e-02  1.00000e-04  1.00000e-04   0.0312     1
 118  6.83834e+00  1.46278e+02  2.41912e-02  1.00000e-04  1.00000e-04   0.0312     1
 119  6.83822e+00  1.47426e+02  2.42967e-02  1.00000e-04  1.00000e-04   0.0312     1
iter 	 cost 	      stop 	    grad 	  xreg 	      ureg 	 step 	 feas
 120  6.83808e+00  1.48019e+02  2.43755e-02  1.00000e-04  1.00000e-04   0.0312     1
 121  6.83794e+00  1.48093e+02  2.44273e-02  1.00000e-04  1.00000e-04   0.0312     1
 122  6.83779e+00  1.47687e+02  2.44519e-02  1.00000e-04  1.00000e-04   0.0312     1
 123  6.83762e+00  1.46840e+02  2.44494e-02  1.00000e-04  1.00000e-04   0.0312     1
 124  6.83745e+00  1.45590e+02  2.44200e-02  1.00000e-04  1.00000e-04   0.0312     1
 125  6.83726e+00  1.43975e+02  2.43643e-02  1.00000e-04  1.00000e-04   0.0312     1
 126  6.83707e+00  1.42032e+02  2.42827e-02  1.00000e-04  1.00000e-04   0.0312     1
 127  6.83686e+00  1.39797e+02  2.41764e-02  1.00000e-04  1.00000e-04   0.0312     1
 128  6.83665e+00  1.37303e+02  2.40457e-02  1.00000e-04  1.00000e-04   0.0312     1
 129  6.83643e+00  1.34585e+02  2.38919e-02  1.00000e-04  1.00000e-04   0.0312     1
iter 	 cost 	      stop 	    grad 	  xreg 	      ureg 	 step 	 feas
 130  6.83620e+00  1.31672e+02  2.37158e-02  1.00000e-04  1.00000e-04   0.0312     1
 131  6.83596e+00  1.28595e+02  2.35187e-02  1.00000e-04  1.00000e-04   0.0312     1
 132  6.83572e+00  1.25379e+02  2.33022e-02  1.00000e-04  1.00000e-04   0.0312     1
 133  6.83547e+00  1.22053e+02  2.30665e-02  1.00000e-04  1.00000e-04   0.0312     1
 134  6.83522e+00  1.18637e+02  2.28131e-02  1.00000e-04  1.00000e-04   0.0312     1
 135  6.83495e+00  1.15155e+02  2.25433e-02  1.00000e-04  1.00000e-04   0.0312     1
 136  6.83469e+00  1.11625e+02  2.22582e-02  1.00000e-04  1.00000e-04   0.0312     1
 137  6.83442e+00  1.08067e+02  2.19492e-02  1.00000e-04  1.00000e-04   0.0312     1
 138  6.83415e+00  1.04497e+02  2.16374e-02  1.00000e-04  1.00000e-04   0.0312     1
 139  6.83387e+00  1.00929e+02  2.13138e-02  1.00000e-04  1.00000e-04   0.0312     1
iter 	 cost 	      stop 	    grad 	  xreg 	      ureg 	 step 	 feas
 140  6.83359e+00  9.73774e+01  2.09796e-02  1.00000e-04  1.00000e-04   0.0312     1
 141  6.83331e+00  9.38538e+01  2.06358e-02  1.00000e-04  1.00000e-04   0.0312     1
 142  6.83303e+00  9.03689e+01  2.02836e-02  1.00000e-04  1.00000e-04   0.0312     1
 143  6.83275e+00  8.69321e+01  1.99239e-02  1.00000e-04  1.00000e-04   0.0312     1
 144  6.83246e+00  8.35516e+01  1.95580e-02  1.00000e-04  1.00000e-04   0.0312     1
 145  6.83218e+00  8.02348e+01  1.91866e-02  1.00000e-04  1.00000e-04   0.0312     1
 146  6.83189e+00  7.69873e+01  1.88106e-02  1.00000e-04  1.00000e-04   0.0312     1
 147  6.83161e+00  7.38142e+01  1.84310e-02  1.00000e-04  1.00000e-04   0.0312     1
 148  6.83149e+00  7.07197e+01  1.80486e-02  1.00000e-04  1.00000e-04   0.0625     1
 149  6.83133e+00  6.93458e+01  1.81700e-02  1.00000e-04  1.00000e-04   0.0625     1
iter 	 cost 	      stop 	    grad 	  xreg 	      ureg 	 step 	 feas
 150  6.83112e+00  6.74143e+01  1.81860e-02  1.00000e-04  1.00000e-04   0.0625     1
 151  6.83088e+00  6.50413e+01  1.81036e-02  1.00000e-04  1.00000e-04   0.0625     1
 152  6.83060e+00  6.23338e+01  1.79316e-02  1.00000e-04  1.00000e-04   0.0625     1
 153  6.83029e+00  5.93850e+01  1.76787e-02  1.00000e-04  1.00000e-04   0.0625     1
 154  6.82995e+00  5.62770e+01  1.73544e-02  1.00000e-04  1.00000e-04   0.0625     1
 155  6.82960e+00  5.30794e+01  1.69678e-02  1.00000e-04  1.00000e-04   0.0625     1
 156  6.82923e+00  4.98526e+01  1.65287e-02  1.00000e-04  1.00000e-04   0.0625     1
 157  6.82884e+00  4.66431e+01  1.60454e-02  1.00000e-04  1.00000e-04   0.0625     1
 158  6.82845e+00  4.34889e+01  1.55259e-02  1.00000e-04  1.00000e-04   0.0625     1
 159  6.82805e+00  4.04206e+01  1.49778e-02  1.00000e-04  1.00000e-04   0.0625     1
iter 	 cost 	      stop 	    grad 	  xreg 	      ureg 	 step 	 feas
 160  6.82765e+00  3.74616e+01  1.44081e-02  1.00000e-04  1.00000e-04   0.0625     1
 161  6.82725e+00  3.46290e+01  1.38234e-02  1.00000e-04  1.00000e-04   0.0625     1
 162  6.82709e+00  3.19349e+01  1.32294e-02  1.00000e-04  1.00000e-04   0.1250     1
 163  6.82680e+00  3.05914e+01  1.32977e-02  1.00000e-04  1.00000e-04   0.1250     1
 164  6.82641e+00  2.85380e+01  1.30764e-02  1.00000e-04  1.00000e-04   0.1250     1
 165  6.82594e+00  2.60673e+01  1.26199e-02  1.00000e-04  1.00000e-04   0.1250     1
 166  6.82542e+00  2.34072e+01  1.19826e-02  1.00000e-04  1.00000e-04   0.1250     1
 167  6.82487e+00  2.07259e+01  1.12189e-02  1.00000e-04  1.00000e-04   0.1250     1
 168  6.82432e+00  1.81385e+01  1.03744e-02  1.00000e-04  1.00000e-04   0.1250     1
 169  6.82407e+00  1.57187e+01  9.48901e-03  1.00000e-04  1.00000e-04   0.2500     1
iter 	 cost 	      stop 	    grad 	  xreg 	      ureg 	 step 	 feas
 170  6.82364e+00  1.44964e+01  9.40033e-03  1.00000e-04  1.00000e-04   0.2500     1
 171  6.82285e+00  1.22637e+01  8.85943e-03  1.00000e-04  1.00000e-04   0.2500     1
 172  6.82252e+00  9.78179e+00  7.55390e-03  1.00000e-04  1.00000e-04   0.5000     1
 173  6.82132e+00  8.70702e+00  7.29306e-03  1.00000e-04  1.00000e-04   0.5000     1
 174  6.82051e+00  5.49207e+00  5.15329e-03  1.00000e-04  1.00000e-04   0.2500     1
 175  6.82033e+00  3.56255e+00  3.62489e-03  1.00000e-04  1.00000e-04   0.5000     1
 176  6.81900e+00  7.66068e+00  3.39718e-03  1.00000e-05  1.00000e-05   1.0000     1
 177  6.81889e+00  7.53147e-01  9.92869e-04  1.00000e-05  1.00000e-05   0.2500     1
 178  6.81854e+00  4.69320e-01  7.99748e-04  1.00000e-06  1.00000e-06   1.0000     1
 179  6.81853e+00  1.41501e-01  2.04703e-04  1.00000e-06  1.00000e-06   0.0625     1
iter 	 cost 	      stop 	    grad 	  xreg 	      ureg 	 step 	 feas
 180  6.81843e+00  1.29705e-01  1.92456e-04  1.00000e-07  1.00000e-07   1.0000     1
 181  6.81843e+00  2.23775e-03  7.34153e-06  1.00000e-06  1.00000e-06   0.0078     1
 182  6.81843e+00  2.20954e-03  5.86893e-06  1.00000e-07  1.00000e-07   1.0000     1
 183  6.81843e+00  8.89388e-06  2.05710e-06  1.00000e-08  1.00000e-08   1.0000     1
 184  6.81843e+00  3.86099e-07  1.20287e-06  1.00000e-09  1.00000e-09   1.0000     1
 185  6.81843e+00  7.47302e-06  7.25563e-07  1.00000e-08  1.00000e-08   0.0020     1
 186  6.81843e+00  7.51177e-06  8.06943e-07  1.00000e-07  1.00000e-07   0.0020     1
 187  6.81843e+00  7.46699e-06  7.48662e-07  1.00000e-06  1.00000e-06   0.0020     1
 188  6.81843e+00  7.48257e-06  7.82292e-07  1.00000e-05  1.00000e-05   0.0020     1
 189  6.81843e+00  7.46149e-06  7.19765e-07  1.00000e-04  1.00000e-04   0.0020     1
iter 	 cost 	      stop 	    grad 	  xreg 	      ureg 	 step 	 feas
 190  6.81843e+00  7.43256e-06  6.72448e-07  1.00000e-03  1.00000e-03   0.0020     1
 191  6.81843e+00  7.24939e-06  6.03813e-07  1.00000e-02  1.00000e-02   0.0020     1
 192  6.81843e+00  5.18227e-06  1.86831e-07  1.00000e-03  1.00000e-03   1.0000     1
 193  6.81843e+00  1.11102e-07  3.59205e-07  1.00000e-04  1.00000e-04   1.0000     1
 194  6.81843e+00  1.23619e-07  3.89204e-07  1.00000e-05  1.00000e-05   1.0000     1
 195  6.81843e+00  1.83742e-06  3.04951e-07  1.00000e-06  1.00000e-06   1.0000     1
 196  6.81843e+00  4.14378e-05  5.53791e-07  1.00000e-06  1.00000e-06   0.5000     1
 197  6.81843e+00  2.87770e-05  2.24266e-07  1.00000e-07  1.00000e-07   1.0000     1
 198  6.81843e+00  8.84475e-08  1.25491e-07  1.00000e-07  1.00000e-07   0.5000     1
('Finally reached = ', array([3.99962986e-01, 2.39368714e-05, 1.19998329e+00]))
('Distance between hand and target = ', 4.7140033318188594e-05)
('Distance to default state = ', 1.6046623423273219)
('XY distance to CoM reference = ', 0.09817884581698187)
```
which increases quite a lot the number of iterations when compared with https://github.com/loco-3d/crocoddyl/blob/devel/examples/log/humanoid_taichi.log.

It took me time to realize that the reason was a big gap threshold (i.e., `1e-9`).
I spent extra time to find a good value for this threshold, it turns out that `1e-20` is a good default value.
So, this PR only proposes to change that value.


**Important note**
We really need to check our log files every time that we change something at the solver level.
Unfortunately, we have not yet find a good way of checking these log files.