### PR TITLE
Removed unnecessary computation and fixed residual in control gravity costs

### DIFF
--- a/bindings/python/crocoddyl/multibody/costs/control-gravity-contact.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/control-gravity-contact.cpp
@@ -46,22 +46,6 @@ void exposeCostControlGravContact() {
           "The default nu is obtained from state.nv. We use ActivationModelQuad \n"
           "as a default activation model (i.e. a=0.5*||r||^2).\n"
           ":param state: state description"))
-      .def(bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActivationModelAbstract>,
-                    boost::shared_ptr<ActuationModelAbstract> >(
-          bp::args("self", "state", "activation", "actuation"),
-          "Initialize the control cost model.\n\n"
-          "We use ActivationModelQuad as a default activation model (i.e. "
-          "a=0.5*||r||^2).\n"
-          ":param state: state description\n"
-          ":param activation: activation model\n"
-          ":param actuation: actuation model"))
-      .def(bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActuationModelAbstract> >(
-          bp::args("self", "state", "actuation"),
-          "Initialize the control cost model.\n\n"
-          "We use ActivationModelQuad as a default activation model (i.e. "
-          "a=0.5*||r||^2).\n"
-          ":param state: state description\n"
-          ":param actuation: actuation model"))
       .def<void (CostModelControlGravContact::*)(const boost::shared_ptr<CostDataAbstract> &,
                                                  const Eigen::Ref<const Eigen::VectorXd> &,
                                                  const Eigen::Ref<const Eigen::VectorXd> &)>(

--- a/bindings/python/crocoddyl/multibody/costs/control-gravity-contact.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/control-gravity-contact.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2020, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2020-2021, LAAS-CNRS, University of Edinburgh
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -14,6 +14,8 @@ namespace crocoddyl {
 namespace python {
 
 void exposeCostControlGravContact() {
+  bp::register_ptr_to_python<boost::shared_ptr<CostModelControlGravContact> >();
+
   bp::class_<CostModelControlGravContact, bp::bases<CostModelAbstract> >(
       "CostModelControlGravContact",
       "This cost function defines a residual vector as r = u - "
@@ -49,8 +51,7 @@ void exposeCostControlGravContact() {
           bp::args("self", "state", "activation", "actuation"),
           "Initialize the control cost model.\n\n"
           "We use ActivationModelQuad as a default activation model (i.e. "
-          "a=0.5*||r||^2). The default reference "
-          "control is obtained from np.zero(state.nv).\n"
+          "a=0.5*||r||^2).\n"
           ":param state: state description\n"
           ":param activation: activation model\n"
           ":param actuation: actuation model"))
@@ -58,8 +59,7 @@ void exposeCostControlGravContact() {
           bp::args("self", "state", "actuation"),
           "Initialize the control cost model.\n\n"
           "We use ActivationModelQuad as a default activation model (i.e. "
-          "a=0.5*||r||^2). The default reference "
-          "control is obtained from np.zero(state.nv).\n"
+          "a=0.5*||r||^2).\n"
           ":param state: state description\n"
           ":param actuation: actuation model"))
       .def<void (CostModelControlGravContact::*)(const boost::shared_ptr<CostDataAbstract> &,
@@ -92,6 +92,9 @@ void exposeCostControlGravContact() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.");
+
+  bp::register_ptr_to_python<boost::shared_ptr<CostDataControlGravContact> >();
+
   bp::class_<CostDataControlGravContact, bp::bases<CostDataAbstract> >(
       "CostDataControlGravContact", "Data for control gravity cost in contact.\n\n",
       bp::init<CostModelControlGravContact *, DataCollectorAbstract *>(

--- a/bindings/python/crocoddyl/multibody/costs/control-gravity-contact.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/control-gravity-contact.cpp
@@ -19,19 +19,47 @@ void exposeCostControlGravContact() {
       "This cost function defines a residual vector as r = u - "
       "g(q,fext), with u as the control, q as the position,"
       "fext as the external forces and g as the gravity vector in contact",
-      bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActivationModelAbstract>,
-               boost::shared_ptr<ActuationModelAbstract> >(
+      bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActivationModelAbstract>, std::size_t>(
+          bp::args("self", "state", "activation", "nu"),
+          "Initialize the control-gravity cost model.\n\n"
+          ":param state: state description\n"
+          ":param activation: activation model\n"
+          ":param nu: dimension of the control vector"))
+      .def(bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActivationModelAbstract> >(
+          bp::args("self", "state", "activation"),
+          "Initialize the control-gravity cost model.\n\n"
+          "The default nu is obtained from state.nv.\n"
+          ":param state: state description\n"
+          ":param activation: activation model"))
+      .def(bp::init<boost::shared_ptr<StateMultibody>, std::size_t>(
+          bp::args("self", "state", "nu"),
+          "Initialize the control-gravity cost model.\n\n"
+          "We use ActivationModelQuad as a default activation model (i.e.\n"
+          "a=0.5*||r||^2).\n"
+          ":param state: state description\n"
+          ":param nu: dimension of the control vector"))
+      .def(bp::init<boost::shared_ptr<StateMultibody> >(
+          bp::args("self", "state"),
+          "Initialize the control cost model.\n\n"
+          "The default nu is obtained from state.nv. We use ActivationModelQuad \n"
+          "as a default activation model (i.e. a=0.5*||r||^2).\n"
+          ":param state: state description"))
+      .def(bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActivationModelAbstract>,
+                    boost::shared_ptr<ActuationModelAbstract> >(
           bp::args("self", "state", "activation", "actuation"),
           "Initialize the control cost model.\n\n"
-          "The default reference control is obtained from np.zero(nu), with nu "
-          "obtained from activation.nr.\n"
+          "We use ActivationModelQuad as a default activation model (i.e. "
+          "a=0.5*||r||^2). The default reference "
+          "control is obtained from np.zero(state.nv).\n"
           ":param state: state description\n"
           ":param activation: activation model\n"
           ":param actuation: actuation model"))
       .def(bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActuationModelAbstract> >(
           bp::args("self", "state", "actuation"),
           "Initialize the control cost model.\n\n"
-          "The default reference control is obtained from np.zero(nu).\n"
+          "We use ActivationModelQuad as a default activation model (i.e. "
+          "a=0.5*||r||^2). The default reference "
+          "control is obtained from np.zero(state.nv).\n"
           ":param state: state description\n"
           ":param actuation: actuation model"))
       .def<void (CostModelControlGravContact::*)(const boost::shared_ptr<CostDataAbstract> &,

--- a/bindings/python/crocoddyl/multibody/costs/control-gravity.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/control-gravity.cpp
@@ -47,23 +47,6 @@ void exposeCostControlGrav() {
           "The default nu is obtained from state.nv. We use ActivationModelQuad \n"
           "as a default activation model (i.e. a=0.5*||r||^2).\n"
           ":param state: state description"))
-      .def(bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActivationModelAbstract>,
-                    boost::shared_ptr<ActuationModelAbstract> >(
-          bp::args("self", "state", "activation", "actuation"),
-          "Initialize the control cost model.\n\n"
-          "We use ActivationModelQuad as a default activation model (i.e. "
-          "a=0.5*||r||^2).\n"
-          ":param state: state description\n"
-          ":param activation: activation model\n"
-          ":param actuation: actuation model"))
-      .def(bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActuationModelAbstract> >(
-          bp::args("self", "state", "actuation"),
-          "Initialize the control cost model.\n\n"
-          "We use ActivationModelQuad as a default activation model (i.e. "
-          "a=0.5*||r||^2). The default reference "
-          "control is obtained from np.zero(state.nv).\n"
-          ":param state: state description\n"
-          ":param actuation: actuation model"))
       .def<void (CostModelControlGrav::*)(const boost::shared_ptr<CostDataAbstract> &,
                                           const Eigen::Ref<const Eigen::VectorXd> &,
                                           const Eigen::Ref<const Eigen::VectorXd> &)>(

--- a/bindings/python/crocoddyl/multibody/costs/control-gravity.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/control-gravity.cpp
@@ -52,8 +52,7 @@ void exposeCostControlGrav() {
           bp::args("self", "state", "activation", "actuation"),
           "Initialize the control cost model.\n\n"
           "We use ActivationModelQuad as a default activation model (i.e. "
-          "a=0.5*||r||^2). The default reference "
-          "control is obtained from np.zero(state.nv).\n"
+          "a=0.5*||r||^2).\n"
           ":param state: state description\n"
           ":param activation: activation model\n"
           ":param actuation: actuation model"))

--- a/bindings/python/crocoddyl/multibody/costs/control-gravity.cpp
+++ b/bindings/python/crocoddyl/multibody/costs/control-gravity.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2020, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2020-2021, LAAS-CNRS, University of Edinburgh
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -14,18 +14,46 @@ namespace crocoddyl {
 namespace python {
 
 void exposeCostControlGrav() {
+  bp::register_ptr_to_python<boost::shared_ptr<CostModelControlGrav> >();
+
   bp::class_<CostModelControlGrav, bp::bases<CostModelAbstract> >(
       "CostModelControlGrav",
       "This cost function defines a residual vector as r = a(u) - g(q), "
       "where q, g(q) are the generalized position and gravity vector, "
       "respectively,"
       "and a(u) is the actuated torque.",
-      bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActivationModelAbstract>,
-               boost::shared_ptr<ActuationModelAbstract> >(
+      bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActivationModelAbstract>, std::size_t>(
+          bp::args("self", "state", "activation", "nu"),
+          "Initialize the control-gravity cost model.\n\n"
+          ":param state: state description\n"
+          ":param activation: activation model\n"
+          ":param nu: dimension of the control vector"))
+      .def(bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActivationModelAbstract> >(
+          bp::args("self", "state", "activation"),
+          "Initialize the control-gravity cost model.\n\n"
+          "The default nu is obtained from state.nv.\n"
+          ":param state: state description\n"
+          ":param activation: activation model"))
+      .def(bp::init<boost::shared_ptr<StateMultibody>, std::size_t>(
+          bp::args("self", "state", "nu"),
+          "Initialize the control-gravity cost model.\n\n"
+          "We use ActivationModelQuad as a default activation model (i.e.\n"
+          "a=0.5*||r||^2).\n"
+          ":param state: state description\n"
+          ":param nu: dimension of the control vector"))
+      .def(bp::init<boost::shared_ptr<StateMultibody> >(
+          bp::args("self", "state"),
+          "Initialize the control cost model.\n\n"
+          "The default nu is obtained from state.nv. We use ActivationModelQuad \n"
+          "as a default activation model (i.e. a=0.5*||r||^2).\n"
+          ":param state: state description"))
+      .def(bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActivationModelAbstract>,
+                    boost::shared_ptr<ActuationModelAbstract> >(
           bp::args("self", "state", "activation", "actuation"),
           "Initialize the control cost model.\n\n"
-          "The default reference control is obtained from np.zero(nu), with nu "
-          "obtained from activation.nr.\n"
+          "We use ActivationModelQuad as a default activation model (i.e. "
+          "a=0.5*||r||^2). The default reference "
+          "control is obtained from np.zero(state.nv).\n"
           ":param state: state description\n"
           ":param activation: activation model\n"
           ":param actuation: actuation model"))
@@ -67,6 +95,9 @@ void exposeCostControlGrav() {
            "returns the allocated data for a predefined cost.\n"
            ":param data: shared data\n"
            ":return cost data.");
+
+  bp::register_ptr_to_python<boost::shared_ptr<CostDataControlGrav> >();
+
   bp::class_<CostDataControlGrav, bp::bases<CostDataAbstract> >(
       "CostDataControlGrav", "Data for control gravity cost.\n\n",
       bp::init<CostModelControlGrav *, DataCollectorAbstract *>(

--- a/include/crocoddyl/core/numdiff/cost.hpp
+++ b/include/crocoddyl/core/numdiff/cost.hpp
@@ -29,7 +29,7 @@ class CostModelNumDiffTpl : public CostModelAbstractTpl<_Scalar> {
   typedef MathBaseTpl<Scalar> MathBase;
   typedef typename MathBaseTpl<Scalar>::VectorXs VectorXs;
   typedef typename MathBaseTpl<Scalar>::MatrixXs MatrixXs;
-  typedef boost::function<void(const VectorXs&)> ReevaluationFunction;
+  typedef boost::function<void(const VectorXs&, const VectorXs&)> ReevaluationFunction;
 
   /**
    * @brief Initialize the numdiff cost model

--- a/include/crocoddyl/core/numdiff/cost.hxx
+++ b/include/crocoddyl/core/numdiff/cost.hxx
@@ -51,7 +51,7 @@ void CostModelNumDiffTpl<Scalar>::calcDiff(const boost::shared_ptr<CostDataAbstr
     model_->get_state()->integrate(x, data_nd->dx, data_nd->xp);
     // call the update function on the pinocchio data
     for (size_t i = 0; i < reevals_.size(); ++i) {
-      reevals_[i](data_nd->xp);
+      reevals_[i](data_nd->xp, u);
     }
     // cost(x+dx, u)
     model_->calc(data_nd->data_x[ix], data_nd->xp, u);
@@ -66,14 +66,14 @@ void CostModelNumDiffTpl<Scalar>::calcDiff(const boost::shared_ptr<CostDataAbstr
 
   // Computing the d cost(x,u) / du
   data_nd->du.setZero();
-  // call the update function on the pinocchio data
-  for (std::size_t i = 0; i < reevals_.size(); ++i) {
-    reevals_[i](x);
-  }
   for (std::size_t iu = 0; iu < model_->get_nu(); ++iu) {
     // up = u + du
     data_nd->du(iu) = disturbance_;
     data_nd->up = u + data_nd->du;
+    // call the update function
+    for (std::size_t i = 0; i < reevals_.size(); ++i) {
+      reevals_[i](x, data_nd->up);
+    }
     // cost(x, u+du)
     model_->calc(data_nd->data_u[iu], x, data_nd->up);
     // Lu

--- a/include/crocoddyl/multibody/costs/control-gravity-contact.hpp
+++ b/include/crocoddyl/multibody/costs/control-gravity-contact.hpp
@@ -13,7 +13,6 @@
 #include "crocoddyl/multibody/states/multibody.hpp"
 #include "crocoddyl/multibody/data/contacts.hpp"
 #include "crocoddyl/core/utils/exception.hpp"
-#include "crocoddyl/core/utils/deprecate.hpp"
 
 namespace crocoddyl {
 
@@ -76,10 +75,6 @@ class CostModelControlGravContactTpl : public CostModelAbstractTpl<_Scalar> {
    */
   CostModelControlGravContactTpl(boost::shared_ptr<StateMultibody> state,
                                  boost::shared_ptr<ActivationModelAbstract> activation);
-  DEPRECATED("Use constructor without actuation model",
-             CostModelControlGravContactTpl(boost::shared_ptr<StateMultibody> state,
-                                            boost::shared_ptr<ActivationModelAbstract> activation,
-                                            boost::shared_ptr<ActuationModelAbstract> actuation_model);)
 
   /**
    * @brief Initialize the control gravity contact cost model
@@ -102,10 +97,6 @@ class CostModelControlGravContactTpl : public CostModelAbstractTpl<_Scalar> {
    * @param[in] state  State of the multibody system
    */
   explicit CostModelControlGravContactTpl(boost::shared_ptr<StateMultibody> state);
-  DEPRECATED("Use constructor without actuation model",
-             CostModelControlGravContactTpl(boost::shared_ptr<StateMultibody> state,
-                                            boost::shared_ptr<ActuationModelAbstract> actuation_model);)
-
   virtual ~CostModelControlGravContactTpl();
 
   /**

--- a/include/crocoddyl/multibody/costs/control-gravity-contact.hpp
+++ b/include/crocoddyl/multibody/costs/control-gravity-contact.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2020, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2020-2021, LAAS-CNRS, University of Edinburgh
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////

--- a/include/crocoddyl/multibody/costs/control-gravity-contact.hpp
+++ b/include/crocoddyl/multibody/costs/control-gravity-contact.hpp
@@ -9,21 +9,11 @@
 #ifndef CROCODDYL_CORE_COSTS_CONTROL_GRAVITY_CONTACT_HPP_
 #define CROCODDYL_CORE_COSTS_CONTROL_GRAVITY_CONTACT_HPP_
 
-#include "crocoddyl/multibody/contact-base.hpp"
-#include "crocoddyl/multibody/contacts/multiple-contacts.hpp"
-#include "crocoddyl/multibody/data/contacts.hpp"
-
 #include "crocoddyl/core/cost-base.hpp"
-#include "crocoddyl/core/fwd.hpp"
-#include "crocoddyl/core/utils/deprecate.hpp"
-#include "crocoddyl/core/utils/exception.hpp"
-//#include "crocoddyl/core/actuation-base.hpp"
-#include "crocoddyl/multibody/actuations/floating-base.hpp"
-#include "crocoddyl/multibody/actuations/full.hpp"
-#include "crocoddyl/multibody/data/multibody.hpp"
-#include "crocoddyl/multibody/frames.hpp"
-#include "crocoddyl/multibody/fwd.hpp"
 #include "crocoddyl/multibody/states/multibody.hpp"
+#include "crocoddyl/multibody/data/contacts.hpp"
+#include "crocoddyl/core/utils/exception.hpp"
+#include "crocoddyl/core/utils/deprecate.hpp"
 
 namespace crocoddyl {
 
@@ -69,27 +59,52 @@ class CostModelControlGravContactTpl : public CostModelAbstractTpl<_Scalar> {
   /**
    * @brief Initialize the control gravity contact cost model
    *
-   * The default `nu` value is obtained from the actuation model.
+   * @param[in] state       State of the multibody system
+   * @param[in] activation  Activation model
+   * @param[in] nu          Dimension of the control vector
+   */
+  CostModelControlGravContactTpl(boost::shared_ptr<StateMultibody> state,
+                                 boost::shared_ptr<ActivationModelAbstract> activation, const std::size_t nu);
+
+  /**
+   * @brief Initialize the control gravity contact cost model
+   *
+   * The default `nu` value is obtained from `StateAbstractTpl::get_nv()`.
    *
    * @param[in] state       State of the multibody system
    * @param[in] activation  Activation model
    */
   CostModelControlGravContactTpl(boost::shared_ptr<StateMultibody> state,
-                                 boost::shared_ptr<ActivationModelAbstract> activation,
-                                 boost::shared_ptr<ActuationModelAbstract> actuation_model);
+                                 boost::shared_ptr<ActivationModelAbstract> activation);
+  DEPRECATED("Use constructor without actuation model",
+             CostModelControlGravContactTpl(boost::shared_ptr<StateMultibody> state,
+                                            boost::shared_ptr<ActivationModelAbstract> activation,
+                                            boost::shared_ptr<ActuationModelAbstract> actuation_model);)
 
   /**
    * @brief Initialize the control gravity contact cost model
    *
-   * The default `nu` value is obtained from the actuation model.
    * We use `ActivationModelQuadTpl` as a default activation model (i.e.
    * \f$a=\frac{1}{2}\|\mathbf{r}\|^2\f$).
    *
-   * @param[in] state       State of the multibody system
+   * @param[in] state  State of the multibody system
+   * @param[in] nu     Dimension of the control vector
    */
+  CostModelControlGravContactTpl(boost::shared_ptr<StateMultibody> state, const std::size_t nu);
 
-  explicit CostModelControlGravContactTpl(boost::shared_ptr<StateMultibody> state,
-                                          boost::shared_ptr<ActuationModelAbstract> actuation_model);
+  /**
+   * @brief Initialize the control gravity contact cost model
+   *
+   * The default `nu` value is obtained from `StateAbstractTpl::get_nv()`.
+   * We use `ActivationModelQuadTpl` as a default activation model (i.e.
+   * \f$a=\frac{1}{2}\|\mathbf{r}\|^2\f$).
+   *
+   * @param[in] state  State of the multibody system
+   */
+  explicit CostModelControlGravContactTpl(boost::shared_ptr<StateMultibody> state);
+  DEPRECATED("Use constructor without actuation model",
+             CostModelControlGravContactTpl(boost::shared_ptr<StateMultibody> state,
+                                            boost::shared_ptr<ActuationModelAbstract> actuation_model);)
 
   virtual ~CostModelControlGravContactTpl();
 
@@ -123,7 +138,6 @@ class CostModelControlGravContactTpl : public CostModelAbstractTpl<_Scalar> {
 
  private:
   typename StateMultibody::PinocchioModel pin_model_;
-  const boost::shared_ptr<crocoddyl::ActuationModelAbstract> actuation_model_;
 };
 
 template <typename _Scalar>

--- a/include/crocoddyl/multibody/costs/control-gravity-contact.hxx
+++ b/include/crocoddyl/multibody/costs/control-gravity-contact.hxx
@@ -33,19 +33,6 @@ CostModelControlGravContactTpl<Scalar>::CostModelControlGravContactTpl(
 }
 
 template <typename Scalar>
-CostModelControlGravContactTpl<Scalar>::CostModelControlGravContactTpl(
-    boost::shared_ptr<StateMultibody> state, boost::shared_ptr<ActivationModelAbstract> activation,
-    boost::shared_ptr<ActuationModelAbstract> actuation_model)
-    : Base(state, activation, actuation_model->get_nu()), pin_model_(*state->get_pinocchio()) {
-  if (activation_->get_nr() != state_->get_nv()) {
-    throw_pretty("Invalid argument: "
-                 << "nr is equals to " + std::to_string(state_->get_nv()));
-  }
-  std::cerr << "Deprecated CostModelControlGravContact constructor: Use constructor without actuation model"
-            << std::endl;
-}
-
-template <typename Scalar>
 CostModelControlGravContactTpl<Scalar>::CostModelControlGravContactTpl(boost::shared_ptr<StateMultibody> state,
                                                                        std::size_t nu)
     : Base(state, state->get_nv(), nu), pin_model_(*state->get_pinocchio()) {}
@@ -53,14 +40,6 @@ CostModelControlGravContactTpl<Scalar>::CostModelControlGravContactTpl(boost::sh
 template <typename Scalar>
 CostModelControlGravContactTpl<Scalar>::CostModelControlGravContactTpl(boost::shared_ptr<StateMultibody> state)
     : Base(state, state->get_nv(), state->get_nv()), pin_model_(*state->get_pinocchio()) {}
-
-template <typename Scalar>
-CostModelControlGravContactTpl<Scalar>::CostModelControlGravContactTpl(
-    boost::shared_ptr<StateMultibody> state, boost::shared_ptr<ActuationModelAbstract> actuation_model)
-    : Base(state, state->get_nv(), actuation_model->get_nu()), pin_model_(*state->get_pinocchio()) {
-  std::cerr << "Deprecated CostModelControlGravContact constructor: Use constructor without actuation model"
-            << std::endl;
-}
 
 template <typename Scalar>
 CostModelControlGravContactTpl<Scalar>::~CostModelControlGravContactTpl() {}

--- a/include/crocoddyl/multibody/costs/control-gravity-contact.hxx
+++ b/include/crocoddyl/multibody/costs/control-gravity-contact.hxx
@@ -6,18 +6,16 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "crocoddyl/core/utils/exception.hpp"
 #include "pinocchio/algorithm/rnea-derivatives.hpp"
 #include "pinocchio/algorithm/rnea.hpp"
 
 namespace crocoddyl {
+
 template <typename Scalar>
 CostModelControlGravContactTpl<Scalar>::CostModelControlGravContactTpl(
     boost::shared_ptr<StateMultibody> state, boost::shared_ptr<ActivationModelAbstract> activation,
-    boost::shared_ptr<ActuationModelAbstract> actuation_model)
-    : Base(state, activation, actuation_model->get_nu()),
-      pin_model_(*state->get_pinocchio()),
-      actuation_model_(actuation_model) {
+    const std::size_t nu)
+    : Base(state, activation, nu), pin_model_(*state->get_pinocchio()) {
   if (activation_->get_nr() != state_->get_nv()) {
     throw_pretty("Invalid argument: "
                  << "nr is equals to " + std::to_string(state_->get_nv()));
@@ -26,10 +24,43 @@ CostModelControlGravContactTpl<Scalar>::CostModelControlGravContactTpl(
 
 template <typename Scalar>
 CostModelControlGravContactTpl<Scalar>::CostModelControlGravContactTpl(
+    boost::shared_ptr<StateMultibody> state, boost::shared_ptr<ActivationModelAbstract> activation)
+    : Base(state, activation, state->get_nv()), pin_model_(*state->get_pinocchio()) {
+  if (activation_->get_nr() != state_->get_nv()) {
+    throw_pretty("Invalid argument: "
+                 << "nr is equals to " + std::to_string(state_->get_nv()));
+  }
+}
+
+template <typename Scalar>
+CostModelControlGravContactTpl<Scalar>::CostModelControlGravContactTpl(
+    boost::shared_ptr<StateMultibody> state, boost::shared_ptr<ActivationModelAbstract> activation,
+    boost::shared_ptr<ActuationModelAbstract> actuation_model)
+    : Base(state, activation, actuation_model->get_nu()), pin_model_(*state->get_pinocchio()) {
+  if (activation_->get_nr() != state_->get_nv()) {
+    throw_pretty("Invalid argument: "
+                 << "nr is equals to " + std::to_string(state_->get_nv()));
+  }
+  std::cerr << "Deprecated CostModelControlGravContact constructor: Use constructor without actuation model"
+            << std::endl;
+}
+
+template <typename Scalar>
+CostModelControlGravContactTpl<Scalar>::CostModelControlGravContactTpl(boost::shared_ptr<StateMultibody> state,
+                                                                       std::size_t nu)
+    : Base(state, state->get_nv(), nu), pin_model_(*state->get_pinocchio()) {}
+
+template <typename Scalar>
+CostModelControlGravContactTpl<Scalar>::CostModelControlGravContactTpl(boost::shared_ptr<StateMultibody> state)
+    : Base(state, state->get_nv(), state->get_nv()), pin_model_(*state->get_pinocchio()) {}
+
+template <typename Scalar>
+CostModelControlGravContactTpl<Scalar>::CostModelControlGravContactTpl(
     boost::shared_ptr<StateMultibody> state, boost::shared_ptr<ActuationModelAbstract> actuation_model)
-    : Base(state, state->get_nv(), actuation_model->get_nu()),
-      pin_model_(*state->get_pinocchio()),
-      actuation_model_(actuation_model) {}
+    : Base(state, state->get_nv(), actuation_model->get_nu()), pin_model_(*state->get_pinocchio()) {
+  std::cerr << "Deprecated CostModelControlGravContact constructor: Use constructor without actuation model"
+            << std::endl;
+}
 
 template <typename Scalar>
 CostModelControlGravContactTpl<Scalar>::~CostModelControlGravContactTpl() {}
@@ -46,7 +77,6 @@ void CostModelControlGravContactTpl<Scalar>::calc(const boost::shared_ptr<CostDa
 
   const Eigen::VectorBlock<const Eigen::Ref<const VectorXs>, Eigen::Dynamic> q = x.head(state_->get_nq());
 
-  actuation_model_->calc(d->actuation, x, u);
   data->r = pinocchio::computeStaticTorque(pin_model_, d->pinocchio, q, d->fext) - d->actuation->tau;
   activation_->calc(data->activation, data->r);
   data->cost = data->activation->a_value;
@@ -67,7 +97,6 @@ void CostModelControlGravContactTpl<Scalar>::calcDiff(const boost::shared_ptr<Co
   pinocchio::computeStaticTorqueDerivatives(pin_model_, d->pinocchio, q, d->fext, d->dg_dq);
 
   activation_->calcDiff(data->activation, data->r);
-  actuation_model_->calcDiff(d->actuation, x, u);
   const std::size_t &nv = state_->get_nv();
 
   data->Lu.noalias() = -d->actuation->dtau_du.transpose() * data->activation->Ar;

--- a/include/crocoddyl/multibody/costs/control-gravity-contact.hxx
+++ b/include/crocoddyl/multibody/costs/control-gravity-contact.hxx
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2020, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2020-2021, LAAS-CNRS, University of Edinburgh
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -77,7 +77,7 @@ void CostModelControlGravContactTpl<Scalar>::calc(const boost::shared_ptr<CostDa
 
   const Eigen::VectorBlock<const Eigen::Ref<const VectorXs>, Eigen::Dynamic> q = x.head(state_->get_nq());
 
-  data->r = pinocchio::computeStaticTorque(pin_model_, d->pinocchio, q, d->fext) - d->actuation->tau;
+  data->r = d->actuation->tau - pinocchio::computeStaticTorque(pin_model_, d->pinocchio, q, d->fext);
   activation_->calc(data->activation, data->r);
   data->cost = data->activation->a_value;
 }
@@ -97,10 +97,10 @@ void CostModelControlGravContactTpl<Scalar>::calcDiff(const boost::shared_ptr<Co
   pinocchio::computeStaticTorqueDerivatives(pin_model_, d->pinocchio, q, d->fext, d->dg_dq);
 
   activation_->calcDiff(data->activation, data->r);
-  const std::size_t &nv = state_->get_nv();
+  const std::size_t nv = state_->get_nv();
 
-  data->Lu.noalias() = -d->actuation->dtau_du.transpose() * data->activation->Ar;
-  data->Lx.head(nv).noalias() = d->dg_dq.transpose() * data->activation->Ar;
+  data->Lx.head(nv).noalias() = -d->dg_dq.transpose() * data->activation->Ar;
+  data->Lu.noalias() = d->actuation->dtau_du.transpose() * data->activation->Ar;
 
   d->Arr_dgdq.noalias() = data->activation->Arr * d->dg_dq;
   d->Arr_dtaudu.noalias() = data->activation->Arr * d->actuation->dtau_du;

--- a/include/crocoddyl/multibody/costs/control-gravity.hpp
+++ b/include/crocoddyl/multibody/costs/control-gravity.hpp
@@ -20,21 +20,18 @@ namespace crocoddyl {
 /**
  * @brief Control gravity cost
  *
- * This cost function defines a residual vector as
- * \f$\mathbf{r}=\mathbf{u}-\mathbf{g}(\mathbf{q})\f$, where
- * \f$\mathbf{u}\in~\mathbb{R}^{nu}\f$ is the current control input, g the
- * gravity torque corresponding to the current configuration,
- * \f$\mathbf{q}\in~\mathbb{R}^{nq}\f$ the current position joints input.
- * Note that the dimension of the residual vector is obtained from `nu`.
+ * This cost function defines a residual vector as \f$\mathbf{r}=\mathbf{u}-\mathbf{g}(\mathbf{q})\f$, where
+ * \f$\mathbf{u}\in~\mathbb{R}^{nu}\f$ is the current control input, \f$\mathbf{g}(\mathbf{q})\f$ is the
+ * gravity torque corresponding to the current configuration, \f$\mathbf{q}\in~\mathbb{R}^{nq}\f$ the current
+ * position joints input. Note that the dimension of the residual vector is obtained from `StateAbstractTpl::get_nv()`.
  *
- * Both cost and residual derivatives are computed analytically.
- * For the computation of the cost Hessian, we use the Gauss-Newton
- * approximation, e.g. \f$\mathbf{l_{xx}} = \mathbf{l_{x}}^T \mathbf{l_{x}} \f$.
+ * Both cost and residual derivatives are computed analytically. For the computation of the cost Hessian, we use the
+ * Gauss-Newton approximation, e.g. \f$\mathbf{l_{xx}} = \mathbf{l_{x}}^T \mathbf{l_{x}} \f$.
  *
- * As described in CostModelAbstractTpl(), the cost value and its derivatives
- * are calculated by `calc` and `calcDiff`, respectively.
+ * As described in CostModelAbstractTpl(), the cost value and its derivatives are calculated by `calc` and `calcDiff`,
+ * respectively.
  *
- * \sa `CostModelAbstractTpl`, `calc()`, `calcDiff()`, `createData()`
+ * \sa `CostModelAbstractTpl`, calc(), calcDiff(), createData()
  */
 template <typename _Scalar>
 class CostModelControlGravTpl : public CostModelAbstractTpl<_Scalar> {

--- a/include/crocoddyl/multibody/costs/control-gravity.hpp
+++ b/include/crocoddyl/multibody/costs/control-gravity.hpp
@@ -160,8 +160,11 @@ struct CostDataControlGravTpl : public CostDataAbstractTpl<_Scalar> {
     DataCollectorActMultibodyTpl<Scalar> *d = dynamic_cast<DataCollectorActMultibodyTpl<Scalar> *>(shared);
     if (d == NULL) {
       throw_pretty(
-          "Invalid argument: the shared data should be derived from "
-          "DataCollectorActMultibodyTpl");
+          "Invalid argument: the shared data should be derived from DataCollectorActMultibodyTpl");
+    }
+    if (static_cast<std::size_t>(d->actuation->dtau_du.cols()) != model->get_state()->get_nv()) {
+      throw_pretty(
+          "Invalid argument: the actuation model should consider all the control dimensions (i.e., nu == state.nv)");
     }
     // Avoids data casting at runtime
     StateMultibody *sm = static_cast<StateMultibody *>(model->get_state().get());

--- a/include/crocoddyl/multibody/costs/control-gravity.hpp
+++ b/include/crocoddyl/multibody/costs/control-gravity.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2020, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2020-2021, LAAS-CNRS, University of Edinburgh
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -19,6 +19,7 @@
 #include "crocoddyl/multibody/frames.hpp"
 #include "crocoddyl/multibody/fwd.hpp"
 #include "crocoddyl/multibody/states/multibody.hpp"
+#include "crocoddyl/core/utils/deprecate.hpp"
 
 namespace crocoddyl {
 
@@ -62,26 +63,52 @@ class CostModelControlGravTpl : public CostModelAbstractTpl<_Scalar> {
   /**
    * @brief Initialize the control gravity cost model
    *
-   * The default `nu` value is obtained from the actuation model.
+   * @param[in] state       State of the multibody system
+   * @param[in] activation  Activation model
+   * @param[in] nu          Dimension of control vector
+   */
+  CostModelControlGravTpl(boost::shared_ptr<StateMultibody> state,
+                          boost::shared_ptr<ActivationModelAbstract> activation, const std::size_t nu);
+
+  /**
+   * @brief Initialize the control gravity cost model
+   *
+   * The default `nu` value is obtained from `StateAbstractTpl::get_nv()`.
    *
    * @param[in] state       State of the multibody system
    * @param[in] activation  Activation model
    */
   CostModelControlGravTpl(boost::shared_ptr<StateMultibody> state,
-                          boost::shared_ptr<ActivationModelAbstract> activation,
-                          boost::shared_ptr<ActuationModelAbstract> actuation_model);
+                          boost::shared_ptr<ActivationModelAbstract> activation);
+  DEPRECATED("Use constructor without actuation model",
+             CostModelControlGravTpl(boost::shared_ptr<StateMultibody> state,
+                                     boost::shared_ptr<ActivationModelAbstract> activation,
+                                     boost::shared_ptr<ActuationModelAbstract> actuation_model);)
 
   /**
    * @brief Initialize the control gravity cost model
    *
-   * The default `nu` value is obtained from the actuation model.
    * We use `ActivationModelQuadTpl` as a default activation model (i.e.
    * \f$a=\frac{1}{2}\|\mathbf{r}\|^2\f$).
    *
-   * @param[in] state       State of the multibody system
+   * @param[in] state  State of the multibody system
+   * @param[in] nu     Dimension of control vector
    */
-  explicit CostModelControlGravTpl(boost::shared_ptr<StateMultibody> state,
-                                   boost::shared_ptr<ActuationModelAbstract> actuation_model);
+  CostModelControlGravTpl(boost::shared_ptr<StateMultibody> state, const std::size_t nu);
+
+  /**
+   * @brief Initialize the control gravity cost model
+   *
+   * The default `nu` value is obtained from `StateAbstractTpl::get_nv()`.
+   * We use `ActivationModelQuadTpl` as a default activation model (i.e.
+   * \f$a=\frac{1}{2}\|\mathbf{r}\|^2\f$).
+   *
+   * @param[in] state  State of the multibody system
+   */
+  explicit CostModelControlGravTpl(boost::shared_ptr<StateMultibody> state);
+  DEPRECATED("Use constructor without actuation model",
+             CostModelControlGravTpl(boost::shared_ptr<StateMultibody> state,
+                                     boost::shared_ptr<ActuationModelAbstract> actuation_model);)
 
   virtual ~CostModelControlGravTpl();
 
@@ -115,7 +142,6 @@ class CostModelControlGravTpl : public CostModelAbstractTpl<_Scalar> {
 
  private:
   typename StateMultibody::PinocchioModel pin_model_;
-  const boost::shared_ptr<crocoddyl::ActuationModelAbstract> actuation_model_;
 };
 
 template <typename _Scalar>

--- a/include/crocoddyl/multibody/costs/control-gravity.hpp
+++ b/include/crocoddyl/multibody/costs/control-gravity.hpp
@@ -13,7 +13,6 @@
 #include "crocoddyl/multibody/states/multibody.hpp"
 #include "crocoddyl/multibody/data/multibody.hpp"
 #include "crocoddyl/core/utils/exception.hpp"
-#include "crocoddyl/core/utils/deprecate.hpp"
 
 namespace crocoddyl {
 
@@ -71,10 +70,6 @@ class CostModelControlGravTpl : public CostModelAbstractTpl<_Scalar> {
    */
   CostModelControlGravTpl(boost::shared_ptr<StateMultibody> state,
                           boost::shared_ptr<ActivationModelAbstract> activation);
-  DEPRECATED("Use constructor without actuation model",
-             CostModelControlGravTpl(boost::shared_ptr<StateMultibody> state,
-                                     boost::shared_ptr<ActivationModelAbstract> activation,
-                                     boost::shared_ptr<ActuationModelAbstract> actuation_model);)
 
   /**
    * @brief Initialize the control gravity cost model
@@ -97,9 +92,6 @@ class CostModelControlGravTpl : public CostModelAbstractTpl<_Scalar> {
    * @param[in] state  State of the multibody system
    */
   explicit CostModelControlGravTpl(boost::shared_ptr<StateMultibody> state);
-  DEPRECATED("Use constructor without actuation model",
-             CostModelControlGravTpl(boost::shared_ptr<StateMultibody> state,
-                                     boost::shared_ptr<ActuationModelAbstract> actuation_model);)
 
   virtual ~CostModelControlGravTpl();
 

--- a/include/crocoddyl/multibody/costs/control-gravity.hpp
+++ b/include/crocoddyl/multibody/costs/control-gravity.hpp
@@ -159,8 +159,7 @@ struct CostDataControlGravTpl : public CostDataAbstractTpl<_Scalar> {
     // Check that proper shared data has been passed
     DataCollectorActMultibodyTpl<Scalar> *d = dynamic_cast<DataCollectorActMultibodyTpl<Scalar> *>(shared);
     if (d == NULL) {
-      throw_pretty(
-          "Invalid argument: the shared data should be derived from DataCollectorActMultibodyTpl");
+      throw_pretty("Invalid argument: the shared data should be derived from DataCollectorActMultibodyTpl");
     }
     if (static_cast<std::size_t>(d->actuation->dtau_du.cols()) != model->get_state()->get_nv()) {
       throw_pretty(

--- a/include/crocoddyl/multibody/costs/control-gravity.hpp
+++ b/include/crocoddyl/multibody/costs/control-gravity.hpp
@@ -10,15 +10,9 @@
 #define CROCODDYL_CORE_COSTS_CONTROL_GRAVITY_HPP_
 
 #include "crocoddyl/core/cost-base.hpp"
-#include "crocoddyl/core/fwd.hpp"
-#include "crocoddyl/core/utils/deprecate.hpp"
-#include "crocoddyl/core/utils/exception.hpp"
-#include "crocoddyl/multibody/actuations/full.hpp"
-#include "crocoddyl/multibody/data/contacts.hpp"
-#include "crocoddyl/multibody/data/multibody.hpp"
-#include "crocoddyl/multibody/frames.hpp"
-#include "crocoddyl/multibody/fwd.hpp"
 #include "crocoddyl/multibody/states/multibody.hpp"
+#include "crocoddyl/multibody/data/multibody.hpp"
+#include "crocoddyl/core/utils/exception.hpp"
 #include "crocoddyl/core/utils/deprecate.hpp"
 
 namespace crocoddyl {

--- a/include/crocoddyl/multibody/costs/control-gravity.hxx
+++ b/include/crocoddyl/multibody/costs/control-gravity.hxx
@@ -113,7 +113,7 @@ void CostModelControlGravTpl<Scalar>::calcDiff(const boost::shared_ptr<CostDataA
   const Eigen::VectorBlock<const Eigen::Ref<const VectorXs>, Eigen::Dynamic> q = x.head(state_->get_nq());
   pinocchio::computeGeneralizedGravityDerivatives(pin_model_, d->pinocchio, q, d->dg_dq);
 
-  const std::size_t &nv = state_->get_nv();
+  const std::size_t nv = state_->get_nv();
   activation_->calcDiff(data->activation, data->r);
 
   data->Lx.head(nv).noalias() = -d->dg_dq.transpose() * data->activation->Ar;

--- a/include/crocoddyl/multibody/costs/control-gravity.hxx
+++ b/include/crocoddyl/multibody/costs/control-gravity.hxx
@@ -94,7 +94,7 @@ void CostModelControlGravTpl<Scalar>::calc(const boost::shared_ptr<CostDataAbstr
   Data *d = static_cast<Data *>(data.get());
 
   const Eigen::VectorBlock<const Eigen::Ref<const VectorXs>, Eigen::Dynamic> q = x.head(state_->get_nq());
-  data->r = pinocchio::computeGeneralizedGravity(pin_model_, d->pinocchio, q) - d->actuation->tau;
+  data->r = d->actuation->tau - pinocchio::computeGeneralizedGravity(pin_model_, d->pinocchio, q);
 
   activation_->calc(data->activation, data->r);
   data->cost = data->activation->a_value;
@@ -116,8 +116,8 @@ void CostModelControlGravTpl<Scalar>::calcDiff(const boost::shared_ptr<CostDataA
   const std::size_t &nv = state_->get_nv();
   activation_->calcDiff(data->activation, data->r);
 
-  data->Lu.noalias() = -d->actuation->dtau_du.transpose() * data->activation->Ar;
-  data->Lx.head(nv).noalias() = d->dg_dq.transpose() * data->activation->Ar;
+  data->Lx.head(nv).noalias() = -d->dg_dq.transpose() * data->activation->Ar;
+  data->Lu.noalias() = d->actuation->dtau_du.transpose() * data->activation->Ar;
 
   d->Arr_dgdq.noalias() = data->activation->Arr * d->dg_dq;
   d->Arr_dtaudu.noalias() = data->activation->Arr * d->actuation->dtau_du;

--- a/include/crocoddyl/multibody/costs/control-gravity.hxx
+++ b/include/crocoddyl/multibody/costs/control-gravity.hxx
@@ -6,9 +6,8 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "crocoddyl/core/utils/exception.hpp"
-#include "pinocchio/algorithm/rnea-derivatives.hpp"
-#include "pinocchio/algorithm/rnea.hpp"
+#include <pinocchio/algorithm/rnea-derivatives.hpp>
+#include <pinocchio/algorithm/rnea.hpp>
 
 namespace crocoddyl {
 
@@ -39,23 +38,6 @@ CostModelControlGravTpl<Scalar>::CostModelControlGravTpl(boost::shared_ptr<State
 }
 
 template <typename Scalar>
-CostModelControlGravTpl<Scalar>::CostModelControlGravTpl(boost::shared_ptr<StateMultibody> state,
-                                                         boost::shared_ptr<ActivationModelAbstract> activation,
-                                                         boost::shared_ptr<ActuationModelAbstract> actuation_model)
-    : Base(state, activation, actuation_model->get_nu()), pin_model_(*state->get_pinocchio()) {
-  if (activation_->get_nr() != state_->get_nv()) {
-    throw_pretty("Invalid argument: "
-                 << "nr is equals to " + std::to_string(state_->get_nv()));
-  }
-  if (nu_ == 0) {
-    throw_pretty("Invalid argument: "
-                 << "it seems to be an autonomous system, if so, don't add "
-                    "this cost function");
-  }
-  std::cerr << "Deprecated CostModelControlGrav constructor: Use constructor without actuation model" << std::endl;
-}
-
-template <typename Scalar>
 CostModelControlGravTpl<Scalar>::CostModelControlGravTpl(boost::shared_ptr<StateMultibody> state, const std::size_t nu)
     : Base(state, state->get_nv(), nu), pin_model_(*state->get_pinocchio()) {
   if (nu_ == 0) {
@@ -68,18 +50,6 @@ CostModelControlGravTpl<Scalar>::CostModelControlGravTpl(boost::shared_ptr<State
 template <typename Scalar>
 CostModelControlGravTpl<Scalar>::CostModelControlGravTpl(boost::shared_ptr<StateMultibody> state)
     : Base(state, state->get_nv(), state->get_nv()), pin_model_(*state->get_pinocchio()) {}
-
-template <typename Scalar>
-CostModelControlGravTpl<Scalar>::CostModelControlGravTpl(boost::shared_ptr<StateMultibody> state,
-                                                         boost::shared_ptr<ActuationModelAbstract> actuation_model)
-    : Base(state, state->get_nv(), actuation_model->get_nu()), pin_model_(*state->get_pinocchio()) {
-  if (nu_ == 0) {
-    throw_pretty("Invalid argument: "
-                 << "it seems to be an autonomous system, if so, don't add "
-                    "this cost function");
-  }
-  std::cerr << "Deprecated CostModelControlGrav constructor: Use constructor without actuation model" << std::endl;
-}
 
 template <typename Scalar>
 CostModelControlGravTpl<Scalar>::~CostModelControlGravTpl() {}

--- a/include/crocoddyl/multibody/costs/control-gravity.hxx
+++ b/include/crocoddyl/multibody/costs/control-gravity.hxx
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2020, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2020-2021, LAAS-CNRS, University of Edinburgh
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -11,13 +11,12 @@
 #include "pinocchio/algorithm/rnea.hpp"
 
 namespace crocoddyl {
+
 template <typename Scalar>
 CostModelControlGravTpl<Scalar>::CostModelControlGravTpl(boost::shared_ptr<StateMultibody> state,
                                                          boost::shared_ptr<ActivationModelAbstract> activation,
-                                                         boost::shared_ptr<ActuationModelAbstract> actuation_model)
-    : Base(state, activation, actuation_model->get_nu()),
-      pin_model_(*state->get_pinocchio()),
-      actuation_model_(actuation_model) {
+                                                         const std::size_t nu)
+    : Base(state, activation, nu), pin_model_(*state->get_pinocchio()) {
   if (activation_->get_nr() != state_->get_nv()) {
     throw_pretty("Invalid argument: "
                  << "nr is equals to " + std::to_string(state_->get_nv()));
@@ -31,15 +30,55 @@ CostModelControlGravTpl<Scalar>::CostModelControlGravTpl(boost::shared_ptr<State
 
 template <typename Scalar>
 CostModelControlGravTpl<Scalar>::CostModelControlGravTpl(boost::shared_ptr<StateMultibody> state,
+                                                         boost::shared_ptr<ActivationModelAbstract> activation)
+    : Base(state, activation, state->get_nv()), pin_model_(*state->get_pinocchio()) {
+  if (activation_->get_nr() != state_->get_nv()) {
+    throw_pretty("Invalid argument: "
+                 << "nr is equals to " + std::to_string(state_->get_nv()));
+  }
+}
+
+template <typename Scalar>
+CostModelControlGravTpl<Scalar>::CostModelControlGravTpl(boost::shared_ptr<StateMultibody> state,
+                                                         boost::shared_ptr<ActivationModelAbstract> activation,
                                                          boost::shared_ptr<ActuationModelAbstract> actuation_model)
-    : Base(state, state->get_nv(), actuation_model->get_nu()),
-      pin_model_(*state->get_pinocchio()),
-      actuation_model_(actuation_model) {
+    : Base(state, activation, actuation_model->get_nu()), pin_model_(*state->get_pinocchio()) {
+  if (activation_->get_nr() != state_->get_nv()) {
+    throw_pretty("Invalid argument: "
+                 << "nr is equals to " + std::to_string(state_->get_nv()));
+  }
   if (nu_ == 0) {
     throw_pretty("Invalid argument: "
                  << "it seems to be an autonomous system, if so, don't add "
                     "this cost function");
   }
+  std::cerr << "Deprecated CostModelControlGrav constructor: Use constructor without actuation model" << std::endl;
+}
+
+template <typename Scalar>
+CostModelControlGravTpl<Scalar>::CostModelControlGravTpl(boost::shared_ptr<StateMultibody> state, const std::size_t nu)
+    : Base(state, state->get_nv(), nu), pin_model_(*state->get_pinocchio()) {
+  if (nu_ == 0) {
+    throw_pretty("Invalid argument: "
+                 << "it seems to be an autonomous system, if so, don't add "
+                    "this cost function");
+  }
+}
+
+template <typename Scalar>
+CostModelControlGravTpl<Scalar>::CostModelControlGravTpl(boost::shared_ptr<StateMultibody> state)
+    : Base(state, state->get_nv(), state->get_nv()), pin_model_(*state->get_pinocchio()) {}
+
+template <typename Scalar>
+CostModelControlGravTpl<Scalar>::CostModelControlGravTpl(boost::shared_ptr<StateMultibody> state,
+                                                         boost::shared_ptr<ActuationModelAbstract> actuation_model)
+    : Base(state, state->get_nv(), actuation_model->get_nu()), pin_model_(*state->get_pinocchio()) {
+  if (nu_ == 0) {
+    throw_pretty("Invalid argument: "
+                 << "it seems to be an autonomous system, if so, don't add "
+                    "this cost function");
+  }
+  std::cerr << "Deprecated CostModelControlGrav constructor: Use constructor without actuation model" << std::endl;
 }
 
 template <typename Scalar>
@@ -55,8 +94,6 @@ void CostModelControlGravTpl<Scalar>::calc(const boost::shared_ptr<CostDataAbstr
   Data *d = static_cast<Data *>(data.get());
 
   const Eigen::VectorBlock<const Eigen::Ref<const VectorXs>, Eigen::Dynamic> q = x.head(state_->get_nq());
-
-  actuation_model_->calc(d->actuation, x, u);
   data->r = pinocchio::computeGeneralizedGravity(pin_model_, d->pinocchio, q) - d->actuation->tau;
 
   activation_->calc(data->activation, data->r);
@@ -74,12 +111,10 @@ void CostModelControlGravTpl<Scalar>::calcDiff(const boost::shared_ptr<CostDataA
   Data *d = static_cast<Data *>(data.get());
 
   const Eigen::VectorBlock<const Eigen::Ref<const VectorXs>, Eigen::Dynamic> q = x.head(state_->get_nq());
-
   pinocchio::computeGeneralizedGravityDerivatives(pin_model_, d->pinocchio, q, d->dg_dq);
 
   const std::size_t &nv = state_->get_nv();
   activation_->calcDiff(data->activation, data->r);
-  actuation_model_->calcDiff(d->actuation, x, u);
 
   data->Lu.noalias() = -d->actuation->dtau_du.transpose() * data->activation->Ar;
   data->Lx.head(nv).noalias() = d->dg_dq.transpose() * data->activation->Ar;

--- a/include/crocoddyl/multibody/numdiff/contact.hpp
+++ b/include/crocoddyl/multibody/numdiff/contact.hpp
@@ -26,7 +26,7 @@ class ContactModelNumDiffTpl : public ContactModelAbstractTpl<_Scalar> {
   typedef ContactDataNumDiffTpl<Scalar> Data;
   typedef MathBaseTpl<Scalar> MathBase;
   typedef typename MathBaseTpl<Scalar>::VectorXs VectorXs;
-  typedef boost::function<void(const typename MathBaseTpl<Scalar>::VectorXs&)> ReevaluationFunction;
+  typedef boost::function<void(const VectorXs&, const VectorXs&)> ReevaluationFunction;
 
   /**
    * @brief Construct a new ContactModelNumDiff object from a ContactModelAbstract.

--- a/include/crocoddyl/multibody/numdiff/contact.hxx
+++ b/include/crocoddyl/multibody/numdiff/contact.hxx
@@ -45,7 +45,7 @@ void ContactModelNumDiffTpl<Scalar>::calcDiff(const boost::shared_ptr<ContactDat
     model_->get_state()->integrate(x, data_nd->dx, data_nd->xp);
     // call the update function on the pinocchio data
     for (size_t i = 0; i < reevals_.size(); ++i) {
-      reevals_[i](data_nd->xp);
+      reevals_[i](data_nd->xp, VectorXs::Zero(model_->get_nu()));
     }
     // contact(x+dx, u)
     model_->calc(data_nd->data_x[ix], data_nd->xp);

--- a/unittest/factory/actuation.cpp
+++ b/unittest/factory/actuation.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, University of Edinburgh
+// Copyright (C) 2019-2021, University of Edinburgh
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -97,6 +97,12 @@ boost::shared_ptr<crocoddyl::ActuationModelAbstract> ActuationModelFactory::crea
       break;
   }
   return actuation;
+}
+
+void updateActuation(const boost::shared_ptr<crocoddyl::ActuationModelAbstract>& model,
+                     const boost::shared_ptr<crocoddyl::ActuationDataAbstract>& data, const Eigen::VectorXd& x,
+                     const Eigen::VectorXd& u) {
+  model->calc(data, x, u);
 }
 
 }  // namespace unittest

--- a/unittest/factory/actuation.hpp
+++ b/unittest/factory/actuation.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, University of Edinburgh
+// Copyright (C) 2019-2021, University of Edinburgh
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -47,6 +47,20 @@ class ActuationModelFactory {
   boost::shared_ptr<crocoddyl::ActuationModelAbstract> create(ActuationModelTypes::Type actuation_type,
                                                               StateModelTypes::Type state_type) const;
 };
+
+/**
+ * @brief Update the actuation model needed for numerical differentiation.
+ * We use the address of the object to avoid a copy from the
+ * "boost::bind".
+ *
+ * @param model[in]  Pinocchio model
+ * @param data[out]  Pinocchio data
+ * @param x[in]      State vector
+ * @param u[in]      Control vector
+ */
+void updateActuation(const boost::shared_ptr<crocoddyl::ActuationModelAbstract>& model,
+                     const boost::shared_ptr<crocoddyl::ActuationDataAbstract>& data, const Eigen::VectorXd& x,
+                     const Eigen::VectorXd& u);
 
 }  // namespace unittest
 }  // namespace crocoddyl

--- a/unittest/factory/contact_cost.cpp
+++ b/unittest/factory/contact_cost.cpp
@@ -98,7 +98,7 @@ boost::shared_ptr<crocoddyl::DifferentialActionModelAbstract> ContactCostModelFa
       break;
     case ContactCostModelTypes::CostModelControlGravContact:
       cost = boost::make_shared<crocoddyl::CostModelControlGravContact>(
-          state, ActivationModelFactory().create(activation_type, state->get_nv()), action->get_actuation());
+          state, ActivationModelFactory().create(activation_type, state->get_nv()), nu);
       break;
     default:
       throw_pretty(__FILE__ ": Wrong ContactCostModelTypes::Type given");

--- a/unittest/factory/cost.cpp
+++ b/unittest/factory/cost.cpp
@@ -177,12 +177,5 @@ boost::shared_ptr<crocoddyl::CostModelAbstract> create_random_cost(StateModelTyp
   return factory.create(rand_type, state_type, ActivationModelTypes::ActivationModelQuad, nu);
 }
 
-void updateActuation(const boost::shared_ptr<crocoddyl::ActuationModelAbstract>& model,
-                     const boost::shared_ptr<crocoddyl::ActuationDataAbstract>& data, const Eigen::VectorXd& x,
-                     const Eigen::VectorXd& u) {
-  model->calc(data, x, u);
-  model->calcDiff(data, x, u);
-}
-
 }  // namespace unittest
 }  // namespace crocoddyl

--- a/unittest/factory/cost.cpp
+++ b/unittest/factory/cost.cpp
@@ -180,5 +180,12 @@ boost::shared_ptr<crocoddyl::CostModelAbstract> create_random_cost(StateModelTyp
   return factory.create(rand_type, state_type, ActivationModelTypes::ActivationModelQuad, nu);
 }
 
+void updateActuation(const boost::shared_ptr<crocoddyl::ActuationModelAbstract>& model,
+                     const boost::shared_ptr<crocoddyl::ActuationDataAbstract>& data, const Eigen::VectorXd& x,
+                     const Eigen::VectorXd& u) {
+  model->calc(data, x, u);
+  model->calcDiff(data, x, u);
+}
+
 }  // namespace unittest
 }  // namespace crocoddyl

--- a/unittest/factory/cost.cpp
+++ b/unittest/factory/cost.cpp
@@ -28,7 +28,7 @@ namespace unittest {
 const std::vector<CostModelTypes::Type> CostModelTypes::all(CostModelTypes::init_all());
 const std::vector<CostModelNoFFTypes::Type> CostModelNoFFTypes::all(CostModelNoFFTypes::init_all());
 
-std::ostream &operator<<(std::ostream &os, CostModelTypes::Type type) {
+std::ostream& operator<<(std::ostream& os, CostModelTypes::Type type) {
   switch (type) {
     case CostModelTypes::CostModelState:
       os << "CostModelState";
@@ -63,7 +63,7 @@ std::ostream &operator<<(std::ostream &os, CostModelTypes::Type type) {
   return os;
 }
 
-std::ostream &operator<<(std::ostream &os, CostModelNoFFTypes::Type type) {
+std::ostream& operator<<(std::ostream& os, CostModelNoFFTypes::Type type) {
   switch (type) {
     case CostModelNoFFTypes::CostModelControlGrav:
       os << "CostModelControlGrav";

--- a/unittest/factory/cost.cpp
+++ b/unittest/factory/cost.cpp
@@ -149,9 +149,6 @@ boost::shared_ptr<crocoddyl::CostModelAbstract> CostModelFactory::create(CostMod
   boost::shared_ptr<crocoddyl::CostModelAbstract> cost;
   boost::shared_ptr<crocoddyl::StateMultibody> state = boost::static_pointer_cast<crocoddyl::StateMultibody>(
       state_factory.create(StateModelTypes::StateMultibody_TalosArm));
-
-  boost::shared_ptr<crocoddyl::ActuationModelFull> actuation =
-      boost::make_shared<crocoddyl::ActuationModelFull>(state);
   if (nu == std::numeric_limits<std::size_t>::max()) {
     nu = state->get_nv();
   }
@@ -159,7 +156,7 @@ boost::shared_ptr<crocoddyl::CostModelAbstract> CostModelFactory::create(CostMod
   switch (cost_type) {
     case CostModelNoFFTypes::CostModelControlGrav:
       cost = boost::make_shared<crocoddyl::CostModelControlGrav>(
-          state, activation_factory.create(activation_type, state->get_nv()), actuation);
+          state, activation_factory.create(activation_type, state->get_nv()));
       break;
     default:
       throw_pretty(__FILE__ ": Wrong CostModelTypes::Type given");

--- a/unittest/factory/cost.hpp
+++ b/unittest/factory/cost.hpp
@@ -79,6 +79,20 @@ class CostModelFactory {
 boost::shared_ptr<crocoddyl::CostModelAbstract> create_random_cost(
     StateModelTypes::Type state_type, std::size_t nu = std::numeric_limits<std::size_t>::max());
 
+/**
+ * @brief Update the actuation model needed for numerical differentiation.
+ * We use the address of the object to avoid a copy from the
+ * "boost::bind".
+ *
+ * @param model[in]  Pinocchio model
+ * @param data[out]  Pinocchio data
+ * @param x[in]      State vector
+ * @param u[in]      Control vector
+ */
+void updateActuation(const boost::shared_ptr<crocoddyl::ActuationModelAbstract>& model,
+                     const boost::shared_ptr<crocoddyl::ActuationDataAbstract>& data, const Eigen::VectorXd& x,
+                     const Eigen::VectorXd& u);
+
 }  // namespace unittest
 }  // namespace crocoddyl
 

--- a/unittest/factory/cost.hpp
+++ b/unittest/factory/cost.hpp
@@ -78,21 +78,6 @@ class CostModelFactory {
 
 boost::shared_ptr<crocoddyl::CostModelAbstract> create_random_cost(
     StateModelTypes::Type state_type, std::size_t nu = std::numeric_limits<std::size_t>::max());
-
-/**
- * @brief Update the actuation model needed for numerical differentiation.
- * We use the address of the object to avoid a copy from the
- * "boost::bind".
- *
- * @param model[in]  Pinocchio model
- * @param data[out]  Pinocchio data
- * @param x[in]      State vector
- * @param u[in]      Control vector
- */
-void updateActuation(const boost::shared_ptr<crocoddyl::ActuationModelAbstract>& model,
-                     const boost::shared_ptr<crocoddyl::ActuationDataAbstract>& data, const Eigen::VectorXd& x,
-                     const Eigen::VectorXd& u);
-
 }  // namespace unittest
 }  // namespace crocoddyl
 

--- a/unittest/factory/cost.hpp
+++ b/unittest/factory/cost.hpp
@@ -55,8 +55,8 @@ struct CostModelNoFFTypes {
   static const std::vector<Type> all;
 };
 
-std::ostream &operator<<(std::ostream &os, CostModelTypes::Type type);
-std::ostream &operator<<(std::ostream &os, CostModelNoFFTypes::Type type);
+std::ostream& operator<<(std::ostream& os, CostModelTypes::Type type);
+std::ostream& operator<<(std::ostream& os, CostModelNoFFTypes::Type type);
 
 class CostModelFactory {
  public:

--- a/unittest/factory/pinocchio_model.cpp
+++ b/unittest/factory/pinocchio_model.cpp
@@ -119,7 +119,8 @@ std::size_t PinocchioModelFactory::get_frame_id() const { return frame_id_; }
  * @param data contains the results of the computations.
  * @param x is the state vector.
  */
-void updateAllPinocchio(pinocchio::Model* const model, pinocchio::Data* data, const Eigen::VectorXd& x) {
+void updateAllPinocchio(pinocchio::Model* const model, pinocchio::Data* data, const Eigen::VectorXd& x,
+                        const Eigen::VectorXd&) {
   const Eigen::VectorXd& q = x.segment(0, model->nq);
   const Eigen::VectorXd& v = x.segment(model->nq, model->nv);
   Eigen::VectorXd a = Eigen::VectorXd::Zero(model->nv);

--- a/unittest/factory/pinocchio_model.hpp
+++ b/unittest/factory/pinocchio_model.hpp
@@ -67,11 +67,13 @@ class PinocchioModelFactory {
  * differentiation. We use the address of the object to avoid a copy from the
  * "boost::bind".
  *
- * @param model is the rigid body robot model.
- * @param data contains the results of the computations.
- * @param x is the state vector.
+ * @param model[in]  Pinocchio model
+ * @param data[out]  Pinocchio data
+ * @param x[in]      State vector
+ * @param u[in]      Control vector
  */
-void updateAllPinocchio(pinocchio::Model* const model, pinocchio::Data* data, const Eigen::VectorXd& x);
+void updateAllPinocchio(pinocchio::Model* const model, pinocchio::Data* data, const Eigen::VectorXd& x,
+                        const Eigen::VectorXd& u = Eigen::VectorXd());
 
 }  // namespace unittest
 }  // namespace crocoddyl

--- a/unittest/test_contacts.cpp
+++ b/unittest/test_contacts.cpp
@@ -162,7 +162,7 @@ void test_partial_derivatives_against_numdiff(ContactModelTypes::Type contact_ty
 
   // set the function that needs to be called at every step of the numdiff
   std::vector<crocoddyl::ContactModelNumDiff::ReevaluationFunction> reevals;
-  reevals.push_back(boost::bind(&crocoddyl::unittest::updateAllPinocchio, &pinocchio_model, &pinocchio_data, _1));
+  reevals.push_back(boost::bind(&crocoddyl::unittest::updateAllPinocchio, &pinocchio_model, &pinocchio_data, _1, _2));
   model_num_diff.set_reevals(reevals);
 
   // Computing the contact derivatives

--- a/unittest/test_costs.cpp
+++ b/unittest/test_costs.cpp
@@ -114,7 +114,7 @@ void test_partial_derivatives_against_numdiff(CostModelTypes::Type cost_type, St
 
   // set the function that needs to be called at every step of the numdiff
   std::vector<crocoddyl::CostModelNumDiff::ReevaluationFunction> reevals;
-  reevals.push_back(boost::bind(&crocoddyl::unittest::updateAllPinocchio, &pinocchio_model, &pinocchio_data, _1));
+  reevals.push_back(boost::bind(&crocoddyl::unittest::updateAllPinocchio, &pinocchio_model, &pinocchio_data, _1, _2));
   model_num_diff.set_reevals(reevals);
 
   // Computing the cost derivatives

--- a/unittest/test_costs_noFF.cpp
+++ b/unittest/test_costs_noFF.cpp
@@ -104,9 +104,9 @@ void test_partial_derivatives_against_numdiff(CostModelNoFFTypes::Type cost_type
   pinocchio::Model& pinocchio_model = *state->get_pinocchio().get();
   pinocchio::Data pinocchio_data(pinocchio_model);
 
-  boost::shared_ptr<crocoddyl::ActuationModelAbstract> actuation =
+  boost::shared_ptr<crocoddyl::ActuationModelAbstract> actuation_model =
       boost::make_shared<crocoddyl::ActuationModelFull>(state);
-  const boost::shared_ptr<crocoddyl::ActuationDataAbstract>& actuation_data = actuation->createData();
+  const boost::shared_ptr<crocoddyl::ActuationDataAbstract>& actuation_data = actuation_model->createData();
   crocoddyl::DataCollectorActMultibody shared_data(&pinocchio_data, actuation_data);
   const boost::shared_ptr<crocoddyl::CostDataAbstract>& data = model->createData(&shared_data);
 
@@ -123,7 +123,7 @@ void test_partial_derivatives_against_numdiff(CostModelNoFFTypes::Type cost_type
 
   // set the function that needs to be called at every step of the numdiff
   std::vector<crocoddyl::CostModelNumDiff::ReevaluationFunction> reevals;
-  reevals.push_back(boost::bind(&crocoddyl::unittest::updateAllPinocchio, &pinocchio_model, &pinocchio_data, _1));
+  reevals.push_back(boost::bind(&crocoddyl::unittest::updateAllPinocchio, &pinocchio_model, &pinocchio_data, _1, _2));
   model_num_diff.set_reevals(reevals);
 
   // Computing the cost derivatives

--- a/unittest/test_costs_noFF.cpp
+++ b/unittest/test_costs_noFF.cpp
@@ -3,7 +3,7 @@
 //
 // Copyright (C) 2019-2021, LAAS-CNRS, New York University,
 //                          Max Planck Gesellschaft, University of Edinburgh,
-//                           INRIA
+//                          INRIA
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -16,6 +16,7 @@
 #include "crocoddyl/multibody/data/multibody.hpp"
 
 #include "factory/cost.hpp"
+#include "factory/actuation.hpp"
 #include "unittest_common.hpp"
 
 using namespace boost::unit_test;

--- a/unittest/test_costs_noFF.cpp
+++ b/unittest/test_costs_noFF.cpp
@@ -124,9 +124,12 @@ void test_partial_derivatives_against_numdiff(CostModelNoFFTypes::Type cost_type
   // set the function that needs to be called at every step of the numdiff
   std::vector<crocoddyl::CostModelNumDiff::ReevaluationFunction> reevals;
   reevals.push_back(boost::bind(&crocoddyl::unittest::updateAllPinocchio, &pinocchio_model, &pinocchio_data, _1, _2));
+  reevals.push_back(boost::bind(&crocoddyl::unittest::updateActuation, actuation_model, actuation_data, _1, _2));
   model_num_diff.set_reevals(reevals);
 
   // Computing the cost derivatives
+  actuation_model->calc(actuation_data, x, u);
+  actuation_model->calcDiff(actuation_data, x, u);
   model->calc(data, x, u);
   model->calcDiff(data, x, u);
 


### PR DESCRIPTION
This PR handles the comments that I left in https://github.com/loco-3d/crocoddyl/pull/888#pullrequestreview-588392158 plus a few extra improvements of both cost functions: control gravity and control gravity contact. Concretely, these is the list of actions:
 1. Remove unnecessary computation regarding the actuation model.
 2. Adapted the unittest and cost / contact numdiff routines for properly testing 1.
 3. Deprecated constructors as they don't need to pass the actuation model.
 4. Fixed the residual computation (i.e., r = tau - g(q) rather than r = g(q) - tau)

Let me give you explanations for each point. First, it is not needed to pass the actuation model as the actuation data is stored by the action models as designed choice (point 1). Second, I believe you guys got confused as the unittest (concretely,  the numdiff routines) were not written to update actuation data, and as a consequence, you introduced point 1 (point 2). Third, I have to deprecated all the constructor functions that pass the actuation model as this not anymore needed (point 3). Finally, I noticed that the residual vectors were computed with opposite sign. However, I also saw that this was not compatible with the code and PR documentation (see  https://github.com/loco-3d/crocoddyl/pull/888#issue-528146304).

@edantec and @proyan -- this PR is important for you. Pay particular attention to point 4.