### PR TITLE
Used isZero in unit-tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,7 @@ INCLUDE(cmake/apple.cmake)
 
 # Print initial message
 MESSAGE(STATUS "${PROJECT_DESCRIPTION}, version ${PROJECT_VERSION}")
-MESSAGE(STATUS "Copyright (C) 2018-2020 CNRS-LAAS")
-MESSAGE(STATUS "Copyright (C) 2019-2020 University of Edinburgh")
+MESSAGE(STATUS "Copyright (C) 2018-2021 CNRS-LAAS, University of Edinburgh")
 MESSAGE(STATUS "All rights reserved.")
 MESSAGE(STATUS "Released under the BSD 3-Clause License.")
 

--- a/unittest/factory/cost.cpp
+++ b/unittest/factory/cost.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2019-2021, LAAS-CNRS, University of Edinburgh
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////

--- a/unittest/factory/cost.cpp
+++ b/unittest/factory/cost.cpp
@@ -152,12 +152,10 @@ boost::shared_ptr<crocoddyl::CostModelAbstract> CostModelFactory::create(CostMod
 
   boost::shared_ptr<crocoddyl::ActuationModelFull> actuation =
       boost::make_shared<crocoddyl::ActuationModelFull>(state);
-
-  crocoddyl::FrameIndex frame_index = state->get_pinocchio()->frames.size() - 1;
-  pinocchio::SE3 frame_SE3 = pinocchio::SE3::Random();
   if (nu == std::numeric_limits<std::size_t>::max()) {
     nu = state->get_nv();
   }
+
   switch (cost_type) {
     case CostModelNoFFTypes::CostModelControlGrav:
       cost = boost::make_shared<crocoddyl::CostModelControlGrav>(

--- a/unittest/test_actions.cpp
+++ b/unittest/test_actions.cpp
@@ -88,9 +88,9 @@ void test_partial_derivatives_against_numdiff(ActionModelTypes::Type action_mode
   model_num_diff.calcDiff(data_num_diff, x, u);
 
   // Checking the partial derivatives against NumDiff
-  double tol = NUMDIFF_MODIFIER * sqrt(model_num_diff.get_disturbance());
-  BOOST_CHECK((data->Fx - data_num_diff->Fx).isZero(tol));
-  BOOST_CHECK((data->Fu - data_num_diff->Fu).isZero(tol));
+  double tol = sqrt(model_num_diff.get_disturbance());
+  BOOST_CHECK((data->Fx - data_num_diff->Fx).isZero(NUMDIFF_MODIFIER * tol));
+  BOOST_CHECK((data->Fu - data_num_diff->Fu).isZero(NUMDIFF_MODIFIER * tol));
   BOOST_CHECK((data->Lx - data_num_diff->Lx).isZero(tol));
   BOOST_CHECK((data->Lu - data_num_diff->Lu).isZero(tol));
   if (model_num_diff.get_with_gauss_approx()) {

--- a/unittest/test_actions.cpp
+++ b/unittest/test_actions.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, LAAS-CNRS, New York University, Max Planck Gesellschaft
+// Copyright (C) 2019-2021, LAAS-CNRS, New York University, Max Planck Gesellschaft
 //                          University of Edinburgh, INRIA
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
@@ -88,19 +88,19 @@ void test_partial_derivatives_against_numdiff(ActionModelTypes::Type action_mode
   model_num_diff.calcDiff(data_num_diff, x, u);
 
   // Checking the partial derivatives against NumDiff
-  double tol = NUMDIFF_MODIFIER * model_num_diff.get_disturbance();
-  BOOST_CHECK((data->Fx - data_num_diff->Fx).isMuchSmallerThan(1.0, tol));
-  BOOST_CHECK((data->Fu - data_num_diff->Fu).isMuchSmallerThan(1.0, tol));
-  BOOST_CHECK((data->Lx - data_num_diff->Lx).isMuchSmallerThan(1.0, tol));
-  BOOST_CHECK((data->Lu - data_num_diff->Lu).isMuchSmallerThan(1.0, tol));
+  double tol = NUMDIFF_MODIFIER * sqrt(model_num_diff.get_disturbance());
+  BOOST_CHECK((data->Fx - data_num_diff->Fx).isZero(tol));
+  BOOST_CHECK((data->Fu - data_num_diff->Fu).isZero(tol));
+  BOOST_CHECK((data->Lx - data_num_diff->Lx).isZero(tol));
+  BOOST_CHECK((data->Lu - data_num_diff->Lu).isZero(tol));
   if (model_num_diff.get_with_gauss_approx()) {
-    BOOST_CHECK((data->Lxx - data_num_diff->Lxx).isMuchSmallerThan(1.0, tol));
-    BOOST_CHECK((data->Lxu - data_num_diff->Lxu).isMuchSmallerThan(1.0, tol));
-    BOOST_CHECK((data->Luu - data_num_diff->Luu).isMuchSmallerThan(1.0, tol));
+    BOOST_CHECK((data->Lxx - data_num_diff->Lxx).isZero(tol));
+    BOOST_CHECK((data->Lxu - data_num_diff->Lxu).isZero(tol));
+    BOOST_CHECK((data->Luu - data_num_diff->Luu).isZero(tol));
   } else {
-    BOOST_CHECK((data_num_diff->Lxx).isMuchSmallerThan(1.0, tol));
-    BOOST_CHECK((data_num_diff->Lxu).isMuchSmallerThan(1.0, tol));
-    BOOST_CHECK((data_num_diff->Luu).isMuchSmallerThan(1.0, tol));
+    BOOST_CHECK((data_num_diff->Lxx).isZero(tol));
+    BOOST_CHECK((data_num_diff->Lxu).isZero(tol));
+    BOOST_CHECK((data_num_diff->Luu).isZero(tol));
   }
 }
 

--- a/unittest/test_activations.cpp
+++ b/unittest/test_activations.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, LAAS-CNRS, New York University, Max Planck Gesellschaft
+// Copyright (C) 2019-2021, LAAS-CNRS, New York University, Max Planck Gesellschaft
 //                          University of Edinburgh, INRIA
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
@@ -69,9 +69,9 @@ void test_partial_derivatives_against_numdiff(ActivationModelTypes::Type activat
   model_num_diff.calcDiff(data_num_diff, r);
 
   // Checking the partial derivatives against NumDiff
-  double tol = NUMDIFF_MODIFIER * model_num_diff.get_disturbance();
+  double tol = NUMDIFF_MODIFIER * sqrt(model_num_diff.get_disturbance());
   BOOST_CHECK(std::abs(data->a_value - data_num_diff->a_value) < tol);
-  BOOST_CHECK((data->Ar - data_num_diff->Ar).isMuchSmallerThan(1.0, tol));
+  BOOST_CHECK((data->Ar - data_num_diff->Ar).isZero(tol));
 
   // numerical differentiation of the Hessian is not good enough to be tested.
   // BOOST_CHECK((data->Arr - data_num_diff->Arr).isMuchSmallerThan(1.0, tol));

--- a/unittest/test_activations.cpp
+++ b/unittest/test_activations.cpp
@@ -69,7 +69,7 @@ void test_partial_derivatives_against_numdiff(ActivationModelTypes::Type activat
   model_num_diff.calcDiff(data_num_diff, r);
 
   // Checking the partial derivatives against NumDiff
-  double tol = NUMDIFF_MODIFIER * sqrt(model_num_diff.get_disturbance());
+  double tol = sqrt(model_num_diff.get_disturbance());
   BOOST_CHECK(std::abs(data->a_value - data_num_diff->a_value) < tol);
   BOOST_CHECK((data->Ar - data_num_diff->Ar).isZero(tol));
 

--- a/unittest/test_actuation.cpp
+++ b/unittest/test_actuation.cpp
@@ -68,7 +68,7 @@ void test_partial_derivatives_against_numdiff(ActuationModelTypes::Type actuatio
   model_num_diff.calcDiff(data_num_diff, x, u);
 
   // Checking the partial derivatives against NumDiff
-  double tol = NUMDIFF_MODIFIER * sqrt(model_num_diff.get_disturbance());
+  double tol = sqrt(model_num_diff.get_disturbance());
   BOOST_CHECK((data->dtau_dx - data_num_diff->dtau_dx).isZero(tol));
   BOOST_CHECK((data->dtau_du - data_num_diff->dtau_du).isZero(tol));
 }

--- a/unittest/test_actuation.cpp
+++ b/unittest/test_actuation.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, University of Edinburgh
+// Copyright (C) 2019-2021, University of Edinburgh
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -68,9 +68,9 @@ void test_partial_derivatives_against_numdiff(ActuationModelTypes::Type actuatio
   model_num_diff.calcDiff(data_num_diff, x, u);
 
   // Checking the partial derivatives against NumDiff
-  double tol = NUMDIFF_MODIFIER * model_num_diff.get_disturbance();
-  BOOST_CHECK((data->dtau_dx - data_num_diff->dtau_dx).isMuchSmallerThan(1.0, tol));
-  BOOST_CHECK((data->dtau_du - data_num_diff->dtau_du).isMuchSmallerThan(1.0, tol));
+  double tol = NUMDIFF_MODIFIER * sqrt(model_num_diff.get_disturbance());
+  BOOST_CHECK((data->dtau_dx - data_num_diff->dtau_dx).isZero(tol));
+  BOOST_CHECK((data->dtau_du - data_num_diff->dtau_du).isZero(tol));
 }
 
 //----------------------------------------------------------------------------//

--- a/unittest/test_boxqp.cpp
+++ b/unittest/test_boxqp.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, University of Edinburgh
+// Copyright (C) 2019-2021, University of Edinburgh
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -39,13 +39,13 @@ void test_unconstrained_qp_with_identity_hessian() {
 
   // Checking the solution of the problem. Note that it the negative of the gradient since Hessian
   // is identity matrix
-  BOOST_CHECK((sol.x + gradient).isMuchSmallerThan(1.0, 1e-9));
+  BOOST_CHECK((sol.x + gradient).isZero(1e-9));
 
   // Checking the solution against a regularized case
   double reg = random_real_in_range(1e-9, 1e2);
   boxqp.set_reg(reg);
   crocoddyl::BoxQPSolution sol_reg = boxqp.solve(hessian, gradient, lb, ub, xinit);
-  BOOST_CHECK((sol_reg.x + gradient / (1 + reg)).isMuchSmallerThan(1.0, 1e-9));
+  BOOST_CHECK((sol_reg.x + gradient / (1 + reg)).isZero(1e-9));
 
   // Checking the all bounds are free and zero clamped
   BOOST_CHECK(sol.free_idx.size() == nx);
@@ -70,14 +70,14 @@ void test_unconstrained_qp() {
 
   // Checking the solution against the KKT solution
   Eigen::VectorXd xkkt = -hessian.inverse() * gradient;
-  BOOST_CHECK((sol.x - xkkt).isMuchSmallerThan(1.0, 1e-9));
+  BOOST_CHECK((sol.x - xkkt).isZero(1e-9));
 
   // Checking the solution against a regularized KKT problem
   double reg = random_real_in_range(1e-9, 1e2);
   boxqp.set_reg(reg);
   crocoddyl::BoxQPSolution sol_reg = boxqp.solve(hessian, gradient, lb, ub, xinit);
   Eigen::VectorXd xkkt_reg = -(hessian + reg * Eigen::MatrixXd::Identity(nx, nx)).inverse() * gradient;
-  BOOST_CHECK((sol_reg.x - xkkt_reg).isMuchSmallerThan(1.0, 1e-9));
+  BOOST_CHECK((sol_reg.x - xkkt_reg).isZero(1e-9));
 
   // Checking the all bounds are free and zero clamped
   BOOST_CHECK(sol.free_idx.size() == nx);
@@ -120,12 +120,12 @@ void test_box_qp_with_identity_hessian() {
 
   // Checking the solution of the problem. Note that it the negative of the gradient since Hessian
   // is identity matrix
-  BOOST_CHECK((sol.x - negbounded_gradient).isMuchSmallerThan(1.0, 1e-9));
+  BOOST_CHECK((sol.x - negbounded_gradient).isZero(1e-9));
 
   // Checking the solution against a regularized case
   boxqp.set_reg(reg);
   crocoddyl::BoxQPSolution sol_reg = boxqp.solve(hessian, gradient, lb, ub, xinit);
-  BOOST_CHECK((sol_reg.x - negbounded_gradient / (1 + reg)).isMuchSmallerThan(1.0, 1e-9));
+  BOOST_CHECK((sol_reg.x - negbounded_gradient / (1 + reg)).isZero(1e-9));
 
   // Checking the all bounds are free and zero clamped
   BOOST_CHECK(sol.free_idx.size() == nf);

--- a/unittest/test_contact_costs.cpp
+++ b/unittest/test_contact_costs.cpp
@@ -43,17 +43,17 @@ void test_partial_derivatives_against_contact_numdiff(ContactCostModelTypes::Typ
   model_num_diff.calcDiff(data_num_diff, x, u);
 
   // Checking the partial derivatives against NumDiff
-  double tol = NUMDIFF_MODIFIER * model_num_diff.get_disturbance();
-  BOOST_CHECK((data->Lx - data_num_diff->Lx).isMuchSmallerThan(1.0, tol));
-  BOOST_CHECK((data->Lu - data_num_diff->Lu).isMuchSmallerThan(1.0, tol));
+  double tol = NUMDIFF_MODIFIER * sqrt(model_num_diff.get_disturbance());
+  BOOST_CHECK((data->Lx - data_num_diff->Lx).isZero(tol));
+  BOOST_CHECK((data->Lu - data_num_diff->Lu).isZero(tol));
   if (model_num_diff.get_with_gauss_approx()) {
-    BOOST_CHECK((data->Lxx - data_num_diff->Lxx).isMuchSmallerThan(1.0, tol));
-    BOOST_CHECK((data->Lxu - data_num_diff->Lxu).isMuchSmallerThan(1.0, tol));
-    BOOST_CHECK((data->Luu - data_num_diff->Luu).isMuchSmallerThan(1.0, tol));
+    BOOST_CHECK((data->Lxx - data_num_diff->Lxx).isZero(tol));
+    BOOST_CHECK((data->Lxu - data_num_diff->Lxu).isZero(tol));
+    BOOST_CHECK((data->Luu - data_num_diff->Luu).isZero(tol));
   } else {
-    BOOST_CHECK((data_num_diff->Lxx).isMuchSmallerThan(1.0, tol));
-    BOOST_CHECK((data_num_diff->Lxu).isMuchSmallerThan(1.0, tol));
-    BOOST_CHECK((data_num_diff->Luu).isMuchSmallerThan(1.0, tol));
+    BOOST_CHECK((data_num_diff->Lxx).isZero(tol));
+    BOOST_CHECK((data_num_diff->Lxu).isZero(tol));
+    BOOST_CHECK((data_num_diff->Luu).isZero(tol));
   }
 }
 

--- a/unittest/test_contact_costs.cpp
+++ b/unittest/test_contact_costs.cpp
@@ -43,7 +43,7 @@ void test_partial_derivatives_against_contact_numdiff(ContactCostModelTypes::Typ
   model_num_diff.calcDiff(data_num_diff, x, u);
 
   // Checking the partial derivatives against NumDiff
-  double tol = NUMDIFF_MODIFIER * sqrt(model_num_diff.get_disturbance());
+  double tol = sqrt(model_num_diff.get_disturbance());
   BOOST_CHECK((data->Lx - data_num_diff->Lx).isZero(tol));
   BOOST_CHECK((data->Lu - data_num_diff->Lu).isZero(tol));
   if (model_num_diff.get_with_gauss_approx()) {

--- a/unittest/test_contacts.cpp
+++ b/unittest/test_contacts.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, University of Edinburgh
+// Copyright (C) 2019-2021, University of Edinburgh
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -174,8 +174,8 @@ void test_partial_derivatives_against_numdiff(ContactModelTypes::Type contact_ty
   model_num_diff.calcDiff(data_num_diff, x);
 
   // Checking the partial derivatives against NumDiff
-  double tol = NUMDIFF_MODIFIER * model_num_diff.get_disturbance();
-  BOOST_CHECK((data->da0_dx - data_num_diff->da0_dx).isMuchSmallerThan(1.0, tol));
+  double tol = NUMDIFF_MODIFIER * sqrt(model_num_diff.get_disturbance());
+  BOOST_CHECK((data->da0_dx - data_num_diff->da0_dx).isZero(tol));
 }
 
 //----------------------------------------------------------------------------//

--- a/unittest/test_contacts.cpp
+++ b/unittest/test_contacts.cpp
@@ -174,7 +174,7 @@ void test_partial_derivatives_against_numdiff(ContactModelTypes::Type contact_ty
   model_num_diff.calcDiff(data_num_diff, x);
 
   // Checking the partial derivatives against NumDiff
-  double tol = NUMDIFF_MODIFIER * sqrt(model_num_diff.get_disturbance());
+  double tol = sqrt(model_num_diff.get_disturbance());
   BOOST_CHECK((data->da0_dx - data_num_diff->da0_dx).isZero(tol));
 }
 

--- a/unittest/test_cop_support.cpp
+++ b/unittest/test_cop_support.cpp
@@ -27,8 +27,8 @@ void test_constructor() {
   // Create the CoP support support
   crocoddyl::CoPSupport support(R, box);
 
-  BOOST_CHECK((support.get_R() - R).isMuchSmallerThan(1.0, 1e-9));
-  BOOST_CHECK((support.get_box() - box).isMuchSmallerThan(1.0, 1e-9));
+  BOOST_CHECK((support.get_R() - R).isZero(1e-9));
+  BOOST_CHECK((support.get_box() - box).isZero(1e-9));
   BOOST_CHECK(static_cast<std::size_t>(support.get_A().rows()) == 4);
   BOOST_CHECK(static_cast<std::size_t>(support.get_lb().size()) == 4);
   BOOST_CHECK(static_cast<std::size_t>(support.get_ub().size()) == 4);
@@ -41,8 +41,8 @@ void test_constructor() {
   // Create the wrench support
   support = crocoddyl::CoPSupport(R, box);
 
-  BOOST_CHECK((support.get_R() - R).isMuchSmallerThan(1.0, 1e-9));
-  BOOST_CHECK((support.get_box() - box).isMuchSmallerThan(1.0, 1e-9));
+  BOOST_CHECK((support.get_R() - R).isZero(1e-9));
+  BOOST_CHECK((support.get_box() - box).isZero(1e-9));
   BOOST_CHECK(static_cast<std::size_t>(support.get_A().rows()) == 4);
   BOOST_CHECK(static_cast<std::size_t>(support.get_lb().size()) == 4);
   BOOST_CHECK(static_cast<std::size_t>(support.get_ub().size()) == 4);
@@ -63,8 +63,7 @@ void test_A_matrix_with_rotation_change() {
   crocoddyl::CoPSupport support_2(R, box);
 
   for (std::size_t i = 0; i < 4; ++i) {
-    BOOST_CHECK(
-        (support_1.get_A().row(i).head(3) - support_2.get_A().row(i).head(3) * R).isMuchSmallerThan(1.0, 1e-9));
+    BOOST_CHECK((support_1.get_A().row(i).head(3) - support_2.get_A().row(i).head(3) * R).isZero(1e-9));
   }
 }
 

--- a/unittest/test_costs.cpp
+++ b/unittest/test_costs.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, LAAS-CNRS, New York University,
+// Copyright (C) 2019-2021, LAAS-CNRS, New York University,
 //                          Max Planck Gesellschaft, University of Edinburgh,
 //                          INRIA
 // Copyright note valid unless otherwise stated in individual files.
@@ -126,19 +126,18 @@ void test_partial_derivatives_against_numdiff(CostModelTypes::Type cost_type, St
   model_num_diff.calcDiff(data_num_diff, x, u);
 
   // Checking the partial derivatives against NumDiff
-  double tol = NUMDIFF_MODIFIER * model_num_diff.get_disturbance();
-
-  BOOST_CHECK((data->Lx - data_num_diff->Lx).isMuchSmallerThan(1.0, tol));
-  BOOST_CHECK((data->Lu - data_num_diff->Lu).isMuchSmallerThan(1.0, tol));
+  double tol = NUMDIFF_MODIFIER * sqrt(model_num_diff.get_disturbance());
+  BOOST_CHECK((data->Lx - data_num_diff->Lx).isZero(tol));
+  BOOST_CHECK((data->Lu - data_num_diff->Lu).isZero(tol));
   if (model_num_diff.get_with_gauss_approx()) {
     // The num diff is not precise enough to be tested here.
-    BOOST_CHECK((data->Lxx - data_num_diff->Lxx).isMuchSmallerThan(1.0, tol));
-    BOOST_CHECK((data->Lxu - data_num_diff->Lxu).isMuchSmallerThan(1.0, tol));
-    BOOST_CHECK((data->Luu - data_num_diff->Luu).isMuchSmallerThan(1.0, tol));
+    BOOST_CHECK((data->Lxx - data_num_diff->Lxx).isZero(tol));
+    BOOST_CHECK((data->Lxu - data_num_diff->Lxu).isZero(tol));
+    BOOST_CHECK((data->Luu - data_num_diff->Luu).isZero(tol));
   } else {
-    BOOST_CHECK((data_num_diff->Lxx).isMuchSmallerThan(1.0, tol));
-    BOOST_CHECK((data_num_diff->Lxu).isMuchSmallerThan(1.0, tol));
-    BOOST_CHECK((data_num_diff->Luu).isMuchSmallerThan(1.0, tol));
+    BOOST_CHECK((data_num_diff->Lxx).isZero(tol));
+    BOOST_CHECK((data_num_diff->Lxu).isZero(tol));
+    BOOST_CHECK((data_num_diff->Luu).isZero(tol));
   }
 }
 

--- a/unittest/test_costs.cpp
+++ b/unittest/test_costs.cpp
@@ -208,11 +208,11 @@ void test_partial_derivatives_in_cost_sum(CostModelTypes::Type cost_type, StateM
   cost_sum.calc(data_sum, x, u);
   cost_sum.calcDiff(data_sum, x, u);
 
-  BOOST_CHECK((data->Lx - data_sum->Lx).isMuchSmallerThan(1.0));
-  BOOST_CHECK((data->Lu - data_sum->Lu).isMuchSmallerThan(1.0));
-  BOOST_CHECK((data->Lxx - data_sum->Lxx).isMuchSmallerThan(1.0));
-  BOOST_CHECK((data->Lxu - data_sum->Lxu).isMuchSmallerThan(1.0));
-  BOOST_CHECK((data->Luu - data_sum->Luu).isMuchSmallerThan(1.0));
+  BOOST_CHECK((data->Lx - data_sum->Lx).isZero());
+  BOOST_CHECK((data->Lu - data_sum->Lu).isZero());
+  BOOST_CHECK((data->Lxx - data_sum->Lxx).isZero());
+  BOOST_CHECK((data->Lxu - data_sum->Lxu).isZero());
+  BOOST_CHECK((data->Luu - data_sum->Luu).isZero());
 }
 
 //----------------------------------------------------------------------------//

--- a/unittest/test_costs.cpp
+++ b/unittest/test_costs.cpp
@@ -126,7 +126,7 @@ void test_partial_derivatives_against_numdiff(CostModelTypes::Type cost_type, St
   model_num_diff.calcDiff(data_num_diff, x, u);
 
   // Checking the partial derivatives against NumDiff
-  double tol = NUMDIFF_MODIFIER * sqrt(model_num_diff.get_disturbance());
+  double tol = sqrt(model_num_diff.get_disturbance());
   BOOST_CHECK((data->Lx - data_num_diff->Lx).isZero(tol));
   BOOST_CHECK((data->Lu - data_num_diff->Lu).isZero(tol));
   if (model_num_diff.get_with_gauss_approx()) {

--- a/unittest/test_costs_noFF.cpp
+++ b/unittest/test_costs_noFF.cpp
@@ -222,11 +222,11 @@ void test_partial_derivatives_in_cost_sum(CostModelNoFFTypes::Type cost_type,
   cost_sum.calc(data_sum, x, u);
   cost_sum.calcDiff(data_sum, x, u);
 
-  BOOST_CHECK((data->Lx - data_sum->Lx).isMuchSmallerThan(1.0));
-  BOOST_CHECK((data->Lu - data_sum->Lu).isMuchSmallerThan(1.0));
-  BOOST_CHECK((data->Lxx - data_sum->Lxx).isMuchSmallerThan(1.0));
-  BOOST_CHECK((data->Lxu - data_sum->Lxu).isMuchSmallerThan(1.0));
-  BOOST_CHECK((data->Luu - data_sum->Luu).isMuchSmallerThan(1.0));
+  BOOST_CHECK((data->Lx - data_sum->Lx).isZero());
+  BOOST_CHECK((data->Lu - data_sum->Lu).isZero());
+  BOOST_CHECK((data->Lxx - data_sum->Lxx).isZero());
+  BOOST_CHECK((data->Lxu - data_sum->Lxu).isZero());
+  BOOST_CHECK((data->Luu - data_sum->Luu).isZero());
 }
 
 //----------------------------------------------------------------------------//

--- a/unittest/test_costs_noFF.cpp
+++ b/unittest/test_costs_noFF.cpp
@@ -135,7 +135,7 @@ void test_partial_derivatives_against_numdiff(CostModelNoFFTypes::Type cost_type
   model_num_diff.calcDiff(data_num_diff, x, u);
 
   // Checking the partial derivatives against NumDiff
-  double tol = NUMDIFF_MODIFIER * sqrt(model_num_diff.get_disturbance());
+  double tol = sqrt(model_num_diff.get_disturbance());
   BOOST_CHECK((data->Lx - data_num_diff->Lx).isZero(tol));
   BOOST_CHECK((data->Lu - data_num_diff->Lu).isZero(tol));
   if (model_num_diff.get_with_gauss_approx()) {

--- a/unittest/test_costs_noFF.cpp
+++ b/unittest/test_costs_noFF.cpp
@@ -135,19 +135,18 @@ void test_partial_derivatives_against_numdiff(CostModelNoFFTypes::Type cost_type
   model_num_diff.calcDiff(data_num_diff, x, u);
 
   // Checking the partial derivatives against NumDiff
-  double tol = NUMDIFF_MODIFIER * model_num_diff.get_disturbance();
-
-  BOOST_CHECK((data->Lx - data_num_diff->Lx).isMuchSmallerThan(1.0, tol));
-  BOOST_CHECK((data->Lu - data_num_diff->Lu).isMuchSmallerThan(1.0, tol));
+  double tol = NUMDIFF_MODIFIER * sqrt(model_num_diff.get_disturbance());
+  BOOST_CHECK((data->Lx - data_num_diff->Lx).isZero(tol));
+  BOOST_CHECK((data->Lu - data_num_diff->Lu).isZero(tol));
   if (model_num_diff.get_with_gauss_approx()) {
     // The num diff is not precise enough to be tested here.
-    BOOST_CHECK((data->Lxx - data_num_diff->Lxx).isMuchSmallerThan(1.0, tol));
-    BOOST_CHECK((data->Lxu - data_num_diff->Lxu).isMuchSmallerThan(1.0, tol));
-    BOOST_CHECK((data->Luu - data_num_diff->Luu).isMuchSmallerThan(1.0, tol));
+    BOOST_CHECK((data->Lxx - data_num_diff->Lxx).isZero(tol));
+    BOOST_CHECK((data->Lxu - data_num_diff->Lxu).isZero(tol));
+    BOOST_CHECK((data->Luu - data_num_diff->Luu).isZero(tol));
   } else {
-    BOOST_CHECK((data_num_diff->Lxx).isMuchSmallerThan(1.0, tol));
-    BOOST_CHECK((data_num_diff->Lxu).isMuchSmallerThan(1.0, tol));
-    BOOST_CHECK((data_num_diff->Luu).isMuchSmallerThan(1.0, tol));
+    BOOST_CHECK((data_num_diff->Lxx).isZero(tol));
+    BOOST_CHECK((data_num_diff->Lxu).isZero(tol));
+    BOOST_CHECK((data_num_diff->Luu).isZero(tol));
   }
 }
 

--- a/unittest/test_diff_actions.cpp
+++ b/unittest/test_diff_actions.cpp
@@ -123,9 +123,9 @@ void test_partial_derivatives_against_numdiff(DifferentialActionModelTypes::Type
   model_num_diff.calcDiff(data_num_diff, x, u);
 
   // Checking the partial derivatives against NumDiff
-  double tol = NUMDIFF_MODIFIER * sqrt(model_num_diff.get_disturbance());
-  BOOST_CHECK((data->Fx - data_num_diff->Fx).isZero(tol));
-  BOOST_CHECK((data->Fu - data_num_diff->Fu).isZero(tol));
+  double tol = sqrt(model_num_diff.get_disturbance());
+  BOOST_CHECK((data->Fx - data_num_diff->Fx).isZero(NUMDIFF_MODIFIER * tol));
+  BOOST_CHECK((data->Fu - data_num_diff->Fu).isZero(NUMDIFF_MODIFIER * tol));
   BOOST_CHECK((data->Lx - data_num_diff->Lx).isZero(tol));
   BOOST_CHECK((data->Lu - data_num_diff->Lu).isZero(tol));
   if (model_num_diff.get_with_gauss_approx()) {

--- a/unittest/test_diff_actions.cpp
+++ b/unittest/test_diff_actions.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, LAAS-CNRS, New York University, Max Planck Gesellschaft, INRIA
+// Copyright (C) 2019-2021, LAAS-CNRS, New York University, Max Planck Gesellschaft, INRIA
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -123,19 +123,19 @@ void test_partial_derivatives_against_numdiff(DifferentialActionModelTypes::Type
   model_num_diff.calcDiff(data_num_diff, x, u);
 
   // Checking the partial derivatives against NumDiff
-  double tol = NUMDIFF_MODIFIER * model_num_diff.get_disturbance();
-  BOOST_CHECK((data->Fx - data_num_diff->Fx).isMuchSmallerThan(1.0, tol));
-  BOOST_CHECK((data->Fu - data_num_diff->Fu).isMuchSmallerThan(1.0, tol));
-  BOOST_CHECK((data->Lx - data_num_diff->Lx).isMuchSmallerThan(1.0, tol));
-  BOOST_CHECK((data->Lu - data_num_diff->Lu).isMuchSmallerThan(1.0, tol));
+  double tol = NUMDIFF_MODIFIER * sqrt(model_num_diff.get_disturbance());
+  BOOST_CHECK((data->Fx - data_num_diff->Fx).isZero(tol));
+  BOOST_CHECK((data->Fu - data_num_diff->Fu).isZero(tol));
+  BOOST_CHECK((data->Lx - data_num_diff->Lx).isZero(tol));
+  BOOST_CHECK((data->Lu - data_num_diff->Lu).isZero(tol));
   if (model_num_diff.get_with_gauss_approx()) {
-    BOOST_CHECK((data->Lxx - data_num_diff->Lxx).isMuchSmallerThan(1.0, tol));
-    BOOST_CHECK((data->Lxu - data_num_diff->Lxu).isMuchSmallerThan(1.0, tol));
-    BOOST_CHECK((data->Luu - data_num_diff->Luu).isMuchSmallerThan(1.0, tol));
+    BOOST_CHECK((data->Lxx - data_num_diff->Lxx).isZero(tol));
+    BOOST_CHECK((data->Lxu - data_num_diff->Lxu).isZero(tol));
+    BOOST_CHECK((data->Luu - data_num_diff->Luu).isZero(tol));
   } else {
-    BOOST_CHECK((data_num_diff->Lxx).isMuchSmallerThan(1.0, tol));
-    BOOST_CHECK((data_num_diff->Lxu).isMuchSmallerThan(1.0, tol));
-    BOOST_CHECK((data_num_diff->Luu).isMuchSmallerThan(1.0, tol));
+    BOOST_CHECK((data_num_diff->Lxx).isZero(tol));
+    BOOST_CHECK((data_num_diff->Lxu).isZero(tol));
+    BOOST_CHECK((data_num_diff->Luu).isZero(tol));
   }
 }
 

--- a/unittest/test_friction_cone.cpp
+++ b/unittest/test_friction_cone.cpp
@@ -29,7 +29,7 @@ void test_constructor() {
   // Create the friction cone with rotation and surface normal
   crocoddyl::FrictionCone cone(R, mu, nf, inner_appr);
 
-  BOOST_CHECK((cone.get_R() - R).isMuchSmallerThan(1.0, 1e-9));
+  BOOST_CHECK((cone.get_R() - R).isZero(1e-9));
   BOOST_CHECK(cone.get_mu() == mu);
   BOOST_CHECK(cone.get_nf() == nf);
   BOOST_CHECK(cone.get_inner_appr() == inner_appr);
@@ -45,7 +45,7 @@ void test_constructor() {
   // Create the friction cone
   cone = crocoddyl::FrictionCone(R, mu, nf, inner_appr);
 
-  BOOST_CHECK((cone.get_R() - R).isMuchSmallerThan(1.0, 1e-9));
+  BOOST_CHECK((cone.get_R() - R).isZero(1e-9));
   BOOST_CHECK(cone.get_mu() == mu);
   BOOST_CHECK(cone.get_nf() == nf);
   BOOST_CHECK(cone.get_inner_appr() == inner_appr);
@@ -83,7 +83,7 @@ void test_A_matrix_with_rotation_change() {
   crocoddyl::FrictionCone cone_2(R, mu, nf, inner_appr);
 
   for (std::size_t i = 0; i < 5; ++i) {
-    BOOST_CHECK((cone_1.get_A().row(i) - cone_2.get_A().row(i) * R).isMuchSmallerThan(1.0, 1e-9));
+    BOOST_CHECK((cone_1.get_A().row(i) - cone_2.get_A().row(i) * R).isZero(1e-9));
   }
 }
 

--- a/unittest/test_impulse_costs.cpp
+++ b/unittest/test_impulse_costs.cpp
@@ -42,7 +42,7 @@ void test_partial_derivatives_against_impulse_numdiff(ImpulseCostModelTypes::Typ
   model_num_diff.calcDiff(data_num_diff, x, u);
 
   // Checking the partial derivatives against NumDiff
-  double tol = NUMDIFF_MODIFIER * sqrt(model_num_diff.get_disturbance());
+  double tol = sqrt(model_num_diff.get_disturbance());
   BOOST_CHECK((data->Lx - data_num_diff->Lx).isZero(tol));
   BOOST_CHECK((data->Lu - data_num_diff->Lu).isZero(tol));
   if (model_num_diff.get_with_gauss_approx()) {

--- a/unittest/test_impulse_costs.cpp
+++ b/unittest/test_impulse_costs.cpp
@@ -42,17 +42,17 @@ void test_partial_derivatives_against_impulse_numdiff(ImpulseCostModelTypes::Typ
   model_num_diff.calcDiff(data_num_diff, x, u);
 
   // Checking the partial derivatives against NumDiff
-  double tol = NUMDIFF_MODIFIER * model_num_diff.get_disturbance();
-  BOOST_CHECK((data->Lx - data_num_diff->Lx).isMuchSmallerThan(1.0, tol));
-  BOOST_CHECK((data->Lu - data_num_diff->Lu).isMuchSmallerThan(1.0, tol));
+  double tol = NUMDIFF_MODIFIER * sqrt(model_num_diff.get_disturbance());
+  BOOST_CHECK((data->Lx - data_num_diff->Lx).isZero(tol));
+  BOOST_CHECK((data->Lu - data_num_diff->Lu).isZero(tol));
   if (model_num_diff.get_with_gauss_approx()) {
-    BOOST_CHECK((data->Lxx - data_num_diff->Lxx).isMuchSmallerThan(1.0, tol));
-    BOOST_CHECK((data->Lxu - data_num_diff->Lxu).isMuchSmallerThan(1.0, tol));
-    BOOST_CHECK((data->Luu - data_num_diff->Luu).isMuchSmallerThan(1.0, tol));
+    BOOST_CHECK((data->Lxx - data_num_diff->Lxx).isZero(tol));
+    BOOST_CHECK((data->Lxu - data_num_diff->Lxu).isZero(tol));
+    BOOST_CHECK((data->Luu - data_num_diff->Luu).isZero(tol));
   } else {
-    BOOST_CHECK((data_num_diff->Lxx).isMuchSmallerThan(1.0, tol));
-    BOOST_CHECK((data_num_diff->Lxu).isMuchSmallerThan(1.0, tol));
-    BOOST_CHECK((data_num_diff->Luu).isMuchSmallerThan(1.0, tol));
+    BOOST_CHECK((data_num_diff->Lxx).isZero(tol));
+    BOOST_CHECK((data_num_diff->Lxu).isZero(tol));
+    BOOST_CHECK((data_num_diff->Luu).isZero(tol));
   }
 }
 

--- a/unittest/test_multiple_contacts.cpp
+++ b/unittest/test_multiple_contacts.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, University of Edinburgh
+// Copyright (C) 2019-2021, University of Edinburgh
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -431,7 +431,7 @@ void test_updateAccelerationDiff() {
   model.updateAccelerationDiff(data, ddv_dx);
 
   // Test
-  BOOST_CHECK((data->ddv_dx - ddv_dx).isMuchSmallerThan(1.0, 1e-9));
+  BOOST_CHECK((data->ddv_dx - ddv_dx).isZero(1e-9));
 }
 
 void test_updateForceDiff() {

--- a/unittest/test_multiple_impulses.cpp
+++ b/unittest/test_multiple_impulses.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, LAAS-CNRS, New York University, Max Planck Gesellschaft,
+// Copyright (C) 2019-2021, LAAS-CNRS, New York University, Max Planck Gesellschaft,
 //                          INRIA
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
@@ -417,7 +417,7 @@ void test_updateVelocityDiff() {
   model.updateVelocityDiff(data, dvnext_dx);
 
   // Test
-  BOOST_CHECK((data->dvnext_dx - dvnext_dx).isMuchSmallerThan(1.0, 1e-9));
+  BOOST_CHECK((data->dvnext_dx - dvnext_dx).isZero(1e-9));
 }
 
 void test_updateForceDiff() {

--- a/unittest/test_problem.cpp
+++ b/unittest/test_problem.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2020, University of Edinburgh
+// Copyright (C) 2020-2021, University of Edinburgh
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -46,12 +46,12 @@ void test_calc(ActionModelTypes::Type action_model_type) {
     const boost::shared_ptr<crocoddyl::ActionDataAbstract>& data = model->createData();
     model->calc(data, xs[i], us[i]);
     BOOST_CHECK(problem.get_runningDatas()[i]->cost == data->cost);
-    BOOST_CHECK((problem.get_runningDatas()[i]->xnext - data->xnext).isMuchSmallerThan(1.0, 1e-7));
+    BOOST_CHECK((problem.get_runningDatas()[i]->xnext - data->xnext).isZero(1e-9));
   }
   const boost::shared_ptr<crocoddyl::ActionDataAbstract>& data = model->createData();
   model->calc(data, xs.back());
   BOOST_CHECK(problem.get_terminalData()->cost == data->cost);
-  BOOST_CHECK((problem.get_terminalData()->xnext - data->xnext).isMuchSmallerThan(1.0, 1e-7));
+  BOOST_CHECK((problem.get_terminalData()->xnext - data->xnext).isZero(1e-9));
 }
 
 void test_calc_diffAction(DifferentialActionModelTypes::Type action_model_type) {
@@ -82,12 +82,12 @@ void test_calc_diffAction(DifferentialActionModelTypes::Type action_model_type) 
     const boost::shared_ptr<crocoddyl::ActionDataAbstract>& data = model->createData();
     model->calc(data, xs[i], us[i]);
     BOOST_CHECK(problem.get_runningDatas()[i]->cost == data->cost);
-    BOOST_CHECK((problem.get_runningDatas()[i]->xnext - data->xnext).isMuchSmallerThan(1.0, 1e-7));
+    BOOST_CHECK((problem.get_runningDatas()[i]->xnext - data->xnext).isZero(1e-9));
   }
   const boost::shared_ptr<crocoddyl::ActionDataAbstract>& data = model->createData();
   model->calc(data, xs.back());
   BOOST_CHECK(problem.get_terminalData()->cost == data->cost);
-  BOOST_CHECK((problem.get_terminalData()->xnext - data->xnext).isMuchSmallerThan(1.0, 1e-7));
+  BOOST_CHECK((problem.get_terminalData()->xnext - data->xnext).isZero(1e-9));
 }
 
 void test_calcDiff(ActionModelTypes::Type action_model_type) {
@@ -117,20 +117,20 @@ void test_calcDiff(ActionModelTypes::Type action_model_type) {
     const boost::shared_ptr<crocoddyl::ActionDataAbstract>& data = model->createData();
     model->calc(data, xs[i], us[i]);
     model->calcDiff(data, xs[i], us[i]);
-    BOOST_CHECK((problem.get_runningDatas()[i]->Fx - data->Fx).isMuchSmallerThan(1.0, 1e-7));
-    BOOST_CHECK((problem.get_runningDatas()[i]->Fu - data->Fu).isMuchSmallerThan(1.0, 1e-7));
-    BOOST_CHECK((problem.get_runningDatas()[i]->Lx - data->Lx).isMuchSmallerThan(1.0, 1e-7));
-    BOOST_CHECK((problem.get_runningDatas()[i]->Lu - data->Lu).isMuchSmallerThan(1.0, 1e-7));
-    BOOST_CHECK((problem.get_runningDatas()[i]->Lxx - data->Lxx).isMuchSmallerThan(1.0, 1e-7));
-    BOOST_CHECK((problem.get_runningDatas()[i]->Lxu - data->Lxu).isMuchSmallerThan(1.0, 1e-7));
-    BOOST_CHECK((problem.get_runningDatas()[i]->Luu - data->Luu).isMuchSmallerThan(1.0, 1e-7));
+    BOOST_CHECK((problem.get_runningDatas()[i]->Fx - data->Fx).isZero(1e-9));
+    BOOST_CHECK((problem.get_runningDatas()[i]->Fu - data->Fu).isZero(1e-9));
+    BOOST_CHECK((problem.get_runningDatas()[i]->Lx - data->Lx).isZero(1e-9));
+    BOOST_CHECK((problem.get_runningDatas()[i]->Lu - data->Lu).isZero(1e-9));
+    BOOST_CHECK((problem.get_runningDatas()[i]->Lxx - data->Lxx).isZero(1e-9));
+    BOOST_CHECK((problem.get_runningDatas()[i]->Lxu - data->Lxu).isZero(1e-9));
+    BOOST_CHECK((problem.get_runningDatas()[i]->Luu - data->Luu).isZero(1e-9));
   }
   const boost::shared_ptr<crocoddyl::ActionDataAbstract>& data = model->createData();
   model->calc(data, xs.back());
   model->calcDiff(data, xs.back());
-  BOOST_CHECK((problem.get_terminalData()->Fx - data->Fx).isMuchSmallerThan(1.0, 1e-7));
-  BOOST_CHECK((problem.get_terminalData()->Lx - data->Lx).isMuchSmallerThan(1.0, 1e-7));
-  BOOST_CHECK((problem.get_terminalData()->Lxx - data->Lxx).isMuchSmallerThan(1.0, 1e-7));
+  BOOST_CHECK((problem.get_terminalData()->Fx - data->Fx).isZero(1e-9));
+  BOOST_CHECK((problem.get_terminalData()->Lx - data->Lx).isZero(1e-9));
+  BOOST_CHECK((problem.get_terminalData()->Lxx - data->Lxx).isZero(1e-9));
 }
 
 void test_calcDiff_diffAction(DifferentialActionModelTypes::Type action_model_type) {
@@ -162,20 +162,20 @@ void test_calcDiff_diffAction(DifferentialActionModelTypes::Type action_model_ty
     const boost::shared_ptr<crocoddyl::ActionDataAbstract>& data = model->createData();
     model->calc(data, xs[i], us[i]);
     model->calcDiff(data, xs[i], us[i]);
-    BOOST_CHECK((problem.get_runningDatas()[i]->Fx - data->Fx).isMuchSmallerThan(1.0, 1e-7));
-    BOOST_CHECK((problem.get_runningDatas()[i]->Fu - data->Fu).isMuchSmallerThan(1.0, 1e-7));
-    BOOST_CHECK((problem.get_runningDatas()[i]->Lx - data->Lx).isMuchSmallerThan(1.0, 1e-7));
-    BOOST_CHECK((problem.get_runningDatas()[i]->Lu - data->Lu).isMuchSmallerThan(1.0, 1e-7));
-    BOOST_CHECK((problem.get_runningDatas()[i]->Lxx - data->Lxx).isMuchSmallerThan(1.0, 1e-7));
-    BOOST_CHECK((problem.get_runningDatas()[i]->Lxu - data->Lxu).isMuchSmallerThan(1.0, 1e-7));
-    BOOST_CHECK((problem.get_runningDatas()[i]->Luu - data->Luu).isMuchSmallerThan(1.0, 1e-7));
+    BOOST_CHECK((problem.get_runningDatas()[i]->Fx - data->Fx).isZero(1e-7));
+    BOOST_CHECK((problem.get_runningDatas()[i]->Fu - data->Fu).isZero(1e-7));
+    BOOST_CHECK((problem.get_runningDatas()[i]->Lx - data->Lx).isZero(1e-7));
+    BOOST_CHECK((problem.get_runningDatas()[i]->Lu - data->Lu).isZero(1e-7));
+    BOOST_CHECK((problem.get_runningDatas()[i]->Lxx - data->Lxx).isZero(1e-7));
+    BOOST_CHECK((problem.get_runningDatas()[i]->Lxu - data->Lxu).isZero(1e-7));
+    BOOST_CHECK((problem.get_runningDatas()[i]->Luu - data->Luu).isZero(1e-7));
   }
   const boost::shared_ptr<crocoddyl::ActionDataAbstract>& data = model->createData();
   model->calc(data, xs.back());
   model->calcDiff(data, xs.back());
-  BOOST_CHECK((problem.get_terminalData()->Fx - data->Fx).isMuchSmallerThan(1.0, 1e-7));
-  BOOST_CHECK((problem.get_terminalData()->Lx - data->Lx).isMuchSmallerThan(1.0, 1e-7));
-  BOOST_CHECK((problem.get_terminalData()->Lxx - data->Lxx).isMuchSmallerThan(1.0, 1e-7));
+  BOOST_CHECK((problem.get_terminalData()->Fx - data->Fx).isZero(1e-7));
+  BOOST_CHECK((problem.get_terminalData()->Lx - data->Lx).isZero(1e-7));
+  BOOST_CHECK((problem.get_terminalData()->Lxx - data->Lxx).isZero(1e-7));
 }
 
 void test_rollout(ActionModelTypes::Type action_model_type) {
@@ -203,7 +203,7 @@ void test_rollout(ActionModelTypes::Type action_model_type) {
   for (std::size_t i = 0; i < T; ++i) {
     const boost::shared_ptr<crocoddyl::ActionDataAbstract>& data = model->createData();
     model->calc(data, xs[i], us[i]);
-    BOOST_CHECK((xs[i + 1] - data->xnext).isMuchSmallerThan(1.0, 1e-7));
+    BOOST_CHECK((xs[i + 1] - data->xnext).isZero(1e-7));
   }
 }
 
@@ -234,7 +234,7 @@ void test_rollout_diffAction(DifferentialActionModelTypes::Type action_model_typ
   for (std::size_t i = 0; i < T; ++i) {
     const boost::shared_ptr<crocoddyl::ActionDataAbstract>& data = model->createData();
     model->calc(data, xs[i], us[i]);
-    BOOST_CHECK((xs[i + 1] - data->xnext).isMuchSmallerThan(1.0, 1e-7));
+    BOOST_CHECK((xs[i + 1] - data->xnext).isZero(1e-7));
   }
 }
 
@@ -264,7 +264,7 @@ void test_quasiStatic(ActionModelTypes::Type action_model_type) {
     const boost::shared_ptr<crocoddyl::ActionDataAbstract>& data = model->createData();
     Eigen::VectorXd u = Eigen::VectorXd::Zero(model->get_nu());
     model->quasiStatic(data, u, xs[i]);
-    BOOST_CHECK((u - us[i]).isMuchSmallerThan(1.0, 1e-7));
+    BOOST_CHECK((u - us[i]).isZero(1e-7));
   }
 }
 
@@ -296,7 +296,7 @@ void test_quasiStatic_diffAction(DifferentialActionModelTypes::Type action_model
     const boost::shared_ptr<crocoddyl::ActionDataAbstract>& data = model->createData();
     Eigen::VectorXd u = Eigen::VectorXd::Zero(model->get_nu());
     model->quasiStatic(data, u, xs[i]);
-    BOOST_CHECK((u - us[i]).isMuchSmallerThan(1.0, 1e-7));
+    BOOST_CHECK((u - us[i]).isZero(1e-7));
   }
 }
 

--- a/unittest/test_solvers.cpp
+++ b/unittest/test_solvers.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, LAAS-CNRS, New York University,
+// Copyright (C) 2019-2021, LAAS-CNRS, New York University,
 //                          Max Planck Gesellschaft, University of Edinburgh,
 //                          INRIA
 // Copyright note valid unless otherwise stated in individual files.
@@ -70,11 +70,11 @@ void test_kkt_search_direction(ActionModelTypes::Type action_type, size_t T) {
   Eigen::Block<Eigen::MatrixXd> hess = kkt_mat.block(0, 0, ndx + nu, ndx + nu);
 
   // Checking the symmetricity of the Hessian
-  BOOST_CHECK((hess - hess.transpose()).isMuchSmallerThan(1.0, 1e-9));
+  BOOST_CHECK((hess - hess.transpose()).isZero(1e-9));
 
   // Check initial state
-  BOOST_CHECK((state->diff_dx(state->integrate_x(xs[0], kkt->get_dxs()[0]), kkt->get_problem()->get_x0()))
-                  .isMuchSmallerThan(1.0, 1e-9));
+  BOOST_CHECK(
+      (state->diff_dx(state->integrate_x(xs[0], kkt->get_dxs()[0]), kkt->get_problem()->get_x0())).isZero(1e-9));
 }
 
 //____________________________________________________________________________//
@@ -120,16 +120,16 @@ void test_solver_against_kkt_solver(SolverTypes::Type solver_type, ActionModelTy
   BOOST_CHECK_EQUAL(solver->get_xs().size(), T + 1);
 
   // initial state
-  BOOST_CHECK((solver->get_xs()[0] - problem->get_x0()).isMuchSmallerThan(1.0, 1e-9));
+  BOOST_CHECK((solver->get_xs()[0] - problem->get_x0()).isZero(1e-9));
 
   // check solutions against each other
   for (unsigned int t = 0; t < T; ++t) {
     const boost::shared_ptr<crocoddyl::ActionModelAbstract>& model = solver->get_problem()->get_runningModels()[t];
     std::size_t nu = model->get_nu();
-    BOOST_CHECK((state->diff_dx(solver->get_xs()[t], kkt.get_xs()[t])).isMuchSmallerThan(1.0, 1e-9));
-    BOOST_CHECK((solver->get_us()[t].head(nu) - kkt.get_us()[t]).isMuchSmallerThan(1.0, 1e-9));
+    BOOST_CHECK((state->diff_dx(solver->get_xs()[t], kkt.get_xs()[t])).isZero(1e-9));
+    BOOST_CHECK((solver->get_us()[t].head(nu) - kkt.get_us()[t]).isZero(1e-9));
   }
-  BOOST_CHECK((state->diff_dx(solver->get_xs()[T], kkt.get_xs()[T])).isMuchSmallerThan(1.0, 1e-9));
+  BOOST_CHECK((state->diff_dx(solver->get_xs()[T], kkt.get_xs()[T])).isZero(1e-9));
 }
 
 //____________________________________________________________________________//

--- a/unittest/test_states.cpp
+++ b/unittest/test_states.cpp
@@ -47,7 +47,7 @@ void test_integrate_against_difference(StateModelTypes::Type state_type) {
   state->diff(x2i, x2, dxi);
 
   // Checking that both states agree
-  BOOST_CHECK(dxi.isMuchSmallerThan(1.0, 1e-9));
+  BOOST_CHECK(dxi.isZero(1e-9));
 }
 
 void test_difference_against_integrate(StateModelTypes::Type state_type) {
@@ -64,7 +64,7 @@ void test_difference_against_integrate(StateModelTypes::Type state_type) {
   state->diff(x, xidx, dxd);
 
   // Checking that both states agree
-  BOOST_CHECK((dxd - dx).isMuchSmallerThan(1.0, 1e-9));
+  BOOST_CHECK((dxd - dx).isZero(1e-9));
 }
 
 void test_Jdiff_firstsecond(StateModelTypes::Type state_type) {
@@ -86,8 +86,8 @@ void test_Jdiff_firstsecond(StateModelTypes::Type state_type) {
   Eigen::MatrixXd Jdiff_both_second(Eigen::MatrixXd::Zero(state->get_ndx(), state->get_ndx()));
   state->Jdiff(x1, x2, Jdiff_both_first, Jdiff_both_second);
 
-  BOOST_CHECK((Jdiff_first - Jdiff_both_first).isMuchSmallerThan(1.0, 1e-9));
-  BOOST_CHECK((Jdiff_second - Jdiff_both_second).isMuchSmallerThan(1.0, 1e-9));
+  BOOST_CHECK((Jdiff_first - Jdiff_both_first).isZero(1e-9));
+  BOOST_CHECK((Jdiff_second - Jdiff_both_second).isZero(1e-9));
 }
 
 void test_Jint_firstsecond(StateModelTypes::Type state_type) {
@@ -109,8 +109,8 @@ void test_Jint_firstsecond(StateModelTypes::Type state_type) {
   Eigen::MatrixXd Jint_both_second(Eigen::MatrixXd::Zero(state->get_ndx(), state->get_ndx()));
   state->Jintegrate(x, dx, Jint_both_first, Jint_both_second);
 
-  BOOST_CHECK((Jint_first - Jint_both_first).isMuchSmallerThan(1.0, 1e-9));
-  BOOST_CHECK((Jint_second - Jint_both_second).isMuchSmallerThan(1.0, 1e-9));
+  BOOST_CHECK((Jint_first - Jint_both_first).isZero(1e-9));
+  BOOST_CHECK((Jint_second - Jint_both_second).isZero(1e-9));
 }
 
 void test_Jdiff_num_diff_firstsecond(StateModelTypes::Type state_type) {
@@ -135,8 +135,8 @@ void test_Jdiff_num_diff_firstsecond(StateModelTypes::Type state_type) {
   Eigen::MatrixXd Jdiff_num_diff_both_second(Eigen::MatrixXd::Zero(state->get_ndx(), state->get_ndx()));
   state_num_diff.Jdiff(x1, x2, Jdiff_num_diff_both_first, Jdiff_num_diff_both_second);
 
-  BOOST_CHECK((Jdiff_num_diff_first - Jdiff_num_diff_both_first).isMuchSmallerThan(1.0, 1e-9));
-  BOOST_CHECK((Jdiff_num_diff_second - Jdiff_num_diff_both_second).isMuchSmallerThan(1.0, 1e-9));
+  BOOST_CHECK((Jdiff_num_diff_first - Jdiff_num_diff_both_first).isZero(1e-9));
+  BOOST_CHECK((Jdiff_num_diff_second - Jdiff_num_diff_both_second).isZero(1e-9));
 }
 
 void test_Jint_num_diff_firstsecond(StateModelTypes::Type state_type) {
@@ -161,8 +161,8 @@ void test_Jint_num_diff_firstsecond(StateModelTypes::Type state_type) {
   Eigen::MatrixXd Jint_num_diff_both_second(Eigen::MatrixXd::Zero(state->get_ndx(), state->get_ndx()));
   state_num_diff.Jintegrate(x, dx, Jint_num_diff_both_first, Jint_num_diff_both_second);
 
-  BOOST_CHECK((Jint_num_diff_first - Jint_num_diff_both_first).isMuchSmallerThan(1.0, 1e-9));
-  BOOST_CHECK((Jint_num_diff_second - Jint_num_diff_both_second).isMuchSmallerThan(1.0, 1e-9));
+  BOOST_CHECK((Jint_num_diff_first - Jint_num_diff_both_first).isZero(1e-9));
+  BOOST_CHECK((Jint_num_diff_second - Jint_num_diff_both_second).isZero(1e-9));
 }
 
 void test_Jdiff_against_numdiff(StateModelTypes::Type state_type) {
@@ -232,11 +232,11 @@ void test_JintegrateTransport(StateModelTypes::Type state_type) {
   const Eigen::MatrixXd Jtest(Jref);
 
   state->JintegrateTransport(x, dx, Jref, crocoddyl::first);
-  BOOST_CHECK((Jref - Jint_1 * Jtest).isMuchSmallerThan(1.0, 1e-10));
+  BOOST_CHECK((Jref - Jint_1 * Jtest).isZero(1e-10));
 
   Jref = Jtest;
   state->JintegrateTransport(x, dx, Jref, crocoddyl::second);
-  BOOST_CHECK((Jref - Jint_2 * Jtest).isMuchSmallerThan(1.0, 1e-10));
+  BOOST_CHECK((Jref - Jint_2 * Jtest).isZero(1e-10));
 }
 
 void test_Jdiff_and_Jintegrate_are_inverses(StateModelTypes::Type state_type) {
@@ -259,7 +259,7 @@ void test_Jdiff_and_Jintegrate_are_inverses(StateModelTypes::Type state_type) {
   // Checking that Jdiff and Jintegrate are inverses
   Eigen::MatrixXd dX_dDX = Jdx;
   Eigen::MatrixXd dDX_dX = J2;
-  BOOST_CHECK((dX_dDX - dDX_dX.inverse()).isMuchSmallerThan(1.0, 1e-9));
+  BOOST_CHECK((dX_dDX - dDX_dX.inverse()).isZero(1e-9));
 }
 
 void test_velocity_from_Jintegrate_Jdiff(StateModelTypes::Type state_type) {
@@ -287,7 +287,7 @@ void test_velocity_from_Jintegrate_Jdiff(StateModelTypes::Type state_type) {
   state->integrate(x1, dx + eps * h, x2eps);
   Eigen::VectorXd x2_eps(state->get_ndx());
   state->diff(x2, x2eps, x2_eps);
-  BOOST_CHECK((dX_dDX * eps - x2_eps / h).isMuchSmallerThan(1.0, 1e-3));
+  BOOST_CHECK((dX_dDX * eps - x2_eps / h).isZero(1e-3));
 
   // Checking the velocity computed from Jdiff
   const Eigen::VectorXd& x = state->rand();
@@ -300,7 +300,7 @@ void test_velocity_from_Jintegrate_Jdiff(StateModelTypes::Type state_type) {
   J1.setZero();
   J2.setZero();
   state->Jdiff(x1, x, J1, J2);
-  BOOST_CHECK((J2 * eps - (-dx + dxi) / h).isMuchSmallerThan(1.0, 1e-3));
+  BOOST_CHECK((J2 * eps - (-dx + dxi) / h).isZero(1e-3));
 }
 
 //----------------------------------------------------------------------------//

--- a/unittest/test_states.cpp
+++ b/unittest/test_states.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, LAAS-CNRS, New York University, Max Planck Gesellschaft,
+// Copyright (C) 2019-2021, LAAS-CNRS, New York University, Max Planck Gesellschaft,
 //                          University of Edinburgh, INRIA
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
@@ -186,9 +186,9 @@ void test_Jdiff_against_numdiff(StateModelTypes::Type state_type) {
 
   // Checking the partial derivatives against NumDiff
   // The previous tolerance was 10*disturbance
-  double tol = NUMDIFF_MODIFIER * state_num_diff.get_disturbance();
-  BOOST_CHECK((Jdiff_1 - Jdiff_num_1).isMuchSmallerThan(1.0, tol));
-  BOOST_CHECK((Jdiff_2 - Jdiff_num_2).isMuchSmallerThan(1.0, tol));
+  double tol = NUMDIFF_MODIFIER * sqrt(state_num_diff.get_disturbance());
+  BOOST_CHECK((Jdiff_1 - Jdiff_num_1).isZero(tol));
+  BOOST_CHECK((Jdiff_2 - Jdiff_num_2).isZero(tol));
 }
 
 void test_Jintegrate_against_numdiff(StateModelTypes::Type state_type) {
@@ -211,9 +211,9 @@ void test_Jintegrate_against_numdiff(StateModelTypes::Type state_type) {
 
   // Checking the partial derivatives against NumDiff
   // The previous tolerance was 10*disturbance
-  double tol = NUMDIFF_MODIFIER * state_num_diff.get_disturbance();
-  BOOST_CHECK((Jint_1 - Jint_num_1).isMuchSmallerThan(1.0, tol));
-  BOOST_CHECK((Jint_2 - Jint_num_2).isMuchSmallerThan(1.0, tol));
+  double tol = NUMDIFF_MODIFIER * sqrt(state_num_diff.get_disturbance());
+  BOOST_CHECK((Jint_1 - Jint_num_1).isZero(tol));
+  BOOST_CHECK((Jint_2 - Jint_num_2).isZero(tol));
 }
 
 void test_JintegrateTransport(StateModelTypes::Type state_type) {

--- a/unittest/test_states.cpp
+++ b/unittest/test_states.cpp
@@ -211,7 +211,7 @@ void test_Jintegrate_against_numdiff(StateModelTypes::Type state_type) {
 
   // Checking the partial derivatives against NumDiff
   // The previous tolerance was 10*disturbance
-  double tol = NUMDIFF_MODIFIER * sqrt(state_num_diff.get_disturbance());
+  double tol = sqrt(state_num_diff.get_disturbance());
   BOOST_CHECK((Jint_1 - Jint_num_1).isZero(tol));
   BOOST_CHECK((Jint_2 - Jint_num_2).isZero(tol));
 }

--- a/unittest/test_wrench_cone.cpp
+++ b/unittest/test_wrench_cone.cpp
@@ -32,10 +32,10 @@ void test_constructor() {
   // Create the wrench cone
   crocoddyl::WrenchCone cone(R, mu, box, nf, inner_appr);
 
-  BOOST_CHECK((cone.get_R() - R).isMuchSmallerThan(1.0, 1e-9));
+  BOOST_CHECK((cone.get_R() - R).isZero(1e-9));
   BOOST_CHECK(cone.get_mu() == mu);
   BOOST_CHECK(cone.get_nf() == nf);
-  BOOST_CHECK((cone.get_box() - box).isMuchSmallerThan(1.0, 1e-9));
+  BOOST_CHECK((cone.get_box() - box).isZero(1e-9));
   BOOST_CHECK(cone.get_inner_appr() == inner_appr);
   BOOST_CHECK(static_cast<std::size_t>(cone.get_A().rows()) == nf + 13);
   BOOST_CHECK(static_cast<std::size_t>(cone.get_lb().size()) == nf + 13);
@@ -49,10 +49,10 @@ void test_constructor() {
   // Create the wrench cone
   cone = crocoddyl::WrenchCone(R, mu, box, nf, inner_appr);
 
-  BOOST_CHECK((cone.get_R() - R).isMuchSmallerThan(1.0, 1e-9));
+  BOOST_CHECK((cone.get_R() - R).isZero(1e-9));
   BOOST_CHECK(cone.get_mu() == mu);
   BOOST_CHECK(cone.get_nf() == nf);
-  BOOST_CHECK((cone.get_box() - box).isMuchSmallerThan(1.0, 1e-9));
+  BOOST_CHECK((cone.get_box() - box).isZero(1e-9));
   BOOST_CHECK(cone.get_inner_appr() == inner_appr);
   BOOST_CHECK(static_cast<std::size_t>(cone.get_A().rows()) == nf + 13);
   BOOST_CHECK(static_cast<std::size_t>(cone.get_lb().size()) == nf + 13);
@@ -73,14 +73,14 @@ void test_against_friction_cone() {
   crocoddyl::WrenchCone wrench_cone(R, mu, box, nf, inner_appr, 0., 100.);
   crocoddyl::FrictionCone friction_cone(R, mu, nf, inner_appr, 0., 100.);
 
-  BOOST_CHECK((wrench_cone.get_R() - friction_cone.get_R()).isMuchSmallerThan(1.0, 1e-9));
+  BOOST_CHECK((wrench_cone.get_R() - friction_cone.get_R()).isZero(1e-9));
   BOOST_CHECK(wrench_cone.get_mu() == friction_cone.get_mu());
   BOOST_CHECK(wrench_cone.get_nf() == friction_cone.get_nf());
   for (std::size_t i = 0; i < nf + 1; ++i) {
-    BOOST_CHECK((wrench_cone.get_A().row(i).head(3) - friction_cone.get_A().row(i)).isMuchSmallerThan(1.0, 1e-9));
+    BOOST_CHECK((wrench_cone.get_A().row(i).head(3) - friction_cone.get_A().row(i)).isZero(1e-9));
   }
-  BOOST_CHECK((wrench_cone.get_lb().head(nf + 1) - friction_cone.get_lb()).isMuchSmallerThan(1.0, 1e-9));
-  BOOST_CHECK((wrench_cone.get_ub().head(nf + 1) - friction_cone.get_ub()).isMuchSmallerThan(1.0, 1e-9));
+  BOOST_CHECK((wrench_cone.get_lb().head(nf + 1) - friction_cone.get_lb()).isZero(1e-9));
+  BOOST_CHECK((wrench_cone.get_ub().head(nf + 1) - friction_cone.get_ub()).isZero(1e-9));
 }
 
 void test_against_cop_support() {
@@ -97,12 +97,12 @@ void test_against_cop_support() {
   crocoddyl::WrenchCone wrench_cone(R, mu, box, nf, inner_appr, 0., 100.);
   crocoddyl::CoPSupport cop_support(R, box);
 
-  BOOST_CHECK((wrench_cone.get_R() - cop_support.get_R()).isMuchSmallerThan(1.0, 1e-9));
+  BOOST_CHECK((wrench_cone.get_R() - cop_support.get_R()).isZero(1e-9));
   for (std::size_t i = 0; i < 4; ++i) {
-    BOOST_CHECK((wrench_cone.get_A().row(nf + i + 1) - cop_support.get_A().row(i)).isMuchSmallerThan(1.0, 1e-9));
+    BOOST_CHECK((wrench_cone.get_A().row(nf + i + 1) - cop_support.get_A().row(i)).isZero(1e-9));
   }
-  BOOST_CHECK((wrench_cone.get_lb().segment(nf + 1, 4) - cop_support.get_lb()).isMuchSmallerThan(1.0, 1e-9));
-  BOOST_CHECK((wrench_cone.get_ub().segment(nf + 1, 4) - cop_support.get_ub()).isMuchSmallerThan(1.0, 1e-9));
+  BOOST_CHECK((wrench_cone.get_lb().segment(nf + 1, 4) - cop_support.get_lb()).isZero(1e-9));
+  BOOST_CHECK((wrench_cone.get_ub().segment(nf + 1, 4) - cop_support.get_ub()).isZero(1e-9));
 }
 
 void test_force_along_wrench_cone_normal() {

--- a/unittest/unittest_common.hpp
+++ b/unittest/unittest_common.hpp
@@ -14,7 +14,7 @@
 #ifndef CROCODDYL_UNITTEST_COMMON_HPP_
 #define CROCODDYL_UNITTEST_COMMON_HPP_
 
-#define NUMDIFF_MODIFIER 3e4
+#define NUMDIFF_MODIFIER 10.
 
 #include <iterator>
 #include <Eigen/Dense>


### PR DESCRIPTION
This PR replace `isMuchSmallerThan` by `isZero` in all the unit-tests. Additionally, it changes the tolerance in numdiff tests by `10 * sqrt(eps)` where `eps` is the numdiff disturbance. We need to include `10` as a factor since the Talos contact-dynamics unit-tests needed. Finally, this PR increases the tolerance by `1e-9` in some extra unit-tests.


