### PR TITLE
Add stop-watch class (with Python bindings) for profiling code.

### DIFF
--- a/bindings/python/crocoddyl/core/core.cpp
+++ b/bindings/python/crocoddyl/core/core.cpp
@@ -51,6 +51,7 @@ void exposeCore() {
   exposeSolverBoxDDP();
   exposeSolverBoxFDDP();
   exposeCallbacks();
+  exposeStopWatch();
 }
 
 }  // namespace python

--- a/bindings/python/crocoddyl/core/core.hpp
+++ b/bindings/python/crocoddyl/core/core.hpp
@@ -53,6 +53,7 @@ void exposeSolverBoxQP();
 void exposeSolverBoxDDP();
 void exposeSolverBoxFDDP();
 void exposeCallbacks();
+void exposeStopWatch();
 
 void exposeCore();
 

--- a/bindings/python/crocoddyl/core/utils/stop-watch.cpp
+++ b/bindings/python/crocoddyl/core/utils/stop-watch.cpp
@@ -1,16 +1,7 @@
-//#include <boost/python.hpp>
-//#include <iostream>
-//#include <string>
-//#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
-//#include <boost/python/make_constructor.hpp>
-
-//#include "crocoddyl/bindings/python/stop_watch.hpp"
-//#include "crocoddyl/core/utils/stop-watch.hpp"
-
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2021, LAAS-CNRS, University of Edinburgh, University of Trento
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////

--- a/bindings/python/crocoddyl/core/utils/stop-watch.cpp
+++ b/bindings/python/crocoddyl/core/utils/stop-watch.cpp
@@ -1,0 +1,81 @@
+//#include <boost/python.hpp>
+//#include <iostream>
+//#include <string>
+//#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
+//#include <boost/python/make_constructor.hpp>
+
+//#include "crocoddyl/bindings/python/stop_watch.hpp"
+//#include "crocoddyl/core/utils/stop-watch.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2019-2020, LAAS-CNRS, University of Edinburgh
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#include "python/crocoddyl/core/core.hpp"
+#include "crocoddyl/core/utils/stop-watch.hpp"
+
+namespace bp = boost::python;
+using namespace boost::python;
+
+namespace crocoddyl {
+namespace python {
+
+void stop_watch_report(int precision)
+{
+  getProfiler().report_all(precision);
+}
+
+long double stop_watch_get_average_time(const std::string & perf_name)
+{
+  return getProfiler().get_average_time(perf_name);
+}
+
+/** Returns minimum execution time of a certain performance */
+long double stop_watch_get_min_time(const std::string & perf_name)
+{
+  return getProfiler().get_min_time(perf_name);
+}
+
+/** Returns maximum execution time of a certain performance */
+long double stop_watch_get_max_time(const std::string & perf_name)
+{
+  return getProfiler().get_max_time(perf_name);
+}
+
+long double stop_watch_get_total_time(const std::string & perf_name)
+{
+  return getProfiler().get_total_time(perf_name);
+}
+
+void stop_watch_reset_all()
+{
+  getProfiler().reset_all();
+}
+
+void exposeStopWatch()
+{
+    bp::def("stop_watch_report", stop_watch_report,
+            "Report all the times measured by the shared stop-watch.");
+
+    bp::def("stop_watch_get_average_time", stop_watch_get_average_time,
+            "Get the average time measured by the shared stop-watch for the specified task.");
+
+    bp::def("stop_watch_get_min_time", stop_watch_get_min_time,
+            "Get the min time measured by the shared stop-watch for the specified task.");
+
+    bp::def("stop_watch_get_max_time", stop_watch_get_max_time,
+            "Get the max time measured by the shared stop-watch for the specified task.");
+
+    bp::def("stop_watch_get_total_time", stop_watch_get_total_time,
+            "Get the total time measured by the shared stop-watch for the specified task.");
+
+    bp::def("stop_watch_reset_all", stop_watch_reset_all,
+            "Reset the shared stop-watch.");
+}
+
+}  // namespace python
+}  // namespace crocoddyl

