### PR TITLE
Improved multicopter actuation API + fixed unittest

### DIFF
--- a/bindings/python/crocoddyl/crocoddyl.cpp
+++ b/bindings/python/crocoddyl/crocoddyl.cpp
@@ -24,6 +24,7 @@ BOOST_PYTHON_MODULE(libcrocoddyl_pywrap) {
   typedef Eigen::Matrix<Scalar, 4, 1> Vector4;
   typedef Eigen::Matrix<Scalar, 6, 1> Vector6;
   typedef Eigen::Matrix<Scalar, 4, 6> Matrix46;
+  typedef Eigen::Matrix<Scalar, 6, Eigen::Dynamic> Matrix6x;
   typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 3> MatrixX3;
   typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 1> VectorX;
   typedef Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> MatrixX;
@@ -32,6 +33,7 @@ BOOST_PYTHON_MODULE(libcrocoddyl_pywrap) {
   eigenpy::enableEigenPySpecific<Vector6>();
   eigenpy::enableEigenPySpecific<Matrix46>();
   eigenpy::enableEigenPySpecific<MatrixX3>();
+  eigenpy::enableEigenPySpecific<Matrix6x>();
 
   // Register converters between std::vector and Python list
   StdVectorPythonVisitor<VectorX, std::allocator<VectorX>, true>::expose("StdVec_VectorX");

--- a/bindings/python/crocoddyl/multibody/actuations/multicopter-base.cpp
+++ b/bindings/python/crocoddyl/multibody/actuations/multicopter-base.cpp
@@ -16,12 +16,17 @@ void exposeActuationModelMultiCopterBase() {
   bp::class_<ActuationModelMultiCopterBase, bp::bases<ActuationModelAbstract> >(
       "ActuationModelMultiCopterBase",
       "Actuation models with base actuated by several propellers (e.g. aerial manipulators).",
-      bp::init<boost::shared_ptr<StateMultibody>, int, Eigen::MatrixXd>(
-          bp::args("self", "state", "nrotors", "force_torque"),
+      bp::init<boost::shared_ptr<StateMultibody>, Eigen::Matrix<double, 6, Eigen::Dynamic> >(
+          bp::args("self", "state", "tau_f"),
+          "Initialize the full actuation model.\n\n"
+          ":param state: state of multibody system\n"
+          ":param tau_f: matrix that maps rotors thrust to generalized torque of the flying base."))
+      .def(bp::init<boost::shared_ptr<StateMultibody>, std::size_t, Eigen::Matrix<double, 6, Eigen::Dynamic> >(
+          bp::args("self", "state", "nrotors", "tau_f"),
           "Initialize the full actuation model.\n\n"
           ":param state: state of multibody system, \n"
           ":param nrotors: number of rotors of the flying base, \n"
-          ":param force_torque: matrix that maps rotors thrust to generalized torque of the flying base."))
+          ":param tau_f: matrix that maps rotors thrust to generalized torque of the flying base."))
       .def("calc", &ActuationModelMultiCopterBase::calc, bp::args("self", "data", "x", "u"),
            "Compute the actuation signal from the control input u.\n\n"
            ":param data: multicopter-base actuation data\n"

--- a/examples/quadrotor.py
+++ b/examples/quadrotor.py
@@ -24,7 +24,7 @@ l_lim = 0.1
 tau_f = np.array([[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [1.0, 1.0, 1.0, 1.0], [0.0, d_cog, 0.0, -d_cog],
                   [-d_cog, 0.0, d_cog, 0.0], [-cm / cf, cm / cf, -cm / cf, cm / cf]])
 
-actModel = crocoddyl.ActuationModelMultiCopterBase(state, 4, tau_f)
+actModel = crocoddyl.ActuationModelMultiCopterBase(state, tau_f)
 
 runningCostModel = crocoddyl.CostModelSum(state, actModel.nu)
 terminalCostModel = crocoddyl.CostModelSum(state, actModel.nu)

--- a/examples/quadrotor_ubound.py
+++ b/examples/quadrotor_ubound.py
@@ -24,7 +24,7 @@ l_lim = 0.1
 tau_f = np.array([[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0], [1.0, 1.0, 1.0, 1.0], [0.0, d_cog, 0.0, -d_cog],
                   [-d_cog, 0.0, d_cog, 0.0], [-cm / cf, cm / cf, -cm / cf, cm / cf]])
 
-actModel = crocoddyl.ActuationModelMultiCopterBase(state, 4, tau_f)
+actModel = crocoddyl.ActuationModelMultiCopterBase(state, tau_f)
 
 runningCostModel = crocoddyl.CostModelSum(state, actModel.nu)
 terminalCostModel = crocoddyl.CostModelSum(state, actModel.nu)

--- a/include/crocoddyl/multibody/actuations/multicopter-base.hpp
+++ b/include/crocoddyl/multibody/actuations/multicopter-base.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, LAAS-CNRS, IRI: CSIC-UPC
+// Copyright (C) 2019-2021, LAAS-CNRS, IRI: CSIC-UPC, University of Edinburgh
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -9,22 +9,32 @@
 #ifndef CROCODDYL_MULTIBODY_ACTUATIONS_MULTICOPTER_BASE_HPP_
 #define CROCODDYL_MULTIBODY_ACTUATIONS_MULTICOPTER_BASE_HPP_
 
+#include <iostream>
 #include "crocoddyl/multibody/fwd.hpp"
 #include "crocoddyl/core/utils/exception.hpp"
 #include "crocoddyl/core/actuation-base.hpp"
 #include "crocoddyl/multibody/states/multibody.hpp"
+#include "crocoddyl/core/utils/deprecate.hpp"
 
-/* This actuation model is aimed for those robots whose base_link is actuated using a propulsion system, e.g.
+namespace crocoddyl {
+
+/**
+ * @brief Multicopter actuation model
+ *
+ * This actuation model is aimed for those robots whose base_link is actuated using a propulsion system, e.g.,
  * a multicopter or an aerial manipulator (multicopter with a robotic arm attached).
  * Control input: the thrust (force) created by each propeller.
  * tau_f matrix: this matrix relates the thrust of each propeller to the net force and torque that it causes to the
  * base_link. For a simple quadrotor: tau_f.nrows = 6, tau_f.ncols = 4
  *
+ * Both actuation and Jacobians are computed analytically by `calc` and `calcDiff`, respectively.
+ *
  * Reference: M. Geisert and N. Mansard, "Trajectory generation for quadrotor based systems using numerical optimal
  * control," 2016 IEEE International Conference on Robotics and Automation (ICRA), Stockholm, 2016, pp. 2958-2964. See
- * Section III.C  */
-
-namespace crocoddyl {
+ * Section III.C.
+ *
+ * \sa `ActuationModelAbstractTpl`, `calc()`, `calcDiff()`, `createData()`
+ */
 template <typename _Scalar>
 class ActuationModelMultiCopterBaseTpl : public ActuationModelAbstractTpl<_Scalar> {
  public:
@@ -35,10 +45,16 @@ class ActuationModelMultiCopterBaseTpl : public ActuationModelAbstractTpl<_Scala
   typedef StateMultibodyTpl<Scalar> StateMultibody;
   typedef typename MathBase::VectorXs VectorXs;
   typedef typename MathBase::MatrixXs MatrixXs;
+  typedef typename MathBase::Matrix6xs Matrix6xs;
 
-  ActuationModelMultiCopterBaseTpl(boost::shared_ptr<StateMultibody> state, const std::size_t n_rotors,
-                                   const Eigen::Ref<const MatrixXs>& tau_f)
-      : Base(state, state->get_nv() - 6 + n_rotors), n_rotors_(n_rotors) {
+  /**
+   * @brief Initialize the multicopter actuation model
+   *
+   * @param[in] state  State of the dynamical system
+   * @param[in] tau_f  Matrix that maps the thrust of each propeller to the net force and torque
+   */
+  ActuationModelMultiCopterBaseTpl(boost::shared_ptr<StateMultibody> state, const Eigen::Ref<const Matrix6xs>& tau_f)
+      : Base(state, state->get_nv() - 6 + tau_f.cols()), n_rotors_(tau_f.cols()) {
     pinocchio::JointModelFreeFlyerTpl<Scalar> ff_joint;
     if (state->get_pinocchio()->joints[1].shortname() != ff_joint.shortname()) {
       throw_pretty("Invalid argument: "
@@ -48,13 +64,16 @@ class ActuationModelMultiCopterBaseTpl : public ActuationModelAbstractTpl<_Scala
     tau_f_ = MatrixXs::Zero(state_->get_nv(), nu_);
     tau_f_.block(0, 0, 6, n_rotors_) = tau_f;
     if (nu_ > n_rotors_) {
-      tau_f_.bottomRightCorner(nu_ - n_rotors_, nu_ - n_rotors_) =
-          MatrixXs::Identity(nu_ - n_rotors_, nu_ - n_rotors_);
+      tau_f_.bottomRightCorner(nu_ - n_rotors_, nu_ - n_rotors_).diagonal().array() = 1.;
     }
-  };
-  virtual ~ActuationModelMultiCopterBaseTpl(){};
+  }
 
-  virtual void calc(const boost::shared_ptr<Data>& data, const Eigen::Ref<const VectorXs>& /*x*/,
+  DEPRECATED("Use constructor without n_rotors",
+             ActuationModelMultiCopterBaseTpl(boost::shared_ptr<StateMultibody> state, const std::size_t n_rotors,
+                                              const Eigen::Ref<const Matrix6xs>& tau_f));
+  virtual ~ActuationModelMultiCopterBaseTpl() {}
+
+  virtual void calc(const boost::shared_ptr<Data>& data, const Eigen::Ref<const VectorXs>&,
                     const Eigen::Ref<const VectorXs>& u) {
     if (static_cast<std::size_t>(u.size()) != nu_) {
       throw_pretty("Invalid argument: "
@@ -64,9 +83,15 @@ class ActuationModelMultiCopterBaseTpl : public ActuationModelAbstractTpl<_Scala
     data->tau.noalias() = tau_f_ * u;
   }
 
-  virtual void calcDiff(const boost::shared_ptr<Data>& /*data*/, const Eigen::Ref<const VectorXs>& /*x*/,
-                        const Eigen::Ref<const VectorXs>& /*u*/) {
+#ifndef NDEBUG
+  virtual void calcDiff(const boost::shared_ptr<Data>& data, const Eigen::Ref<const VectorXs>&,
+                        const Eigen::Ref<const VectorXs>&) {
+#else
+  virtual void calcDiff(const boost::shared_ptr<Data>&, const Eigen::Ref<const VectorXs>&,
+                        const Eigen::Ref<const VectorXs>&) {
+#endif
     // The derivatives has constant values which were set in createData.
+    assert_pretty(data->dtau_du == tau_f_, "dtau_du has wrong value");
   }
 
   boost::shared_ptr<Data> createData() {
@@ -87,6 +112,25 @@ class ActuationModelMultiCopterBaseTpl : public ActuationModelAbstractTpl<_Scala
   using Base::nu_;
   using Base::state_;
 };
+
+template <typename Scalar>
+ActuationModelMultiCopterBaseTpl<Scalar>::ActuationModelMultiCopterBaseTpl(boost::shared_ptr<StateMultibody> state,
+                                                                           const std::size_t n_rotors,
+                                                                           const Eigen::Ref<const Matrix6xs>& tau_f)
+    : Base(state, state->get_nv() - 6 + n_rotors), n_rotors_(n_rotors) {
+  pinocchio::JointModelFreeFlyerTpl<Scalar> ff_joint;
+  if (state->get_pinocchio()->joints[1].shortname() != ff_joint.shortname()) {
+    throw_pretty("Invalid argument: "
+                 << "the first joint has to be free-flyer");
+  }
+
+  tau_f_ = MatrixXs::Zero(state_->get_nv(), nu_);
+  tau_f_.block(0, 0, 6, n_rotors_) = tau_f;
+  if (nu_ > n_rotors_) {
+    tau_f_.bottomRightCorner(nu_ - n_rotors_, nu_ - n_rotors_).diagonal().array() = 1.;
+  }
+  std::cerr << "Deprecated ActuationModelMultiCopterBase: Use constructor without n_rotors." << std::endl;
+}
 
 }  // namespace crocoddyl
 

--- a/unittest/factory/actuation.cpp
+++ b/unittest/factory/actuation.cpp
@@ -71,13 +71,12 @@ boost::shared_ptr<crocoddyl::ActuationModelAbstract> ActuationModelFactory::crea
       break;
     case ActuationModelTypes::ActuationModelMultiCopterBase:
       state_multibody = boost::static_pointer_cast<crocoddyl::StateMultibody>(state);
-      n_rotors = 4;
-      tau_f = Eigen::MatrixXd::Zero(state_multibody->get_nv(), 4);
+      tau_f = Eigen::MatrixXd::Zero(6, 4);
       tau_f.row(2).fill(1.0);
       tau_f.row(3) << 0.0, 0.1525, 0.0, -0.1525;
       tau_f.row(4) << -0.1525, 0.0, 0.1525, 0.0;
       tau_f.row(5) << -0.01515, 0.01515, -0.01515, 0.01515;
-      actuation = boost::make_shared<crocoddyl::ActuationModelMultiCopterBase>(state_multibody, n_rotors, tau_f);
+      actuation = boost::make_shared<crocoddyl::ActuationModelMultiCopterBase>(state_multibody, tau_f);
       break;
     case ActuationModelTypes::ActuationModelSquashingFull:
       state_multibody = boost::static_pointer_cast<crocoddyl::StateMultibody>(state);


### PR DESCRIPTION
This PR removes an unnecessary argument (i.e., n_rotors) in the multicopter actuation API. Note that this information can be extracted by the mapping matrix. Additionally, it adds checks useful for debugging mode. Finally, it fixes a tiny issue in the unittest.

Note that the PR deprecates the current constructor. @PepMS (fyi)