--- a/bindings/python/crocoddyl/core/utils/stop-watch.cpp
+++ b/bindings/python/crocoddyl/core/utils/stop-watch.cpp
@@ -15,57 +15,38 @@ using namespace boost::python;
 namespace crocoddyl {
 namespace python {
 
-void stop_watch_report(int precision)
-{
-  getProfiler().report_all(precision);
-}
+void stop_watch_report(int precision) { getProfiler().report_all(precision); }
 
-long double stop_watch_get_average_time(const std::string & perf_name)
-{
+long double stop_watch_get_average_time(const std::string& perf_name) {
   return getProfiler().get_average_time(perf_name);
 }
 
 /** Returns minimum execution time of a certain performance */
-long double stop_watch_get_min_time(const std::string & perf_name)
-{
-  return getProfiler().get_min_time(perf_name);
-}
+long double stop_watch_get_min_time(const std::string& perf_name) { return getProfiler().get_min_time(perf_name); }
 
 /** Returns maximum execution time of a certain performance */
-long double stop_watch_get_max_time(const std::string & perf_name)
-{
-  return getProfiler().get_max_time(perf_name);
-}
+long double stop_watch_get_max_time(const std::string& perf_name) { return getProfiler().get_max_time(perf_name); }
 
-long double stop_watch_get_total_time(const std::string & perf_name)
-{
-  return getProfiler().get_total_time(perf_name);
-}
+long double stop_watch_get_total_time(const std::string& perf_name) { return getProfiler().get_total_time(perf_name); }
 
-void stop_watch_reset_all()
-{
-  getProfiler().reset_all();
-}
+void stop_watch_reset_all() { getProfiler().reset_all(); }
 
-void exposeStopWatch()
-{
-    bp::def("stop_watch_report", stop_watch_report,
-            "Report all the times measured by the shared stop-watch.");
+void exposeStopWatch() {
+  bp::def("stop_watch_report", stop_watch_report, "Report all the times measured by the shared stop-watch.");
 
-    bp::def("stop_watch_get_average_time", stop_watch_get_average_time,
-            "Get the average time measured by the shared stop-watch for the specified task.");
+  bp::def("stop_watch_get_average_time", stop_watch_get_average_time,
+          "Get the average time measured by the shared stop-watch for the specified task.");
 
-    bp::def("stop_watch_get_min_time", stop_watch_get_min_time,
-            "Get the min time measured by the shared stop-watch for the specified task.");
+  bp::def("stop_watch_get_min_time", stop_watch_get_min_time,
+          "Get the min time measured by the shared stop-watch for the specified task.");
 
-    bp::def("stop_watch_get_max_time", stop_watch_get_max_time,
-            "Get the max time measured by the shared stop-watch for the specified task.");
+  bp::def("stop_watch_get_max_time", stop_watch_get_max_time,
+          "Get the max time measured by the shared stop-watch for the specified task.");
 
-    bp::def("stop_watch_get_total_time", stop_watch_get_total_time,
-            "Get the total time measured by the shared stop-watch for the specified task.");
+  bp::def("stop_watch_get_total_time", stop_watch_get_total_time,
+          "Get the total time measured by the shared stop-watch for the specified task.");
 
-    bp::def("stop_watch_reset_all", stop_watch_reset_all,
-            "Reset the shared stop-watch.");
+  bp::def("stop_watch_reset_all", stop_watch_reset_all, "Reset the shared stop-watch.");
 }
 
 }  // namespace python

--- a/bindings/python/crocoddyl/core/utils/stop-watch.hpp
+++ b/bindings/python/crocoddyl/core/utils/stop-watch.hpp
@@ -16,15 +16,15 @@ namespace python {
 
 void stop_watch_report(int precision);
 
-long double stop_watch_get_average_time(const std::string & perf_name);
+long double stop_watch_get_average_time(const std::string& perf_name);
 
 /** Returns minimum execution time of a certain performance */
-long double stop_watch_get_min_time(const std::string & perf_name);
+long double stop_watch_get_min_time(const std::string& perf_name);
 
 /** Returns maximum execution time of a certain performance */
-long double stop_watch_get_max_time(const std::string & perf_name);
+long double stop_watch_get_max_time(const std::string& perf_name);
 
-long double stop_watch_get_total_time(const std::string & perf_name);
+long double stop_watch_get_total_time(const std::string& perf_name);
 
 void stop_watch_reset_all();
 

--- a/bindings/python/crocoddyl/core/utils/stop-watch.hpp
+++ b/bindings/python/crocoddyl/core/utils/stop-watch.hpp
@@ -1,0 +1,33 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2019-2020, LAAS-CNRS, University of Edinburgh
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef BINDINGS_PYTHON_CROCODDYL_CORE_STOP_WATCH_HPP_
+#define BINDINGS_PYTHON_CROCODDYL_CORE_STOP_WATCH_HPP_
+
+//#include "crocoddyl/core/action-base.hpp"
+#include "crocoddyl/core/utils/stop-watch.hpp"
+
+namespace crocoddyl {
+namespace python {
+
+void stop_watch_report(int precision);
+
+long double stop_watch_get_average_time(const std::string & perf_name);
+
+/** Returns minimum execution time of a certain performance */
+long double stop_watch_get_min_time(const std::string & perf_name);
+
+/** Returns maximum execution time of a certain performance */
+long double stop_watch_get_max_time(const std::string & perf_name);
+
+long double stop_watch_get_total_time(const std::string & perf_name);
+
+void stop_watch_reset_all();
+
+}  // namespace python
+}  // namespace crocoddyl

--- a/bindings/python/crocoddyl/core/utils/stop-watch.hpp
+++ b/bindings/python/crocoddyl/core/utils/stop-watch.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2021, LAAS-CNRS, University of Edinburgh, University of Trento
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -9,7 +9,6 @@
 #ifndef BINDINGS_PYTHON_CROCODDYL_CORE_STOP_WATCH_HPP_
 #define BINDINGS_PYTHON_CROCODDYL_CORE_STOP_WATCH_HPP_
 
-//#include "crocoddyl/core/action-base.hpp"
 #include "crocoddyl/core/utils/stop-watch.hpp"
 
 namespace crocoddyl {

--- a/include/crocoddyl/core/utils/Stdafx.hh
+++ b/include/crocoddyl/core/utils/Stdafx.hh
@@ -1,0 +1,32 @@
+/*
+Copyright (c) 2010-2013 Tommaso Urli
+
+Tommaso Urli    tommaso.urli@uniud.it   University of Udine
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+#pragma once
+
+#include <iostream>
+#include <map>
+#include <ctime>
+#include <sstream>

--- a/include/crocoddyl/core/utils/stop-watch.hpp
+++ b/include/crocoddyl/core/utils/stop-watch.hpp
@@ -1,29 +1,25 @@
-/*
-Copyright (c) 2010-2013 Tommaso Urli
-
-Tommaso Urli    tommaso.urli@uniud.it   University of Udine
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-*/
-
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2010-2013 Tommaso Urli (tommaso.urli@uniud.it; University of Udine)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+///////////////////////////////////////////////////////////////////////////////
 
 #ifndef CROCODDYL_CORE_UTILS_STOPWATCH_H_
 #define CROCODDYL_CORE_UTILS_STOPWATCH_H_

--- a/include/crocoddyl/core/utils/stop-watch.hpp
+++ b/include/crocoddyl/core/utils/stop-watch.hpp
@@ -35,7 +35,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #pragma GCC visibility push(default)
 #endif
 
+// Uncomment the following line to activate the profiler
 //#define PROFILER_ACTIVE
+
 #ifdef PROFILER_ACTIVE
   #define START_PROFILER(name) getProfiler().start(name)
   #define STOP_PROFILER(name) getProfiler().stop(name)
@@ -63,7 +65,7 @@ enum StopwatchMode
   NONE	    = 0,  // Clock is not initialized
   CPU_TIME  = 1,  // Clock calculates time ranges using ctime and CLOCKS_PER_SEC
   REAL_TIME = 2   // Clock calculates time by asking the operating system how
-  // much real time passed
+                  // much real time passed
 };
 
 
@@ -161,72 +163,73 @@ enum StopwatchMode
 class Stopwatch {
 public:
 
-  /** Constructor */
+  /** @brief Constructor */
   Stopwatch(StopwatchMode _mode=NONE);
 
-  /** Destructor */
+  /** @brief Destructor */
   ~Stopwatch();
 
-  /** Tells if a performance with a certain ID exists */
+  /** @brief Tells if a performance with a certain ID exists */
   bool performance_exists(std::string perf_name);
 
-  /** Initialize stopwatch to use a certain time taking mode */
+  /** @brief Initialize stopwatch to use a certain time taking mode */
   void set_mode(StopwatchMode mode);
 
-  /** Start the stopwatch related to a certain piece of code */
-  void start(std::string perf_name);
+  /** @brief Start the stopwatch related to a certain piece of code */
+  void start(const std::string &perf_name);
 
-  /** Stops the stopwatch related to a certain piece of code */
-  void stop(std::string perf_name);
+  /** @brief Stops the stopwatch related to a certain piece of code */
+  void stop(const std::string &perf_name);
 
-  /** Stops the stopwatch related to a certain piece of code */
-  void pause(std::string perf_name);
+  /** @brief Stops the stopwatch related to a certain piece of code */
+  void pause(const std::string &perf_name);
 
-  /** Reset a certain performance record */
-  void reset(std::string perf_name);
+  /** @brief Reset a certain performance record */
+  void reset(const std::string &perf_name);
 
-  /** Resets all the performance records */
+  /** @brief Resets all the performance records */
   void reset_all();
 
-  /** Dump the data of a certain performance record */
-  void report(std::string perf_name, int precision=2,
+  /** @brief Dump the data of a certain performance record */
+  void report(const std::string &perf_name, int precision=2,
               std::ostream& output = std::cout);
 
-  /** Dump the data of all the performance records */
+  /** @brief Dump the data of all the performance records */
   void report_all(int precision=2, std::ostream& output = std::cout);
 
-  /** Returns total execution time of a certain performance */
-  long double get_total_time(std::string perf_name);
+  /** @brief Returns total execution time of a certain performance */
+  long double get_total_time(const std::string &perf_name);
 
-  /** Returns average execution time of a certain performance */
-  long double get_average_time(std::string perf_name);
+  /** @brief Returns average execution time of a certain performance */
+  long double get_average_time(const std::string &perf_name);
 
-  /** Returns minimum execution time of a certain performance */
-  long double get_min_time(std::string perf_name);
+  /** @brief Returns minimum execution time of a certain performance */
+  long double get_min_time(const std::string &perf_name);
 
-  /** Returns maximum execution time of a certain performance */
-  long double get_max_time(std::string perf_name);
+  /** @brief Returns maximum execution time of a certain performance */
+  long double get_max_time(const std::string &perf_name);
 
-  /** Return last measurement of a certain performance */
-  long double get_last_time(std::string perf_name);
+  /** @brief Return last measurement of a certain performance */
+  long double get_last_time(const std::string &perf_name);
 
-  /** Return the time since the start of the last measurement of a given
-      performance. */
-  long double get_time_so_far(std::string perf_name);
+  /** @brief Return the time since the start of the last measurement of a given
+      performance.
+  */
+  long double get_time_so_far(const std::string &perf_name);
 
-  /**	Turn off clock, all the Stopwatch::* methods return without doing
+  /** @brief Turn off clock, all the Stopwatch::* methods return without doing
         anything after this method is called. */
   void turn_off();
 
-  /** Turn on clock, restore clock operativity after a turn_off(). */
+  /** @brief Turn on clock, restore clock operativity after a turn_off(). */
   void turn_on();
 
-  /** Take time, depends on mode */
+  /** @brief Take time, depends on mode. */
   long double take_time();
 
 protected:
 
-  /** Struct to hold the performance data */
+  /** @brief Struct to hold the performance data */
   struct PerformanceData {
 
     PerformanceData() :
@@ -239,37 +242,18 @@ protected:
       stops(0) {
     }
 
-    /** Start time */
-    long double	clock_start;
-
-    /** Cumulative total time */
-    long double	total_time;
-
-    /** Minimum time */
-    long double	min_time;
-
-    /** Maximum time */
-    long double	max_time;
-
-    /** Last time */
-    long double last_time;
-
-    /** Tells if this performance has been paused, only for internal use */
-    bool paused;
-
-    /** How many cycles have been this stopwatch executed? */
-    int	stops;
+    long double	clock_start;  //!< Start time
+    long double	total_time;   //!< Cumulative total time
+    long double	min_time;     //!< Minimum time
+    long double	max_time;     //!< Maximum time
+    long double last_time;    //!< Last time
+    bool paused;              //!< Tells if this performance has been paused, only for internal use
+    int	stops;                //!< How many cycles have been this stopwatch executed?
   };
 
-  /** Flag to hold the clock's status */
-  bool active;
-
-  /** Time taking mode */
-  StopwatchMode mode;
-
-  /** Pointer to the dynamic structure which holds the collection of performance
-      data */
-  std::map<std::string, PerformanceData >* records_of;
+  bool active;                //!< Flag to hold the clock's status
+  StopwatchMode mode;         //!< Time taking mode
+  std::map<std::string, PerformanceData >* records_of; //!< Dynamic collection of performance data
 
 };
 

--- a/include/crocoddyl/core/utils/stop-watch.hpp
+++ b/include/crocoddyl/core/utils/stop-watch.hpp
@@ -35,11 +35,11 @@
 //#define PROFILER_ACTIVE
 
 #ifdef PROFILER_ACTIVE
-  #define START_PROFILER(name) getProfiler().start(name)
-  #define STOP_PROFILER(name) getProfiler().stop(name)
+#define START_PROFILER(name) getProfiler().start(name)
+#define STOP_PROFILER(name) getProfiler().stop(name)
 #else
-  #define START_PROFILER(name)
-  #define STOP_PROFILER(name)
+#define START_PROFILER(name)
+#define STOP_PROFILER(name)
 #endif
 
 #define STOP_WATCH_MAX_NAME_LENGTH 60
@@ -48,22 +48,18 @@
 namespace crocoddyl {
 
 // Generic stopwatch exception class
-struct StopwatchException
-{
-public:
-  StopwatchException(std::string error) : error(error) { }
+struct StopwatchException {
+ public:
+  StopwatchException(std::string error) : error(error) {}
   std::string error;
 };
 
-
-enum StopwatchMode
-{
-  NONE	    = 0,  // Clock is not initialized
-  CPU_TIME  = 1,  // Clock calculates time ranges using ctime and CLOCKS_PER_SEC
-  REAL_TIME = 2   // Clock calculates time by asking the operating system how
-                  // much real time passed
+enum StopwatchMode {
+  NONE = 0,      // Clock is not initialized
+  CPU_TIME = 1,  // Clock calculates time ranges using ctime and CLOCKS_PER_SEC
+  REAL_TIME = 2  // Clock calculates time by asking the operating system how
+                 // much real time passed
 };
-
 
 /**
     @brief A class representing a stopwatch.
@@ -157,10 +153,9 @@ enum StopwatchMode
 
 */
 class Stopwatch {
-public:
-
+ public:
   /** @brief Constructor */
-  Stopwatch(StopwatchMode _mode=NONE);
+  Stopwatch(StopwatchMode _mode = NONE);
 
   /** @brief Destructor */
   ~Stopwatch();
@@ -187,11 +182,10 @@ public:
   void reset_all();
 
   /** @brief Dump the data of a certain performance record */
-  void report(const std::string &perf_name, int precision=2,
-              std::ostream& output = std::cout);
+  void report(const std::string &perf_name, int precision = 2, std::ostream &output = std::cout);
 
   /** @brief Dump the data of all the performance records */
-  void report_all(int precision=2, std::ostream& output = std::cout);
+  void report_all(int precision = 2, std::ostream &output = std::cout);
 
   /** @brief Returns total execution time of a certain performance */
   long double get_total_time(const std::string &perf_name);
@@ -223,39 +217,29 @@ public:
   /** @brief Take time, depends on mode. */
   long double take_time();
 
-protected:
-
+ protected:
   /** @brief Struct to hold the performance data */
   struct PerformanceData {
+    PerformanceData()
+        : clock_start(0), total_time(0), min_time(0), max_time(0), last_time(0), paused(false), stops(0) {}
 
-    PerformanceData() :
-      clock_start(0),
-      total_time(0),
-      min_time(0),
-      max_time(0),
-      last_time(0),
-      paused(false),
-      stops(0) {
-    }
-
-    long double	clock_start;  //!< Start time
-    long double	total_time;   //!< Cumulative total time
-    long double	min_time;     //!< Minimum time
-    long double	max_time;     //!< Maximum time
+    long double clock_start;  //!< Start time
+    long double total_time;   //!< Cumulative total time
+    long double min_time;     //!< Minimum time
+    long double max_time;     //!< Maximum time
     long double last_time;    //!< Last time
     bool paused;              //!< Tells if this performance has been paused, only for internal use
-    int	stops;                //!< How many cycles have been this stopwatch executed?
+    int stops;                //!< How many cycles have been this stopwatch executed?
   };
 
-  bool active;                //!< Flag to hold the clock's status
-  StopwatchMode mode;         //!< Time taking mode
-  std::map<std::string, PerformanceData >* records_of; //!< Dynamic collection of performance data
-
+  bool active;                                         //!< Flag to hold the clock's status
+  StopwatchMode mode;                                  //!< Time taking mode
+  std::map<std::string, PerformanceData> *records_of;  //!< Dynamic collection of performance data
 };
 
-Stopwatch& getProfiler();
+Stopwatch &getProfiler();
 
-}
+}  // namespace crocoddyl
 
 #ifndef WIN32
 #pragma GCC visibility pop

--- a/include/crocoddyl/core/utils/stop-watch.hpp
+++ b/include/crocoddyl/core/utils/stop-watch.hpp
@@ -1,0 +1,284 @@
+/*
+Copyright (c) 2010-2013 Tommaso Urli
+
+Tommaso Urli    tommaso.urli@uniud.it   University of Udine
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+
+#ifndef CROCODDYL_CORE_UTILS_STOPWATCH_H_
+#define CROCODDYL_CORE_UTILS_STOPWATCH_H_
+
+#include "crocoddyl/core/utils/Stdafx.hh"
+
+#ifndef WIN32
+/* The classes below are exported */
+#pragma GCC visibility push(default)
+#endif
+
+//#define PROFILER_ACTIVE
+#ifdef PROFILER_ACTIVE
+  #define START_PROFILER(name) getProfiler().start(name)
+  #define STOP_PROFILER(name) getProfiler().stop(name)
+#else
+  #define START_PROFILER(name)
+  #define STOP_PROFILER(name)
+#endif
+
+#define STOP_WATCH_MAX_NAME_LENGTH 60
+#define STOP_WATCH_TIME_WIDTH 10
+
+namespace crocoddyl {
+
+// Generic stopwatch exception class
+struct StopwatchException
+{
+public:
+  StopwatchException(std::string error) : error(error) { }
+  std::string error;
+};
+
+
+enum StopwatchMode
+{
+  NONE	    = 0,  // Clock is not initialized
+  CPU_TIME  = 1,  // Clock calculates time ranges using ctime and CLOCKS_PER_SEC
+  REAL_TIME = 2   // Clock calculates time by asking the operating system how
+  // much real time passed
+};
+
+
+/**
+    @brief A class representing a stopwatch.
+
+    @code
+    Stopwatch swatch();
+    @endcode
+
+    The Stopwatch class can be used to measure execution time of code,
+    algorithms, etc., // TODO: he Stopwatch can be initialized in two
+    time-taking modes, CPU time and real time:
+
+    @code
+    swatch.set_mode(REAL_TIME);
+    @endcode
+
+    CPU time is the time spent by the processor on a certain piece of code,
+    while real time is the real amount of time taken by a certain piece of
+    code to execute (i.e. in general if you are doing hard work such as
+    image or video editing on a different process the measured time will
+    probably increase).
+
+    How does it work? Basically, one wraps the code to be measured with the
+    following method calls:
+
+    @code
+    swatch.start("My astounding algorithm");
+    // Hic est code
+    swatch.stop("My astounding algorithm");
+    @endcode
+
+    A string representing the code ID is provided so that nested portions of
+    code can be profiled separately:
+
+    @code
+    swatch.start("My astounding algorithm");
+
+    swatch.start("My astounding algorithm - Super smart init");
+    // Initialization
+    swatch.stop("My astounding algorithm - Super smart init");
+
+    swatch.start("My astounding algorithm - Main loop");
+    // Loop
+    swatch.stop("My astounding algorithm - Main loop");
+
+    swatch.stop("My astounding algorithm");
+    @endcode
+
+    Note: ID strings can be whatever you like, in the previous example I have
+    used "My astounding algorithm - *" only to enforce the fact that the
+    measured code portions are part of My astounding algorithm, but there's no
+    connection between the three measurements.
+
+    If the code for a certain task is scattered through different files or
+    portions of the same file one can use the start-pause-stop method:
+
+    @code
+    swatch.start("Setup");
+    // First part of setup
+    swatch.pause("Setup");
+
+    swatch.start("Main logic");
+    // Main logic
+    swatch.stop("Main logic");
+
+    swatch.start("Setup");
+    // Cleanup (part of the setup)
+    swatch.stop("Setup");
+    @endcode
+
+    Finally, to report the results of the measurements just run:
+
+    @code
+    swatch.report("Code ID");
+    @endcode
+
+    Thou can also provide an additional std::ostream& parameter to report() to
+    redirect the logging on a different output. Also, you can use the
+    get_total/min/max/average_time() methods to get the individual numeric data,
+    without all the details of the logging. You can also extend Stopwatch to
+    implement your own logging syntax.
+
+    To report all the measurements:
+
+    @code
+    swatch.report_all();
+    @endcode
+
+    Same as above, you can redirect the output by providing a std::ostream&
+    parameter.
+
+*/
+class Stopwatch {
+public:
+
+  /** Constructor */
+  Stopwatch(StopwatchMode _mode=NONE);
+
+  /** Destructor */
+  ~Stopwatch();
+
+  /** Tells if a performance with a certain ID exists */
+  bool performance_exists(std::string perf_name);
+
+  /** Initialize stopwatch to use a certain time taking mode */
+  void set_mode(StopwatchMode mode);
+
+  /** Start the stopwatch related to a certain piece of code */
+  void start(std::string perf_name);
+
+  /** Stops the stopwatch related to a certain piece of code */
+  void stop(std::string perf_name);
+
+  /** Stops the stopwatch related to a certain piece of code */
+  void pause(std::string perf_name);
+
+  /** Reset a certain performance record */
+  void reset(std::string perf_name);
+
+  /** Resets all the performance records */
+  void reset_all();
+
+  /** Dump the data of a certain performance record */
+  void report(std::string perf_name, int precision=2,
+              std::ostream& output = std::cout);
+
+  /** Dump the data of all the performance records */
+  void report_all(int precision=2, std::ostream& output = std::cout);
+
+  /** Returns total execution time of a certain performance */
+  long double get_total_time(std::string perf_name);
+
+  /** Returns average execution time of a certain performance */
+  long double get_average_time(std::string perf_name);
+
+  /** Returns minimum execution time of a certain performance */
+  long double get_min_time(std::string perf_name);
+
+  /** Returns maximum execution time of a certain performance */
+  long double get_max_time(std::string perf_name);
+
+  /** Return last measurement of a certain performance */
+  long double get_last_time(std::string perf_name);
+
+  /** Return the time since the start of the last measurement of a given
+      performance. */
+  long double get_time_so_far(std::string perf_name);
+
+  /**	Turn off clock, all the Stopwatch::* methods return without doing
+        anything after this method is called. */
+  void turn_off();
+
+  /** Turn on clock, restore clock operativity after a turn_off(). */
+  void turn_on();
+
+  /** Take time, depends on mode */
+  long double take_time();
+
+protected:
+
+  /** Struct to hold the performance data */
+  struct PerformanceData {
+
+    PerformanceData() :
+      clock_start(0),
+      total_time(0),
+      min_time(0),
+      max_time(0),
+      last_time(0),
+      paused(false),
+      stops(0) {
+    }
+
+    /** Start time */
+    long double	clock_start;
+
+    /** Cumulative total time */
+    long double	total_time;
+
+    /** Minimum time */
+    long double	min_time;
+
+    /** Maximum time */
+    long double	max_time;
+
+    /** Last time */
+    long double last_time;
+
+    /** Tells if this performance has been paused, only for internal use */
+    bool paused;
+
+    /** How many cycles have been this stopwatch executed? */
+    int	stops;
+  };
+
+  /** Flag to hold the clock's status */
+  bool active;
+
+  /** Time taking mode */
+  StopwatchMode mode;
+
+  /** Pointer to the dynamic structure which holds the collection of performance
+      data */
+  std::map<std::string, PerformanceData >* records_of;
+
+};
+
+Stopwatch& getProfiler();
+
+}
+
+#ifndef WIN32
+#pragma GCC visibility pop
+#endif
+
+#endif

--- a/src/core/solvers/ddp.cpp
+++ b/src/core/solvers/ddp.cpp
@@ -13,6 +13,7 @@
 
 #include "crocoddyl/core/solvers/ddp.hpp"
 #include "crocoddyl/core/utils/exception.hpp"
+#include "crocoddyl/core/utils/stop-watch.hpp"
 
 namespace crocoddyl {
 
@@ -124,10 +125,12 @@ bool SolverDDP::solve(const std::vector<Eigen::VectorXd>& init_xs, const std::ve
 }
 
 void SolverDDP::computeDirection(const bool recalcDiff) {
+  START_PROFILER("SolverDDP::computeDirection");
   if (recalcDiff) {
     calcDiff();
   }
   backwardPass();
+  STOP_PROFILER("SolverDDP::computeDirection");
 }
 
 double SolverDDP::tryStep(const double steplength) {
@@ -167,6 +170,7 @@ const Eigen::Vector2d& SolverDDP::expectedImprovement() {
 }
 
 double SolverDDP::calcDiff() {
+  START_PROFILER("SolverDDP::calcDiff");
   if (iter_ == 0) problem_->calc(xs_, us_);
   cost_ = problem_->calcDiff(xs_, us_);
 
@@ -204,10 +208,12 @@ double SolverDDP::calcDiff() {
       it->setZero();
     }
   }
+  STOP_PROFILER("SolverDDP::calcDiff");
   return cost_;
 }
 
 void SolverDDP::backwardPass() {
+  START_PROFILER("SolverDDP::backwardPass");
   const boost::shared_ptr<ActionDataAbstract>& d_T = problem_->get_terminalData();
   Vxx_.back() = d_T->Lxx;
   Vx_.back() = d_T->Lx;
@@ -230,16 +236,22 @@ void SolverDDP::backwardPass() {
 
     Qxx_[t] = d->Lxx;
     Qx_[t] = d->Lx;
+    START_PROFILER("SolverDDP::Qxx");
     FxTVxx_p_.noalias() = d->Fx.transpose() * Vxx_p;
     Qxx_[t].noalias() += FxTVxx_p_ * d->Fx;
+    STOP_PROFILER("SolverDDP::Qxx");
     Qx_[t].noalias() += d->Fx.transpose() * Vx_p;
     if (nu != 0) {
       Qxu_[t].leftCols(nu) = d->Lxu;
       Quu_[t].topLeftCorner(nu, nu) = d->Luu;
       Qu_[t].head(nu) = d->Lu;
-      FuTVxx_p_[t].topRows(nu).noalias() = d->Fu.transpose() * Vxx_p;
+      START_PROFILER("SolverDDP::Qxu");
       Qxu_[t].leftCols(nu).noalias() += FxTVxx_p_ * d->Fu;
+      STOP_PROFILER("SolverDDP::Qxu");
+      START_PROFILER("SolverDDP::Quu");
+      FuTVxx_p_[t].topRows(nu).noalias() = d->Fu.transpose() * Vxx_p;
       Quu_[t].topLeftCorner(nu, nu).noalias() += FuTVxx_p_[t].topRows(nu) * d->Fu;
+      STOP_PROFILER("SolverDDP::Quu");
       Qu_[t].head(nu).noalias() += d->Fu.transpose() * Vx_p;
 
       if (!std::isnan(ureg_)) {
@@ -259,7 +271,9 @@ void SolverDDP::backwardPass() {
         Vx_[t].noalias() += K_[t].topRows(nu).transpose() * Quuk_[t].head(nu);
         Vx_[t].noalias() -= 2 * (K_[t].topRows(nu).transpose() * Qu_[t].head(nu));
       }
+      START_PROFILER("SolverDDP::Vxx");
       Vxx_[t].noalias() -= Qxu_[t].leftCols(nu) * K_[t].topRows(nu);
+      STOP_PROFILER("SolverDDP::Vxx");
     }
     Vxx_[t] = 0.5 * (Vxx_[t] + Vxx_[t].transpose()).eval();
 
@@ -279,9 +293,11 @@ void SolverDDP::backwardPass() {
       throw_pretty("backward_error");
     }
   }
+  STOP_PROFILER("SolverDDP::backwardPass");
 }
 
 void SolverDDP::forwardPass(const double steplength) {
+  START_PROFILER("SolverDDP::forwardPass");
   if (steplength > 1. || steplength < 0.) {
     throw_pretty("Invalid argument: "
                  << "invalid step length, value is between 0. to 1.");
@@ -324,12 +340,16 @@ void SolverDDP::forwardPass(const double steplength) {
   if (raiseIfNaN(cost_try_)) {
     throw_pretty("forward_error");
   }
+  STOP_PROFILER("SolverDDP::forwardPass");
 }
 
 void SolverDDP::computeGains(const std::size_t t) {
+  START_PROFILER("SolverDDP::computeGains");
   const std::size_t nu = problem_->get_runningModels()[t]->get_nu();
   if (nu > 0) {
+    START_PROFILER("SolverDDP::Quu_inv");
     Quu_llt_[t].compute(Quu_[t].topLeftCorner(nu, nu));
+    STOP_PROFILER("SolverDDP::Quu_inv");
     const Eigen::ComputationInfo& info = Quu_llt_[t].info();
     if (info != Eigen::Success) {
       throw_pretty("backward_error");
@@ -337,11 +357,14 @@ void SolverDDP::computeGains(const std::size_t t) {
     K_[t].topRows(nu).noalias() = Qxu_[t].leftCols(nu).transpose();
 
     Eigen::Block<Eigen::MatrixXd> K = K_[t].topRows(nu);
+    START_PROFILER("SolverDDP::Quu_solve");
     Quu_llt_[t].solveInPlace(K);
+    STOP_PROFILER("SolverDDP::Quu_solve");
     k_[t].head(nu) = Qu_[t].head(nu);
     Eigen::VectorBlock<Eigen::VectorXd, Eigen::Dynamic> k = k_[t].head(nu);
     Quu_llt_[t].solveInPlace(k);
   }
+  STOP_PROFILER("SolverDDP::computeGains");
 }
 
 void SolverDDP::increaseRegularization() {

--- a/src/core/solvers/ddp.cpp
+++ b/src/core/solvers/ddp.cpp
@@ -357,9 +357,9 @@ void SolverDDP::computeGains(const std::size_t t) {
     K_[t].topRows(nu).noalias() = Qxu_[t].leftCols(nu).transpose();
 
     Eigen::Block<Eigen::MatrixXd> K = K_[t].topRows(nu);
-    START_PROFILER("SolverDDP::Quu_solve");
+    START_PROFILER("SolverDDP::Quu_inv_Qux");
     Quu_llt_[t].solveInPlace(K);
-    STOP_PROFILER("SolverDDP::Quu_solve");
+    STOP_PROFILER("SolverDDP::Quu_inv_Qux");
     k_[t].head(nu) = Qu_[t].head(nu);
     Eigen::VectorBlock<Eigen::VectorXd, Eigen::Dynamic> k = k_[t].head(nu);
     Quu_llt_[t].solveInPlace(k);

--- a/src/core/utils/stop-watch.cpp
+++ b/src/core/utils/stop-watch.cpp
@@ -1,0 +1,352 @@
+/*
+Copyright (c) 2010-2013 Tommaso Urli
+
+Tommaso Urli    tommaso.urli@uniud.it   University of Udine
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+#include "crocoddyl/core/utils/Stdafx.hh"
+
+#ifndef WIN32
+    #include <sys/time.h>
+#else
+    #include <Windows.h>
+    #include <iomanip>
+#endif
+
+#include <iomanip>      // std::setprecision
+#include "crocoddyl/core/utils/stop-watch.hpp"
+
+using std::map;
+using std::string;
+using std::ostringstream;
+
+namespace crocoddyl {
+
+Stopwatch& getProfiler()
+{
+  static Stopwatch s(REAL_TIME);   // alternatives are CPU_TIME and REAL_TIME
+  return s;
+}
+
+Stopwatch::Stopwatch(StopwatchMode _mode)
+  : active(true), mode(_mode)
+{
+  records_of = new map<string, PerformanceData>();
+}
+
+Stopwatch::~Stopwatch()
+{
+  delete records_of;
+}
+
+void Stopwatch::set_mode(StopwatchMode new_mode)
+{
+  mode = new_mode;
+}
+
+bool Stopwatch::performance_exists(string perf_name)
+{
+  return (records_of->find(perf_name) != records_of->end());
+}
+
+long double Stopwatch::take_time()
+{
+  if ( mode == CPU_TIME ) {
+
+    // Use ctime
+    return clock();
+
+  } else if ( mode == REAL_TIME ) {
+
+    // Query operating system
+
+#ifdef WIN32
+    /*	In case of usage under Windows */
+    FILETIME ft;
+    LARGE_INTEGER intervals;
+
+    // Get the amount of 100 nanoseconds intervals elapsed since January 1, 1601
+    // (UTC)
+    GetSystemTimeAsFileTime(&ft);
+    intervals.LowPart = ft.dwLowDateTime;
+    intervals.HighPart = ft.dwHighDateTime;
+
+    long double measure = intervals.QuadPart;
+    measure -= 116444736000000000.0;	// Convert to UNIX epoch time
+    measure /= 10000000.0;		// Convert to seconds
+
+    return measure;
+#else
+    /* Linux, MacOS, ... */
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+
+    long double measure = tv.tv_usec;
+    measure /= 1000000.0;		// Convert to seconds
+    measure += tv.tv_sec;		// Add seconds part
+
+    return measure;
+#endif
+
+  } else {
+    // If mode == NONE, clock has not been initialized, then throw exception
+    throw StopwatchException("Clock not initialized to a time taking mode!");
+  }
+}
+
+void Stopwatch::start(string perf_name)
+{
+  if (!active) return;
+
+  // Just works if not already present
+  records_of->insert(make_pair(perf_name, PerformanceData()));
+
+  PerformanceData& perf_info = records_of->find(perf_name)->second;
+
+  // Take ctime
+  perf_info.clock_start = take_time();
+
+  // If this is a new start (i.e. not a restart)
+//  if (!perf_info.paused)
+//    perf_info.last_time = 0;
+
+  perf_info.paused = false;
+}
+
+void Stopwatch::stop(string perf_name)
+{
+  if (!active) return;
+
+  long double clock_end = take_time();
+
+  // Try to recover performance data
+  if ( !performance_exists(perf_name) )
+    throw StopwatchException("Performance not initialized.");
+
+  PerformanceData& perf_info = records_of->find(perf_name)->second;
+
+  // check whether the performance has been reset
+  if(perf_info.clock_start==0)
+    return;
+
+  perf_info.stops++;
+  long double  lapse = clock_end - perf_info.clock_start;
+
+  if ( mode == CPU_TIME )
+    lapse /= (double) CLOCKS_PER_SEC;
+
+  // Update last time
+  perf_info.last_time = lapse;
+
+  // Update min/max time
+  if ( lapse >= perf_info.max_time )	perf_info.max_time = lapse;
+  if ( lapse <= perf_info.min_time || perf_info.min_time == 0 )
+    perf_info.min_time = lapse;
+
+  // Update total time
+  perf_info.total_time += lapse;
+}
+
+void Stopwatch::pause(string perf_name)
+{
+  if (!active) return;
+
+  long double  clock_end = clock();
+
+  // Try to recover performance data
+  if ( !performance_exists(perf_name)  )
+    throw StopwatchException("Performance not initialized.");
+
+  PerformanceData& perf_info = records_of->find(perf_name)->second;
+
+  // check whether the performance has been reset
+  if(perf_info.clock_start==0)
+    return;
+
+  long double  lapse = clock_end - perf_info.clock_start;
+
+  // Update total time
+  perf_info.last_time += lapse;
+  perf_info.total_time += lapse;
+}
+
+void Stopwatch::reset_all()
+{
+  if (!active) return;
+
+  map<string, PerformanceData>::iterator it;
+
+  for (it = records_of->begin(); it != records_of->end(); ++it) {
+    reset(it->first);
+  }
+}
+
+void Stopwatch::report_all(int precision, std::ostream& output)
+{
+  if (!active) return;
+
+  output<< "\n"<< std::setw(STOP_WATCH_MAX_NAME_LENGTH)<< std::left<< "*** PROFILING RESULTS [ms] ";
+  output<< std::setw(STOP_WATCH_TIME_WIDTH)<<"min"<<" ";
+  output<< std::setw(STOP_WATCH_TIME_WIDTH)<<"avg"<<" ";
+  output<< std::setw(STOP_WATCH_TIME_WIDTH)<<"max"<<" ";
+  output<< std::setw(STOP_WATCH_TIME_WIDTH)<<"lastTime"<<" ";
+  output<< std::setw(STOP_WATCH_TIME_WIDTH)<<"nSamples"<<" ";
+  output<< std::setw(STOP_WATCH_TIME_WIDTH)<<"totalTime"<< " ***\n";
+  map<string, PerformanceData>::iterator it;
+  for (it = records_of->begin(); it != records_of->end(); ++it) {
+    if(it->second.stops>0)
+      report(it->first, precision, output);
+  }
+}
+
+void Stopwatch::reset(string perf_name)
+{
+  if (!active) return;
+
+  // Try to recover performance data
+  if ( !performance_exists(perf_name)  )
+    throw StopwatchException("Performance not initialized.");
+
+  PerformanceData& perf_info = records_of->find(perf_name)->second;
+
+  perf_info.clock_start = 0;
+  perf_info.total_time = 0;
+  perf_info.min_time = 0;
+  perf_info.max_time = 0;
+  perf_info.last_time = 0;
+  perf_info.paused = false;
+  perf_info.stops = 0;
+}
+
+void Stopwatch::turn_on()
+{
+  std::cout << "Stopwatch active." << std::endl;
+  active = true;
+}
+
+void Stopwatch::turn_off()
+{
+  std::cout << "Stopwatch inactive." << std::endl;
+  active = false;
+}
+
+void Stopwatch::report(string perf_name, int precision, std::ostream& output)
+{
+  if (!active) return;
+
+  // Try to recover performance data
+  if ( !performance_exists(perf_name)  )
+    throw StopwatchException("Performance not initialized.");
+
+  PerformanceData& perf_info = records_of->find(perf_name)->second;
+
+  output << std::setw(STOP_WATCH_MAX_NAME_LENGTH) << std::left<< perf_name;
+  output << std::fixed << std::setprecision(precision) <<  std::setw(STOP_WATCH_TIME_WIDTH)
+         << (perf_info.min_time*1e3) << " ";
+  output << std::fixed << std::setprecision(precision) <<  std::setw(STOP_WATCH_TIME_WIDTH)
+         << (perf_info.total_time*1e3 / (long double) perf_info.stops) << " ";
+  output << std::fixed << std::setprecision(precision) <<  std::setw(STOP_WATCH_TIME_WIDTH)
+         << (perf_info.max_time*1e3) << " ";
+  output << std::fixed << std::setprecision(precision) <<  std::setw(STOP_WATCH_TIME_WIDTH)
+         << (perf_info.last_time*1e3) << " ";
+  output << std::fixed << std::setprecision(precision) <<  std::setw(STOP_WATCH_TIME_WIDTH)
+         << perf_info.stops << " ";
+  output << std::fixed << std::setprecision(precision) <<  std::setw(STOP_WATCH_TIME_WIDTH)
+         << perf_info.total_time*1e3 << std::endl;
+}
+
+long double Stopwatch::get_time_so_far(string perf_name)
+{
+  // Try to recover performance data
+  if ( !performance_exists(perf_name)  )
+    throw StopwatchException("Performance not initialized.");
+
+  long double lapse =
+    (take_time() - (records_of->find(perf_name)->second).clock_start);
+
+  if (mode == CPU_TIME)
+    lapse /= (double) CLOCKS_PER_SEC;
+
+  return lapse;
+}
+
+long double Stopwatch::get_total_time(string perf_name)
+{
+  // Try to recover performance data
+  if ( !performance_exists(perf_name)  )
+    throw StopwatchException("Performance not initialized.");
+
+  PerformanceData& perf_info = records_of->find(perf_name)->second;
+
+  return perf_info.total_time;
+
+}
+
+long double Stopwatch::get_average_time(string perf_name)
+{
+  // Try to recover performance data
+  if ( !performance_exists(perf_name)  )
+    throw StopwatchException("Performance not initialized.");
+
+  PerformanceData& perf_info = records_of->find(perf_name)->second;
+
+  return (perf_info.total_time / (long double)perf_info.stops);
+
+}
+
+long double Stopwatch::get_min_time(string perf_name)
+{
+  // Try to recover performance data
+  if ( !performance_exists(perf_name)  )
+    throw StopwatchException("Performance not initialized.");
+
+  PerformanceData& perf_info = records_of->find(perf_name)->second;
+
+  return perf_info.min_time;
+
+}
+
+long double Stopwatch::get_max_time(string perf_name)
+{
+  // Try to recover performance data
+  if ( !performance_exists(perf_name)  )
+    throw StopwatchException("Performance not initialized.");
+
+  PerformanceData& perf_info = records_of->find(perf_name)->second;
+
+  return perf_info.max_time;
+
+}
+
+long double Stopwatch::get_last_time(string perf_name)
+{
+  // Try to recover performance data
+  if ( !performance_exists(perf_name)  )
+    throw StopwatchException("Performance not initialized.");
+
+  PerformanceData& perf_info = records_of->find(perf_name)->second;
+
+  return perf_info.last_time;
+}
+
+} // end namespace crocoddyl

--- a/src/core/utils/stop-watch.cpp
+++ b/src/core/utils/stop-watch.cpp
@@ -114,7 +114,7 @@ long double Stopwatch::take_time()
   }
 }
 
-void Stopwatch::start(string perf_name)
+void Stopwatch::start(const string &perf_name)
 {
   if (!active) return;
 
@@ -133,7 +133,7 @@ void Stopwatch::start(string perf_name)
   perf_info.paused = false;
 }
 
-void Stopwatch::stop(string perf_name)
+void Stopwatch::stop(const string &perf_name)
 {
   if (!active) return;
 
@@ -167,7 +167,7 @@ void Stopwatch::stop(string perf_name)
   perf_info.total_time += lapse;
 }
 
-void Stopwatch::pause(string perf_name)
+void Stopwatch::pause(const string &perf_name)
 {
   if (!active) return;
 
@@ -219,7 +219,7 @@ void Stopwatch::report_all(int precision, std::ostream& output)
   }
 }
 
-void Stopwatch::reset(string perf_name)
+void Stopwatch::reset(const string &perf_name)
 {
   if (!active) return;
 
@@ -250,7 +250,7 @@ void Stopwatch::turn_off()
   active = false;
 }
 
-void Stopwatch::report(string perf_name, int precision, std::ostream& output)
+void Stopwatch::report(const string &perf_name, int precision, std::ostream& output)
 {
   if (!active) return;
 
@@ -275,7 +275,7 @@ void Stopwatch::report(string perf_name, int precision, std::ostream& output)
          << perf_info.total_time*1e3 << std::endl;
 }
 
-long double Stopwatch::get_time_so_far(string perf_name)
+long double Stopwatch::get_time_so_far(const string &perf_name)
 {
   // Try to recover performance data
   if ( !performance_exists(perf_name)  )
@@ -290,7 +290,7 @@ long double Stopwatch::get_time_so_far(string perf_name)
   return lapse;
 }
 
-long double Stopwatch::get_total_time(string perf_name)
+long double Stopwatch::get_total_time(const string &perf_name)
 {
   // Try to recover performance data
   if ( !performance_exists(perf_name)  )
@@ -302,7 +302,7 @@ long double Stopwatch::get_total_time(string perf_name)
 
 }
 
-long double Stopwatch::get_average_time(string perf_name)
+long double Stopwatch::get_average_time(const string &perf_name)
 {
   // Try to recover performance data
   if ( !performance_exists(perf_name)  )
@@ -314,7 +314,7 @@ long double Stopwatch::get_average_time(string perf_name)
 
 }
 
-long double Stopwatch::get_min_time(string perf_name)
+long double Stopwatch::get_min_time(const string &perf_name)
 {
   // Try to recover performance data
   if ( !performance_exists(perf_name)  )
@@ -326,7 +326,7 @@ long double Stopwatch::get_min_time(string perf_name)
 
 }
 
-long double Stopwatch::get_max_time(string perf_name)
+long double Stopwatch::get_max_time(const string &perf_name)
 {
   // Try to recover performance data
   if ( !performance_exists(perf_name)  )
@@ -338,7 +338,7 @@ long double Stopwatch::get_max_time(string perf_name)
 
 }
 
-long double Stopwatch::get_last_time(string perf_name)
+long double Stopwatch::get_last_time(const string &perf_name)
 {
   // Try to recover performance data
   if ( !performance_exists(perf_name)  )

--- a/src/core/utils/stop-watch.cpp
+++ b/src/core/utils/stop-watch.cpp
@@ -1,28 +1,25 @@
-/*
-Copyright (c) 2010-2013 Tommaso Urli
-
-Tommaso Urli    tommaso.urli@uniud.it   University of Udine
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-*/
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2010-2013 Tommaso Urli (tommaso.urli@uniud.it; University of Udine)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+///////////////////////////////////////////////////////////////////////////////
 
 #include "crocoddyl/core/utils/Stdafx.hh"
 

--- a/src/core/utils/stop-watch.cpp
+++ b/src/core/utils/stop-watch.cpp
@@ -24,57 +24,42 @@
 #include "crocoddyl/core/utils/Stdafx.hh"
 
 #ifndef WIN32
-    #include <sys/time.h>
+#include <sys/time.h>
 #else
-    #include <Windows.h>
-    #include <iomanip>
+#include <Windows.h>
+#include <iomanip>
 #endif
 
-#include <iomanip>      // std::setprecision
+#include <iomanip>  // std::setprecision
 #include "crocoddyl/core/utils/stop-watch.hpp"
 
 using std::map;
-using std::string;
 using std::ostringstream;
+using std::string;
 
 namespace crocoddyl {
 
-Stopwatch& getProfiler()
-{
-  static Stopwatch s(REAL_TIME);   // alternatives are CPU_TIME and REAL_TIME
+Stopwatch& getProfiler() {
+  static Stopwatch s(REAL_TIME);  // alternatives are CPU_TIME and REAL_TIME
   return s;
 }
 
-Stopwatch::Stopwatch(StopwatchMode _mode)
-  : active(true), mode(_mode)
-{
+Stopwatch::Stopwatch(StopwatchMode _mode) : active(true), mode(_mode) {
   records_of = new map<string, PerformanceData>();
 }
 
-Stopwatch::~Stopwatch()
-{
-  delete records_of;
-}
+Stopwatch::~Stopwatch() { delete records_of; }
 
-void Stopwatch::set_mode(StopwatchMode new_mode)
-{
-  mode = new_mode;
-}
+void Stopwatch::set_mode(StopwatchMode new_mode) { mode = new_mode; }
 
-bool Stopwatch::performance_exists(string perf_name)
-{
-  return (records_of->find(perf_name) != records_of->end());
-}
+bool Stopwatch::performance_exists(string perf_name) { return (records_of->find(perf_name) != records_of->end()); }
 
-long double Stopwatch::take_time()
-{
-  if ( mode == CPU_TIME ) {
-
+long double Stopwatch::take_time() {
+  if (mode == CPU_TIME) {
     // Use ctime
     return clock();
 
-  } else if ( mode == REAL_TIME ) {
-
+  } else if (mode == REAL_TIME) {
     // Query operating system
 
 #ifdef WIN32
@@ -89,8 +74,8 @@ long double Stopwatch::take_time()
     intervals.HighPart = ft.dwHighDateTime;
 
     long double measure = intervals.QuadPart;
-    measure -= 116444736000000000.0;	// Convert to UNIX epoch time
-    measure /= 10000000.0;		// Convert to seconds
+    measure -= 116444736000000000.0;  // Convert to UNIX epoch time
+    measure /= 10000000.0;            // Convert to seconds
 
     return measure;
 #else
@@ -99,8 +84,8 @@ long double Stopwatch::take_time()
     gettimeofday(&tv, NULL);
 
     long double measure = tv.tv_usec;
-    measure /= 1000000.0;		// Convert to seconds
-    measure += tv.tv_sec;		// Add seconds part
+    measure /= 1000000.0;  // Convert to seconds
+    measure += tv.tv_sec;  // Add seconds part
 
     return measure;
 #endif
@@ -111,8 +96,7 @@ long double Stopwatch::take_time()
   }
 }
 
-void Stopwatch::start(const string &perf_name)
-{
+void Stopwatch::start(const string& perf_name) {
   if (!active) return;
 
   // Just works if not already present
@@ -124,71 +108,62 @@ void Stopwatch::start(const string &perf_name)
   perf_info.clock_start = take_time();
 
   // If this is a new start (i.e. not a restart)
-//  if (!perf_info.paused)
-//    perf_info.last_time = 0;
+  //  if (!perf_info.paused)
+  //    perf_info.last_time = 0;
 
   perf_info.paused = false;
 }
 
-void Stopwatch::stop(const string &perf_name)
-{
+void Stopwatch::stop(const string& perf_name) {
   if (!active) return;
 
   long double clock_end = take_time();
 
   // Try to recover performance data
-  if ( !performance_exists(perf_name) )
-    throw StopwatchException("Performance not initialized.");
+  if (!performance_exists(perf_name)) throw StopwatchException("Performance not initialized.");
 
   PerformanceData& perf_info = records_of->find(perf_name)->second;
 
   // check whether the performance has been reset
-  if(perf_info.clock_start==0)
-    return;
+  if (perf_info.clock_start == 0) return;
 
   perf_info.stops++;
-  long double  lapse = clock_end - perf_info.clock_start;
+  long double lapse = clock_end - perf_info.clock_start;
 
-  if ( mode == CPU_TIME )
-    lapse /= (double) CLOCKS_PER_SEC;
+  if (mode == CPU_TIME) lapse /= (double)CLOCKS_PER_SEC;
 
   // Update last time
   perf_info.last_time = lapse;
 
   // Update min/max time
-  if ( lapse >= perf_info.max_time )	perf_info.max_time = lapse;
-  if ( lapse <= perf_info.min_time || perf_info.min_time == 0 )
-    perf_info.min_time = lapse;
+  if (lapse >= perf_info.max_time) perf_info.max_time = lapse;
+  if (lapse <= perf_info.min_time || perf_info.min_time == 0) perf_info.min_time = lapse;
 
   // Update total time
   perf_info.total_time += lapse;
 }
 
-void Stopwatch::pause(const string &perf_name)
-{
+void Stopwatch::pause(const string& perf_name) {
   if (!active) return;
 
-  long double  clock_end = clock();
+  long double clock_end = clock();
 
   // Try to recover performance data
-  if ( !performance_exists(perf_name)  )
-    throw StopwatchException("Performance not initialized.");
+  if (!performance_exists(perf_name)) throw StopwatchException("Performance not initialized.");
 
   PerformanceData& perf_info = records_of->find(perf_name)->second;
 
   // check whether the performance has been reset
-  if(perf_info.clock_start==0)
-    return;
+  if (perf_info.clock_start == 0) return;
 
-  long double  lapse = clock_end - perf_info.clock_start;
+  long double lapse = clock_end - perf_info.clock_start;
 
   // Update total time
   perf_info.last_time += lapse;
   perf_info.total_time += lapse;
 }
 
-void Stopwatch::reset_all()
-{
+void Stopwatch::reset_all() {
   if (!active) return;
 
   map<string, PerformanceData>::iterator it;
@@ -198,31 +173,33 @@ void Stopwatch::reset_all()
   }
 }
 
-void Stopwatch::report_all(int precision, std::ostream& output)
-{
+void Stopwatch::report_all(int precision, std::ostream& output) {
   if (!active) return;
 
-  output<< "\n"<< std::setw(STOP_WATCH_MAX_NAME_LENGTH)<< std::left<< "*** PROFILING RESULTS [ms] ";
-  output<< std::setw(STOP_WATCH_TIME_WIDTH)<<"min"<<" ";
-  output<< std::setw(STOP_WATCH_TIME_WIDTH)<<"avg"<<" ";
-  output<< std::setw(STOP_WATCH_TIME_WIDTH)<<"max"<<" ";
-  output<< std::setw(STOP_WATCH_TIME_WIDTH)<<"lastTime"<<" ";
-  output<< std::setw(STOP_WATCH_TIME_WIDTH)<<"nSamples"<<" ";
-  output<< std::setw(STOP_WATCH_TIME_WIDTH)<<"totalTime"<< " ***\n";
+  output << "\n" << std::setw(STOP_WATCH_MAX_NAME_LENGTH) << std::left << "*** PROFILING RESULTS [ms] ";
+  output << std::setw(STOP_WATCH_TIME_WIDTH) << "min"
+         << " ";
+  output << std::setw(STOP_WATCH_TIME_WIDTH) << "avg"
+         << " ";
+  output << std::setw(STOP_WATCH_TIME_WIDTH) << "max"
+         << " ";
+  output << std::setw(STOP_WATCH_TIME_WIDTH) << "lastTime"
+         << " ";
+  output << std::setw(STOP_WATCH_TIME_WIDTH) << "nSamples"
+         << " ";
+  output << std::setw(STOP_WATCH_TIME_WIDTH) << "totalTime"
+         << " ***\n";
   map<string, PerformanceData>::iterator it;
   for (it = records_of->begin(); it != records_of->end(); ++it) {
-    if(it->second.stops>0)
-      report(it->first, precision, output);
+    if (it->second.stops > 0) report(it->first, precision, output);
   }
 }
 
-void Stopwatch::reset(const string &perf_name)
-{
+void Stopwatch::reset(const string& perf_name) {
   if (!active) return;
 
   // Try to recover performance data
-  if ( !performance_exists(perf_name)  )
-    throw StopwatchException("Performance not initialized.");
+  if (!performance_exists(perf_name)) throw StopwatchException("Performance not initialized.");
 
   PerformanceData& perf_info = records_of->find(perf_name)->second;
 
@@ -235,115 +212,92 @@ void Stopwatch::reset(const string &perf_name)
   perf_info.stops = 0;
 }
 
-void Stopwatch::turn_on()
-{
+void Stopwatch::turn_on() {
   std::cout << "Stopwatch active." << std::endl;
   active = true;
 }
 
-void Stopwatch::turn_off()
-{
+void Stopwatch::turn_off() {
   std::cout << "Stopwatch inactive." << std::endl;
   active = false;
 }
 
-void Stopwatch::report(const string &perf_name, int precision, std::ostream& output)
-{
+void Stopwatch::report(const string& perf_name, int precision, std::ostream& output) {
   if (!active) return;
 
   // Try to recover performance data
-  if ( !performance_exists(perf_name)  )
-    throw StopwatchException("Performance not initialized.");
+  if (!performance_exists(perf_name)) throw StopwatchException("Performance not initialized.");
 
   PerformanceData& perf_info = records_of->find(perf_name)->second;
 
-  output << std::setw(STOP_WATCH_MAX_NAME_LENGTH) << std::left<< perf_name;
-  output << std::fixed << std::setprecision(precision) <<  std::setw(STOP_WATCH_TIME_WIDTH)
-         << (perf_info.min_time*1e3) << " ";
-  output << std::fixed << std::setprecision(precision) <<  std::setw(STOP_WATCH_TIME_WIDTH)
-         << (perf_info.total_time*1e3 / (long double) perf_info.stops) << " ";
-  output << std::fixed << std::setprecision(precision) <<  std::setw(STOP_WATCH_TIME_WIDTH)
-         << (perf_info.max_time*1e3) << " ";
-  output << std::fixed << std::setprecision(precision) <<  std::setw(STOP_WATCH_TIME_WIDTH)
-         << (perf_info.last_time*1e3) << " ";
-  output << std::fixed << std::setprecision(precision) <<  std::setw(STOP_WATCH_TIME_WIDTH)
-         << perf_info.stops << " ";
-  output << std::fixed << std::setprecision(precision) <<  std::setw(STOP_WATCH_TIME_WIDTH)
-         << perf_info.total_time*1e3 << std::endl;
+  output << std::setw(STOP_WATCH_MAX_NAME_LENGTH) << std::left << perf_name;
+  output << std::fixed << std::setprecision(precision) << std::setw(STOP_WATCH_TIME_WIDTH)
+         << (perf_info.min_time * 1e3) << " ";
+  output << std::fixed << std::setprecision(precision) << std::setw(STOP_WATCH_TIME_WIDTH)
+         << (perf_info.total_time * 1e3 / (long double)perf_info.stops) << " ";
+  output << std::fixed << std::setprecision(precision) << std::setw(STOP_WATCH_TIME_WIDTH)
+         << (perf_info.max_time * 1e3) << " ";
+  output << std::fixed << std::setprecision(precision) << std::setw(STOP_WATCH_TIME_WIDTH)
+         << (perf_info.last_time * 1e3) << " ";
+  output << std::fixed << std::setprecision(precision) << std::setw(STOP_WATCH_TIME_WIDTH) << perf_info.stops << " ";
+  output << std::fixed << std::setprecision(precision) << std::setw(STOP_WATCH_TIME_WIDTH)
+         << perf_info.total_time * 1e3 << std::endl;
 }
 
-long double Stopwatch::get_time_so_far(const string &perf_name)
-{
+long double Stopwatch::get_time_so_far(const string& perf_name) {
   // Try to recover performance data
-  if ( !performance_exists(perf_name)  )
-    throw StopwatchException("Performance not initialized.");
+  if (!performance_exists(perf_name)) throw StopwatchException("Performance not initialized.");
 
-  long double lapse =
-    (take_time() - (records_of->find(perf_name)->second).clock_start);
+  long double lapse = (take_time() - (records_of->find(perf_name)->second).clock_start);
 
-  if (mode == CPU_TIME)
-    lapse /= (double) CLOCKS_PER_SEC;
+  if (mode == CPU_TIME) lapse /= (double)CLOCKS_PER_SEC;
 
   return lapse;
 }
 
-long double Stopwatch::get_total_time(const string &perf_name)
-{
+long double Stopwatch::get_total_time(const string& perf_name) {
   // Try to recover performance data
-  if ( !performance_exists(perf_name)  )
-    throw StopwatchException("Performance not initialized.");
+  if (!performance_exists(perf_name)) throw StopwatchException("Performance not initialized.");
 
   PerformanceData& perf_info = records_of->find(perf_name)->second;
 
   return perf_info.total_time;
-
 }
 
-long double Stopwatch::get_average_time(const string &perf_name)
-{
+long double Stopwatch::get_average_time(const string& perf_name) {
   // Try to recover performance data
-  if ( !performance_exists(perf_name)  )
-    throw StopwatchException("Performance not initialized.");
+  if (!performance_exists(perf_name)) throw StopwatchException("Performance not initialized.");
 
   PerformanceData& perf_info = records_of->find(perf_name)->second;
 
   return (perf_info.total_time / (long double)perf_info.stops);
-
 }
 
-long double Stopwatch::get_min_time(const string &perf_name)
-{
+long double Stopwatch::get_min_time(const string& perf_name) {
   // Try to recover performance data
-  if ( !performance_exists(perf_name)  )
-    throw StopwatchException("Performance not initialized.");
+  if (!performance_exists(perf_name)) throw StopwatchException("Performance not initialized.");
 
   PerformanceData& perf_info = records_of->find(perf_name)->second;
 
   return perf_info.min_time;
-
 }
 
-long double Stopwatch::get_max_time(const string &perf_name)
-{
+long double Stopwatch::get_max_time(const string& perf_name) {
   // Try to recover performance data
-  if ( !performance_exists(perf_name)  )
-    throw StopwatchException("Performance not initialized.");
+  if (!performance_exists(perf_name)) throw StopwatchException("Performance not initialized.");
 
   PerformanceData& perf_info = records_of->find(perf_name)->second;
 
   return perf_info.max_time;
-
 }
 
-long double Stopwatch::get_last_time(const string &perf_name)
-{
+long double Stopwatch::get_last_time(const string& perf_name) {
   // Try to recover performance data
-  if ( !performance_exists(perf_name)  )
-    throw StopwatchException("Performance not initialized.");
+  if (!performance_exists(perf_name)) throw StopwatchException("Performance not initialized.");
 
   PerformanceData& perf_info = records_of->find(perf_name)->second;
 
   return perf_info.last_time;
 }
 
-} // end namespace crocoddyl
+}  // end namespace crocoddyl


### PR DESCRIPTION
I've added a stop-watch class which is very useful for doing accurate profiling of the code. This is important for the work that I plan to do to optimize the performance of Crocoddyl with high-order integration schemes. Profiling is off by default so that it does not affect computation times.