### PR TITLE
ostream operators, MeshcatVisualizer fix, removal of ineffective SIMD reduction

### DIFF
--- a/bindings/python/crocoddyl/__init__.py
+++ b/bindings/python/crocoddyl/__init__.py
@@ -318,7 +318,11 @@ class MeshcatDisplay(DisplayAbstract):
     def __init__(self, robot, rate=-1, freq=1, openWindow=True):
         DisplayAbstract.__init__(self, rate, freq)
         self.robot = robot
-        robot.setVisualizer(pinocchio.visualize.MeshcatVisualizer())
+        robot.setVisualizer(pinocchio.visualize.MeshcatVisualizer(
+            model=self.robot.model,
+            collision_model=self.robot.collision_model,
+            visual_model=self.robot.visual_model
+        ))
         self._addRobot(openWindow)
 
     def display(self, xs, fs=[], ps=[], dts=[], factor=1.):

--- a/bindings/python/crocoddyl/__init__.py
+++ b/bindings/python/crocoddyl/__init__.py
@@ -318,11 +318,10 @@ class MeshcatDisplay(DisplayAbstract):
     def __init__(self, robot, rate=-1, freq=1, openWindow=True):
         DisplayAbstract.__init__(self, rate, freq)
         self.robot = robot
-        robot.setVisualizer(pinocchio.visualize.MeshcatVisualizer(
-            model=self.robot.model,
-            collision_model=self.robot.collision_model,
-            visual_model=self.robot.visual_model
-        ))
+        robot.setVisualizer(
+            pinocchio.visualize.MeshcatVisualizer(model=self.robot.model,
+                                                  collision_model=self.robot.collision_model,
+                                                  visual_model=self.robot.visual_model))
         self._addRobot(openWindow)
 
     def display(self, xs, fs=[], ps=[], dts=[], factor=1.):

--- a/bindings/python/crocoddyl/core/action-base.cpp
+++ b/bindings/python/crocoddyl/core/action-base.cpp
@@ -8,6 +8,7 @@
 
 #include "python/crocoddyl/core/core.hpp"
 #include "python/crocoddyl/core/action-base.hpp"
+#include "python/crocoddyl/utils/printable.hpp"
 
 namespace crocoddyl {
 namespace python {
@@ -85,7 +86,8 @@ void exposeActionAbstract() {
       .add_property("u_lb", bp::make_function(&ActionModelAbstract_wrap::get_u_lb, bp::return_internal_reference<>()),
                     &ActionModelAbstract_wrap::set_u_lb, "lower control limits")
       .add_property("u_ub", bp::make_function(&ActionModelAbstract_wrap::get_u_ub, bp::return_internal_reference<>()),
-                    &ActionModelAbstract_wrap::set_u_ub, "upper control limits");
+                    &ActionModelAbstract_wrap::set_u_ub, "upper control limits")
+      .def(PrintableVisitor<ActionModelAbstract>());
 
   bp::register_ptr_to_python<boost::shared_ptr<ActionDataAbstract> >();
 

--- a/bindings/python/crocoddyl/core/action-base.cpp
+++ b/bindings/python/crocoddyl/core/action-base.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2019-2021, LAAS-CNRS, University of Edinburgh, University of Oxford
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////

--- a/bindings/python/crocoddyl/core/diff-action-base.cpp
+++ b/bindings/python/crocoddyl/core/diff-action-base.cpp
@@ -8,6 +8,7 @@
 
 #include "python/crocoddyl/core/core.hpp"
 #include "python/crocoddyl/core/diff-action-base.hpp"
+#include "python/crocoddyl/utils/printable.hpp"
 
 namespace crocoddyl {
 namespace python {
@@ -87,7 +88,8 @@ void exposeDifferentialActionAbstract() {
       .add_property("u_ub",
                     bp::make_function(&DifferentialActionModelAbstract_wrap::get_u_ub,
                                       bp::return_value_policy<bp::return_by_value>()),
-                    &DifferentialActionModelAbstract_wrap::set_u_ub, "upper control limits");
+                    &DifferentialActionModelAbstract_wrap::set_u_ub, "upper control limits")
+      .def(PrintableVisitor<DifferentialActionModelAbstract>());
 
   bp::register_ptr_to_python<boost::shared_ptr<DifferentialActionDataAbstract> >();
 

--- a/bindings/python/crocoddyl/core/diff-action-base.cpp
+++ b/bindings/python/crocoddyl/core/diff-action-base.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2019-2021, LAAS-CNRS, University of Edinburgh, University of Oxford
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////

--- a/bindings/python/crocoddyl/core/integrator/euler.cpp
+++ b/bindings/python/crocoddyl/core/integrator/euler.cpp
@@ -1,13 +1,14 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2021, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2019-2021, LAAS-CNRS, University of Edinburgh, University of Oxford
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "python/crocoddyl/core/core.hpp"
 #include "python/crocoddyl/core/action-base.hpp"
+#include "python/crocoddyl/utils/printable.hpp"
 #include "crocoddyl/core/integrator/euler.hpp"
 
 namespace crocoddyl {
@@ -62,7 +63,8 @@ void exposeIntegratedActionEuler() {
                     &IntegratedActionModelEuler::set_differential, "differential action model")
       .add_property(
           "dt", bp::make_function(&IntegratedActionModelEuler::get_dt, bp::return_value_policy<bp::return_by_value>()),
-          &IntegratedActionModelEuler::set_dt, "step time");
+          &IntegratedActionModelEuler::set_dt, "step time")
+      .def(PrintableVisitor<IntegratedActionModelEuler>());
 
   bp::register_ptr_to_python<boost::shared_ptr<IntegratedActionDataEuler> >();
 

--- a/bindings/python/crocoddyl/core/optctrl/shooting.cpp
+++ b/bindings/python/crocoddyl/core/optctrl/shooting.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2019-2021, LAAS-CNRS, University of Edinburgh, University of Oxford
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -9,6 +9,7 @@
 #include <vector>
 #include <memory>
 #include "python/crocoddyl/core/core.hpp"
+#include "python/crocoddyl/utils/printable.hpp"
 #include "python/crocoddyl/utils/vector-converter.hpp"
 #include "crocoddyl/core/optctrl/shooting.hpp"
 
@@ -118,7 +119,8 @@ void exposeShootingProblem() {
       .add_property("ndx", bp::make_function(&ShootingProblem::get_ndx),
                     "dimension of the tangent space of the state manifold")
       .add_property("nu_max", bp::make_function(&ShootingProblem::get_nu_max),
-                    "dimension of the maximum control vector");
+                    "dimension of the maximum control vector")
+      .def(PrintableVisitor<ShootingProblem>());
 }
 
 }  // namespace python

--- a/bindings/python/crocoddyl/multibody/actions/contact-fwddyn.cpp
+++ b/bindings/python/crocoddyl/multibody/actions/contact-fwddyn.cpp
@@ -22,7 +22,7 @@ void exposeDifferentialActionContactFwdDynamics() {
       "Differential action model for contact forward dynamics in multibody systems.\n\n"
       "The contact is modelled as holonomic constraits in the contact frame. There\n"
       "is also a custom implementation in case of system with armatures. If you want to\n"
-      "include the armature, you need to use setArmature(). On the other hand, the\n"
+      "include the armature, you need to use set_armature(). On the other hand, the\n"
       "stack of cost functions are implemented in CostModelSum().",
       bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActuationModelAbstract>,
                boost::shared_ptr<ContactModelMultiple>, boost::shared_ptr<CostModelSum>, bp::optional<double, bool> >(

--- a/bindings/python/crocoddyl/multibody/actions/contact-fwddyn.cpp
+++ b/bindings/python/crocoddyl/multibody/actions/contact-fwddyn.cpp
@@ -1,13 +1,14 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2021, LAAS-CNRS, University of Edinburgh, CTU, INRIA
+// Copyright (C) 2019-2021, LAAS-CNRS, University of Edinburgh, CTU, INRIA, University of Oxford
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "python/crocoddyl/multibody/multibody.hpp"
 #include "python/crocoddyl/core/diff-action-base.hpp"
+#include "python/crocoddyl/utils/printable.hpp"
 #include "crocoddyl/multibody/actions/contact-fwddyn.hpp"
 
 namespace crocoddyl {
@@ -92,7 +93,8 @@ void exposeDifferentialActionContactFwdDynamics() {
       .add_property("JMinvJt_damping",
                     bp::make_function(&DifferentialActionModelContactFwdDynamics::get_damping_factor),
                     bp::make_function(&DifferentialActionModelContactFwdDynamics::set_damping_factor),
-                    "Damping factor for cholesky decomposition of JMinvJt");
+                    "Damping factor for cholesky decomposition of JMinvJt")
+      .def(PrintableVisitor<DifferentialActionModelContactFwdDynamics>());
 
   bp::register_ptr_to_python<boost::shared_ptr<DifferentialActionDataContactFwdDynamics> >();
 

--- a/bindings/python/crocoddyl/multibody/actions/free-fwddyn.cpp
+++ b/bindings/python/crocoddyl/multibody/actions/free-fwddyn.cpp
@@ -21,7 +21,7 @@ void exposeDifferentialActionFreeFwdDynamics() {
       "Differential action model for free forward dynamics in multibody systems.\n\n"
       "This class implements a the dynamics using Articulate Body Algorithm (ABA),\n"
       "or a custom implementation in case of system with armatures. If you want to\n"
-      "include the armature, you need to use setArmature(). On the other hand, the\n"
+      "include the armature, you need to use set_armature(). On the other hand, the\n"
       "stack of cost functions are implemented in CostModelSum().",
       bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ActuationModelAbstract>,
                boost::shared_ptr<CostModelSum> >(bp::args("self", "state", "actuation", "costs"),

--- a/bindings/python/crocoddyl/multibody/actions/impulse-fwddyn.cpp
+++ b/bindings/python/crocoddyl/multibody/actions/impulse-fwddyn.cpp
@@ -22,7 +22,7 @@ void exposeActionImpulseFwdDynamics() {
       "Action model for impulse forward dynamics in multibody systems.\n\n"
       "The impulse is modelled as holonomic constraits in the contact frame. There\n"
       "is also a custom implementation in case of system with armatures. If you want to\n"
-      "include the armature, you need to use setArmature(). On the other hand, the\n"
+      "include the armature, you need to use set_armature(). On the other hand, the\n"
       "stack of cost functions are implemented in CostModelSum().",
       bp::init<boost::shared_ptr<StateMultibody>, boost::shared_ptr<ImpulseModelMultiple>,
                boost::shared_ptr<CostModelSum>, bp::optional<double, double, bool> >(

--- a/bindings/python/crocoddyl/multibody/actions/impulse-fwddyn.cpp
+++ b/bindings/python/crocoddyl/multibody/actions/impulse-fwddyn.cpp
@@ -1,13 +1,14 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2021, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2019-2021, LAAS-CNRS, University of Edinburgh, University of Oxford
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "python/crocoddyl/multibody/multibody.hpp"
 #include "python/crocoddyl/core/action-base.hpp"
+#include "python/crocoddyl/utils/printable.hpp"
 #include "crocoddyl/multibody/actions/impulse-fwddyn.hpp"
 
 namespace crocoddyl {
@@ -91,7 +92,8 @@ void exposeActionImpulseFwdDynamics() {
                     "Restitution coefficient that describes elastic impacts")
       .add_property("JMinvJt_damping", bp::make_function(&ActionModelImpulseFwdDynamics::get_damping_factor),
                     bp::make_function(&ActionModelImpulseFwdDynamics::set_damping_factor),
-                    "Damping factor for cholesky decomposition of JMinvJt");
+                    "Damping factor for cholesky decomposition of JMinvJt")
+      .def(PrintableVisitor<ActionModelImpulseFwdDynamics>());
 
   bp::register_ptr_to_python<boost::shared_ptr<ActionDataImpulseFwdDynamics> >();
 

--- a/bindings/python/crocoddyl/multibody/actuations/floating-base.cpp
+++ b/bindings/python/crocoddyl/multibody/actuations/floating-base.cpp
@@ -18,7 +18,7 @@ void exposeActuationFloatingBase() {
   bp::class_<ActuationModelFloatingBase, bp::bases<ActuationModelAbstract> >(
       "ActuationModelFloatingBase",
       "Floating-base actuation models.\n\n"
-      "It simplies consider a floating-base actuation model, where the first 6 elements are unactuated.",
+      "It simply considers a floating-base actuation model, where the first 6 elements are unactuated.",
       bp::init<boost::shared_ptr<StateMultibody> >(bp::args("self", "state"),
                                                    "Initialize the floating-base actuation model.\n\n"
                                                    ":param state: state of multibody system"))

--- a/include/crocoddyl/core/action-base.hpp
+++ b/include/crocoddyl/core/action-base.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2019-2021, LAAS-CNRS, University of Edinburgh, University of Oxford
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -198,6 +198,12 @@ class ActionModelAbstractTpl {
    * @brief Modify the control upper bounds
    */
   void set_u_ub(const VectorXs& u_ub);
+
+  /**
+   * @brief Print information on the ActionModel
+   */
+  template <class Scalar>
+  friend std::ostream& operator<<(std::ostream& os, const ActionModelAbstractTpl<Scalar>& action_model);
 
  protected:
   std::size_t nu_;                          //!< Control dimension

--- a/include/crocoddyl/core/action-base.hxx
+++ b/include/crocoddyl/core/action-base.hxx
@@ -1,10 +1,14 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2019-2021, LAAS-CNRS, University of Edinburgh, University of Oxford
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
+
+#include <iostream>                 // std::ostream
+#include <typeinfo>                 // typeid()
+#include <boost/core/demangle.hpp>  // boost::core::demangle
 
 #include "crocoddyl/core/utils/exception.hpp"
 
@@ -143,6 +147,12 @@ void ActionModelAbstractTpl<Scalar>::set_u_ub(const VectorXs& u_ub) {
 template <typename Scalar>
 void ActionModelAbstractTpl<Scalar>::update_has_control_limits() {
   has_control_limits_ = isfinite(u_lb_.array()).any() && isfinite(u_ub_.array()).any();
+}
+
+template <typename Scalar>
+std::ostream& operator<<(std::ostream& os, const ActionModelAbstractTpl<Scalar>& action_model) {
+  os << "ActionModel type '" << boost::core::demangle(typeid(action_model).name()) << "'" << action_model;
+  return os;
 }
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/core/action-base.hxx
+++ b/include/crocoddyl/core/action-base.hxx
@@ -6,9 +6,9 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#include <iostream>                 // std::ostream
-#include <typeinfo>                 // typeid()
-#include <boost/core/demangle.hpp>  // boost::core::demangle
+#include <iostream>
+#include <typeinfo>
+#include <boost/core/demangle.hpp>
 
 #include "crocoddyl/core/utils/exception.hpp"
 

--- a/include/crocoddyl/core/action-base.hxx
+++ b/include/crocoddyl/core/action-base.hxx
@@ -151,7 +151,7 @@ void ActionModelAbstractTpl<Scalar>::update_has_control_limits() {
 
 template <typename Scalar>
 std::ostream& operator<<(std::ostream& os, const ActionModelAbstractTpl<Scalar>& action_model) {
-  os << "ActionModel type '" << boost::core::demangle(typeid(action_model).name()) << "'" << action_model;
+  os << "ActionModel type '" << boost::core::demangle(typeid(action_model).name()) << "'";
   return os;
 }
 

--- a/include/crocoddyl/core/diff-action-base.hpp
+++ b/include/crocoddyl/core/diff-action-base.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2019-2021, LAAS-CNRS, University of Edinburgh, University of Oxford
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -194,6 +194,13 @@ class DifferentialActionModelAbstractTpl {
    * @brief Modify the control upper bounds
    */
   void set_u_ub(const VectorXs& u_ub);
+
+  /**
+   * @brief Print information on the DifferentialActionModel
+   */
+  template <class Scalar>
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const DifferentialActionModelAbstractTpl<Scalar>& diff_action_model);
 
  protected:
   std::size_t nu_;                          //!< Control dimension

--- a/include/crocoddyl/core/diff-action-base.hxx
+++ b/include/crocoddyl/core/diff-action-base.hxx
@@ -6,9 +6,9 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#include <iostream>                 // std::ostream
-#include <typeinfo>                 // typeid()
-#include <boost/core/demangle.hpp>  // boost::core::demangle
+#include <iostream>
+#include <typeinfo>
+#include <boost/core/demangle.hpp>
 
 #include "crocoddyl/core/utils/exception.hpp"
 

--- a/include/crocoddyl/core/diff-action-base.hxx
+++ b/include/crocoddyl/core/diff-action-base.hxx
@@ -1,10 +1,14 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, LAAS-CNRS, The University of Edinburgh
+// Copyright (C) 2019-2021, LAAS-CNRS, The University of Edinburgh, University of Oxford
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
+
+#include <iostream>                 // std::ostream
+#include <typeinfo>                 // typeid()
+#include <boost/core/demangle.hpp>  // boost::core::demangle
 
 #include "crocoddyl/core/utils/exception.hpp"
 
@@ -143,6 +147,12 @@ void DifferentialActionModelAbstractTpl<Scalar>::set_u_ub(const VectorXs& u_ub) 
 template <typename Scalar>
 void DifferentialActionModelAbstractTpl<Scalar>::update_has_control_limits() {
   has_control_limits_ = isfinite(u_lb_.array()).any() && isfinite(u_ub_.array()).any();
+}
+
+template <typename Scalar>
+std::ostream& operator<<(std::ostream& os, const DifferentialActionModelAbstractTpl<Scalar>& diff_action_model) {
+  os << "DifferentialActionModel of type '" << boost::core::demangle(typeid(diff_action_model).name()) << "'";
+  return os;
 }
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/core/integrator/euler.hpp
+++ b/include/crocoddyl/core/integrator/euler.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2019-2021, LAAS-CNRS, University of Edinburgh, University of Oxford
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -49,6 +49,12 @@ class IntegratedActionModelEulerTpl : public ActionModelAbstractTpl<_Scalar> {
 
   void set_dt(const Scalar dt);
   void set_differential(boost::shared_ptr<DifferentialActionModelAbstract> model);
+
+  /**
+   * @brief Print information on the ActionModel
+   */
+  template <class Scalar>
+  friend std::ostream& operator<<(std::ostream& os, const IntegratedActionModelEulerTpl<Scalar>& problem);
 
  protected:
   using Base::has_control_limits_;  //!< Indicates whether any of the control limits are active

--- a/include/crocoddyl/core/integrator/euler.hxx
+++ b/include/crocoddyl/core/integrator/euler.hxx
@@ -6,8 +6,9 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#include <iostream>
-#include <typeinfo>
+#include <iostream>                 // std::ostream
+#include <typeinfo>                 // typeid()
+#include <boost/core/demangle.hpp>  // boost::core::demangle
 
 #include "crocoddyl/core/utils/exception.hpp"
 #include "crocoddyl/core/integrator/euler.hpp"
@@ -203,11 +204,8 @@ void IntegratedActionModelEulerTpl<Scalar>::quasiStatic(const boost::shared_ptr<
 
 template <typename Scalar>
 std::ostream& operator<<(std::ostream& os, const IntegratedActionModelEulerTpl<Scalar>& model) {
-  // TODO: TTI
-  // Get derived pointer
-
-  os << "IntegratedActionModelEuler (dt=" << model.get_dt() << ", differential=" << model.get_differential()
-     << " of type '" << typeid(*model.get_differential()).name() << "') " << std::endl;
+  os << "IntegratedActionModelEuler (dt=" << model.get_dt() << ", differential of type '"
+     << boost::core::demangle(typeid(*model.get_differential()).name()) << "')";
   return os;
 }
 

--- a/include/crocoddyl/core/integrator/euler.hxx
+++ b/include/crocoddyl/core/integrator/euler.hxx
@@ -1,12 +1,13 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2019-2021, LAAS-CNRS, University of Edinburgh, University of Oxford
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <iostream>
+#include <typeinfo>
 
 #include "crocoddyl/core/utils/exception.hpp"
 #include "crocoddyl/core/integrator/euler.hpp"
@@ -198,6 +199,16 @@ void IntegratedActionModelEulerTpl<Scalar>::quasiStatic(const boost::shared_ptr<
   boost::shared_ptr<Data> d = boost::static_pointer_cast<Data>(data);
 
   differential_->quasiStatic(d->differential, u, x, maxiter, tol);
+}
+
+template <typename Scalar>
+std::ostream& operator<<(std::ostream& os, const IntegratedActionModelEulerTpl<Scalar>& model) {
+  // TODO: TTI
+  // Get derived pointer
+
+  os << "IntegratedActionModelEuler (dt=" << model.get_dt() << ", differential=" << model.get_differential()
+     << " of type '" << typeid(*model.get_differential()).name() << "') " << std::endl;
+  return os;
 }
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/core/integrator/euler.hxx
+++ b/include/crocoddyl/core/integrator/euler.hxx
@@ -6,9 +6,9 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#include <iostream>                 // std::ostream
-#include <typeinfo>                 // typeid()
-#include <boost/core/demangle.hpp>  // boost::core::demangle
+#include <iostream>
+#include <typeinfo>
+#include <boost/core/demangle.hpp>
 
 #include "crocoddyl/core/utils/exception.hpp"
 #include "crocoddyl/core/integrator/euler.hpp"

--- a/include/crocoddyl/core/optctrl/shooting.hpp
+++ b/include/crocoddyl/core/optctrl/shooting.hpp
@@ -235,6 +235,12 @@ class ShootingProblemTpl {
    */
   std::size_t get_nthreads() const;
 
+  /**
+   * @brief Print information on the ShootingProblem
+   */
+  template <class Scalar>
+  friend std::ostream& operator<<(std::ostream& os, const ShootingProblemTpl<Scalar>& problem);
+
  protected:
   Scalar cost_;                                                          //!< Total cost
   std::size_t T_;                                                        //!< number of running nodes

--- a/include/crocoddyl/core/optctrl/shooting.hpp
+++ b/include/crocoddyl/core/optctrl/shooting.hpp
@@ -236,7 +236,7 @@ class ShootingProblemTpl {
   std::size_t get_nthreads() const;
 
   /**
-   * @brief Print information on the ShootingProblem
+   * @brief Print information on the 'ShootingProblem'
    */
   template <class Scalar>
   friend std::ostream& operator<<(std::ostream& os, const ShootingProblemTpl<Scalar>& problem);

--- a/include/crocoddyl/core/optctrl/shooting.hpp
+++ b/include/crocoddyl/core/optctrl/shooting.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2019-2021, LAAS-CNRS, University of Edinburgh, University of Oxford
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////

--- a/include/crocoddyl/core/optctrl/shooting.hxx
+++ b/include/crocoddyl/core/optctrl/shooting.hxx
@@ -15,7 +15,7 @@ namespace crocoddyl {
 
 template <typename Scalar>
 ShootingProblemTpl<Scalar>::ShootingProblemTpl(
-    const VectorXs& x0, const std::vector<boost::shared_ptr<ActionModelAbstract> >& running_models,
+    const VectorXs& x0, const std::vector<boost::shared_ptr<ActionModelAbstract>>& running_models,
     boost::shared_ptr<ActionModelAbstract> terminal_model)
     : cost_(Scalar(0.)),
       T_(running_models.size()),
@@ -65,9 +65,9 @@ ShootingProblemTpl<Scalar>::ShootingProblemTpl(
 
 template <typename Scalar>
 ShootingProblemTpl<Scalar>::ShootingProblemTpl(
-    const VectorXs& x0, const std::vector<boost::shared_ptr<ActionModelAbstract> >& running_models,
+    const VectorXs& x0, const std::vector<boost::shared_ptr<ActionModelAbstract>>& running_models,
     boost::shared_ptr<ActionModelAbstract> terminal_model,
-    const std::vector<boost::shared_ptr<ActionDataAbstract> >& running_datas,
+    const std::vector<boost::shared_ptr<ActionDataAbstract>>& running_datas,
     boost::shared_ptr<ActionDataAbstract> terminal_data)
     : cost_(Scalar(0.)),
       T_(running_models.size()),
@@ -413,25 +413,25 @@ void ShootingProblemTpl<Scalar>::allocateData() {
 }
 
 template <typename Scalar>
-const std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstractTpl<Scalar> > >&
+const std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstractTpl<Scalar>>>&
 ShootingProblemTpl<Scalar>::get_runningModels() const {
   return running_models_;
 }
 
 template <typename Scalar>
-const boost::shared_ptr<crocoddyl::ActionModelAbstractTpl<Scalar> >& ShootingProblemTpl<Scalar>::get_terminalModel()
+const boost::shared_ptr<crocoddyl::ActionModelAbstractTpl<Scalar>>& ShootingProblemTpl<Scalar>::get_terminalModel()
     const {
   return terminal_model_;
 }
 
 template <typename Scalar>
-const std::vector<boost::shared_ptr<crocoddyl::ActionDataAbstractTpl<Scalar> > >&
+const std::vector<boost::shared_ptr<crocoddyl::ActionDataAbstractTpl<Scalar>>>&
 ShootingProblemTpl<Scalar>::get_runningDatas() const {
   return running_datas_;
 }
 
 template <typename Scalar>
-const boost::shared_ptr<crocoddyl::ActionDataAbstractTpl<Scalar> >& ShootingProblemTpl<Scalar>::get_terminalData()
+const boost::shared_ptr<crocoddyl::ActionDataAbstractTpl<Scalar>>& ShootingProblemTpl<Scalar>::get_terminalData()
     const {
   return terminal_data_;
 }
@@ -446,8 +446,7 @@ void ShootingProblemTpl<Scalar>::set_x0(const VectorXs& x0_in) {
 }
 
 template <typename Scalar>
-void ShootingProblemTpl<Scalar>::set_runningModels(
-    const std::vector<boost::shared_ptr<ActionModelAbstract> >& models) {
+void ShootingProblemTpl<Scalar>::set_runningModels(const std::vector<boost::shared_ptr<ActionModelAbstract>>& models) {
   for (std::size_t i = 0; i < T_; ++i) {
     const boost::shared_ptr<ActionModelAbstract>& model = running_models_[i];
     if (model->get_state()->get_nx() != nx_) {

--- a/include/crocoddyl/core/optctrl/shooting.hxx
+++ b/include/crocoddyl/core/optctrl/shooting.hxx
@@ -533,7 +533,8 @@ std::ostream& operator<<(std::ostream& os, const ShootingProblemTpl<Scalar>& pro
   os << "ShootingProblem (T=" << problem.get_T() << ", nx=" << problem.get_nx() << ", ndx=" << problem.get_ndx()
      << ", nu_max=" << problem.get_nu_max() << ") " << std::endl;
   os << "  Models:" << std::endl;
-  auto runningModels = problem.get_runningModels();
+  const std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstractTpl<Scalar>>>& runningModels =
+      problem.get_runningModels();
   for (std::size_t t = 0; t < problem.get_T(); ++t) {
     os << "    " << t << ": " << *runningModels[t] << std::endl;
   }

--- a/include/crocoddyl/core/optctrl/shooting.hxx
+++ b/include/crocoddyl/core/optctrl/shooting.hxx
@@ -490,8 +490,9 @@ void ShootingProblemTpl<Scalar>::set_terminalModel(boost::shared_ptr<ActionModel
 template <typename Scalar>
 void ShootingProblemTpl<Scalar>::set_nthreads(const int nthreads) {
 #ifndef CROCODDYL_WITH_MULTITHREADING
-  std::cerr << "Warning: the number of threads won't affect the computational performance as it is not enable the "
-               "multithreading support."
+  (void)nthreads;
+  std::cerr << "Warning: the number of threads won't affect the computational performance as multithreading "
+               "support is not enabled."
             << std::endl;
 #else
   if (nthreads < 1) {
@@ -520,8 +521,8 @@ std::size_t ShootingProblemTpl<Scalar>::get_nu_max() const {
 template <typename Scalar>
 std::size_t ShootingProblemTpl<Scalar>::get_nthreads() const {
 #ifndef CROCODDYL_WITH_MULTITHREADING
-  std::cerr << "Warning: the number of threads won't affect the computational performance as it is not enable the "
-               "multithreading support."
+  std::cerr << "Warning: the number of threads won't affect the computational performance as multithreading "
+               "support is not enabled."
             << std::endl;
 #endif
   return nthreads_;

--- a/include/crocoddyl/core/optctrl/shooting.hxx
+++ b/include/crocoddyl/core/optctrl/shooting.hxx
@@ -15,7 +15,7 @@ namespace crocoddyl {
 
 template <typename Scalar>
 ShootingProblemTpl<Scalar>::ShootingProblemTpl(
-    const VectorXs& x0, const std::vector<boost::shared_ptr<ActionModelAbstract>>& running_models,
+    const VectorXs& x0, const std::vector<boost::shared_ptr<ActionModelAbstract> >& running_models,
     boost::shared_ptr<ActionModelAbstract> terminal_model)
     : cost_(Scalar(0.)),
       T_(running_models.size()),
@@ -65,9 +65,9 @@ ShootingProblemTpl<Scalar>::ShootingProblemTpl(
 
 template <typename Scalar>
 ShootingProblemTpl<Scalar>::ShootingProblemTpl(
-    const VectorXs& x0, const std::vector<boost::shared_ptr<ActionModelAbstract>>& running_models,
+    const VectorXs& x0, const std::vector<boost::shared_ptr<ActionModelAbstract> >& running_models,
     boost::shared_ptr<ActionModelAbstract> terminal_model,
-    const std::vector<boost::shared_ptr<ActionDataAbstract>>& running_datas,
+    const std::vector<boost::shared_ptr<ActionDataAbstract> >& running_datas,
     boost::shared_ptr<ActionDataAbstract> terminal_data)
     : cost_(Scalar(0.)),
       T_(running_models.size()),
@@ -413,25 +413,25 @@ void ShootingProblemTpl<Scalar>::allocateData() {
 }
 
 template <typename Scalar>
-const std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstractTpl<Scalar>>>&
+const std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstractTpl<Scalar> > >&
 ShootingProblemTpl<Scalar>::get_runningModels() const {
   return running_models_;
 }
 
 template <typename Scalar>
-const boost::shared_ptr<crocoddyl::ActionModelAbstractTpl<Scalar>>& ShootingProblemTpl<Scalar>::get_terminalModel()
+const boost::shared_ptr<crocoddyl::ActionModelAbstractTpl<Scalar> >& ShootingProblemTpl<Scalar>::get_terminalModel()
     const {
   return terminal_model_;
 }
 
 template <typename Scalar>
-const std::vector<boost::shared_ptr<crocoddyl::ActionDataAbstractTpl<Scalar>>>&
+const std::vector<boost::shared_ptr<crocoddyl::ActionDataAbstractTpl<Scalar> > >&
 ShootingProblemTpl<Scalar>::get_runningDatas() const {
   return running_datas_;
 }
 
 template <typename Scalar>
-const boost::shared_ptr<crocoddyl::ActionDataAbstractTpl<Scalar>>& ShootingProblemTpl<Scalar>::get_terminalData()
+const boost::shared_ptr<crocoddyl::ActionDataAbstractTpl<Scalar> >& ShootingProblemTpl<Scalar>::get_terminalData()
     const {
   return terminal_data_;
 }
@@ -446,7 +446,8 @@ void ShootingProblemTpl<Scalar>::set_x0(const VectorXs& x0_in) {
 }
 
 template <typename Scalar>
-void ShootingProblemTpl<Scalar>::set_runningModels(const std::vector<boost::shared_ptr<ActionModelAbstract>>& models) {
+void ShootingProblemTpl<Scalar>::set_runningModels(
+    const std::vector<boost::shared_ptr<ActionModelAbstract> >& models) {
   for (std::size_t i = 0; i < T_; ++i) {
     const boost::shared_ptr<ActionModelAbstract>& model = running_models_[i];
     if (model->get_state()->get_nx() != nx_) {
@@ -532,7 +533,7 @@ std::ostream& operator<<(std::ostream& os, const ShootingProblemTpl<Scalar>& pro
   os << "ShootingProblem (T=" << problem.get_T() << ", nx=" << problem.get_nx() << ", ndx=" << problem.get_ndx()
      << ", nu_max=" << problem.get_nu_max() << ") " << std::endl;
   os << "  Models:" << std::endl;
-  const std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstractTpl<Scalar>>>& runningModels =
+  const std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstractTpl<Scalar> > >& runningModels =
       problem.get_runningModels();
   for (std::size_t t = 0; t < problem.get_T(); ++t) {
     os << "    " << t << ": " << *runningModels[t] << std::endl;

--- a/include/crocoddyl/core/optctrl/shooting.hxx
+++ b/include/crocoddyl/core/optctrl/shooting.hxx
@@ -527,4 +527,17 @@ std::size_t ShootingProblemTpl<Scalar>::get_nthreads() const {
   return nthreads_;
 }
 
+template <typename Scalar>
+std::ostream& operator<<(std::ostream& os, const ShootingProblemTpl<Scalar>& problem) {
+  os << "ShootingProblem (T=" << problem.get_T() << ", nx=" << problem.get_nx() << ", ndx=" << problem.get_ndx()
+     << ", nu_max=" << problem.get_nu_max() << ") " << std::endl;
+  os << "  Models:" << std::endl;
+  auto runningModels = problem.get_runningModels();
+  for (std::size_t t = 0; t < problem.get_T(); ++t) {
+    os << "    " << t << ": " << runningModels[t] << std::endl;
+  }
+  os << "    T+1: " << problem.get_terminalModel() << std::endl;
+  return os;
+}
+
 }  // namespace crocoddyl

--- a/include/crocoddyl/core/optctrl/shooting.hxx
+++ b/include/crocoddyl/core/optctrl/shooting.hxx
@@ -537,7 +537,7 @@ std::ostream& operator<<(std::ostream& os, const ShootingProblemTpl<Scalar>& pro
   for (std::size_t t = 0; t < problem.get_T(); ++t) {
     os << "    " << t << ": " << *runningModels[t] << std::endl;
   }
-  os << "    T+1: " << *problem.get_terminalModel() << std::endl;
+  os << "    T+1: " << *problem.get_terminalModel();
   return os;
 }
 

--- a/include/crocoddyl/core/optctrl/shooting.hxx
+++ b/include/crocoddyl/core/optctrl/shooting.hxx
@@ -534,9 +534,9 @@ std::ostream& operator<<(std::ostream& os, const ShootingProblemTpl<Scalar>& pro
   os << "  Models:" << std::endl;
   auto runningModels = problem.get_runningModels();
   for (std::size_t t = 0; t < problem.get_T(); ++t) {
-    os << "    " << t << ": " << runningModels[t] << std::endl;
+    os << "    " << t << ": " << *runningModels[t] << std::endl;
   }
-  os << "    T+1: " << problem.get_terminalModel() << std::endl;
+  os << "    T+1: " << *problem.get_terminalModel() << std::endl;
   return os;
 }
 

--- a/include/crocoddyl/multibody/actions/contact-fwddyn.hpp
+++ b/include/crocoddyl/multibody/actions/contact-fwddyn.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, LAAS-CNRS, University of Edinburgh, 2020 CTU, INRIA
+// Copyright (C) 2019-2021, LAAS-CNRS, University of Edinburgh, CTU, INRIA, University of Oxford
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -65,6 +65,12 @@ class DifferentialActionModelContactFwdDynamicsTpl : public DifferentialActionMo
 
   void set_armature(const VectorXs& armature);
   void set_damping_factor(const Scalar damping);
+
+  /**
+   * @brief Print information on the action model
+   */
+  template <class Scalar>
+  friend std::ostream& operator<<(std::ostream& os, const DifferentialActionModelContactFwdDynamicsTpl<Scalar>& model);
 
  protected:
   using Base::has_control_limits_;  //!< Indicates whether any of the control limits

--- a/include/crocoddyl/multibody/actions/contact-fwddyn.hxx
+++ b/include/crocoddyl/multibody/actions/contact-fwddyn.hxx
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, LAAS-CNRS, University of Edinburgh, CTU, INRIA
+// Copyright (C) 2019-2021, LAAS-CNRS, University of Edinburgh, CTU, INRIA, University of Oxford
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -264,6 +264,13 @@ void DifferentialActionModelContactFwdDynamicsTpl<Scalar>::set_damping_factor(co
                  << "The damping factor has to be positive");
   }
   JMinvJt_damping_ = damping;
+}
+
+template <typename Scalar>
+std::ostream& operator<<(std::ostream& os, const DifferentialActionModelContactFwdDynamicsTpl<Scalar>& model) {
+  os << "DifferentialActionModelContactFwdDynamics (" << model.get_contacts().size()
+     << " contacts, JMinvJt_damping=" << model.get_damping_factor() << ") " << std::endl;
+  return os;
 }
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/multibody/actions/contact-fwddyn.hxx
+++ b/include/crocoddyl/multibody/actions/contact-fwddyn.hxx
@@ -269,8 +269,7 @@ void DifferentialActionModelContactFwdDynamicsTpl<Scalar>::set_damping_factor(co
 template <typename Scalar>
 std::ostream& operator<<(std::ostream& os, const DifferentialActionModelContactFwdDynamicsTpl<Scalar>& model) {
   os << "DifferentialActionModelContactFwdDynamics (" << model.get_contacts()->get_nc_total() << " contacts ["
-     << model.get_contacts()->get_nc() << " active], JMinvJt_damping=" << model.get_damping_factor() << ") "
-     << std::endl;
+     << model.get_contacts()->get_nc() << " active], JMinvJt_damping=" << model.get_damping_factor() << ")";
   return os;
 }
 

--- a/include/crocoddyl/multibody/actions/contact-fwddyn.hxx
+++ b/include/crocoddyl/multibody/actions/contact-fwddyn.hxx
@@ -268,8 +268,9 @@ void DifferentialActionModelContactFwdDynamicsTpl<Scalar>::set_damping_factor(co
 
 template <typename Scalar>
 std::ostream& operator<<(std::ostream& os, const DifferentialActionModelContactFwdDynamicsTpl<Scalar>& model) {
-  os << "DifferentialActionModelContactFwdDynamics (" << model.get_contacts().size()
-     << " contacts, JMinvJt_damping=" << model.get_damping_factor() << ") " << std::endl;
+  os << "DifferentialActionModelContactFwdDynamics (" << model.get_contacts()->get_nc_total() << " contacts ["
+     << model.get_contacts()->get_nc() << " active], JMinvJt_damping=" << model.get_damping_factor() << ") "
+     << std::endl;
   return os;
 }
 

--- a/include/crocoddyl/multibody/actions/impulse-fwddyn.hpp
+++ b/include/crocoddyl/multibody/actions/impulse-fwddyn.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2019-2021, LAAS-CNRS, University of Edinburgh, University of Oxford
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -69,6 +69,12 @@ class ActionModelImpulseFwdDynamicsTpl : public ActionModelAbstractTpl<_Scalar> 
   void set_armature(const VectorXs& armature);
   void set_restitution_coefficient(const Scalar r_coeff);
   void set_damping_factor(const Scalar damping);
+
+  /**
+   * @brief Print information on the action model
+   */
+  template <class Scalar>
+  friend std::ostream& operator<<(std::ostream& os, const ActionModelImpulseFwdDynamicsTpl<Scalar>& model);
 
  protected:
   using Base::has_control_limits_;  //!< Indicates whether any of the control limits

--- a/include/crocoddyl/multibody/actions/impulse-fwddyn.hxx
+++ b/include/crocoddyl/multibody/actions/impulse-fwddyn.hxx
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2019-2021, LAAS-CNRS, University of Edinburgh, University of Oxford
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -208,6 +208,13 @@ void ActionModelImpulseFwdDynamicsTpl<Scalar>::set_damping_factor(const Scalar d
                  << "The damping factor has to be positive");
   }
   JMinvJt_damping_ = damping;
+}
+
+template <typename Scalar>
+std::ostream& operator<<(std::ostream& os, const ActionModelImpulseFwdDynamicsTpl<Scalar>& model) {
+  os << "ActionModelImpulseFwdDynamics (r_coeff=" << model.get_restitution_coefficient()
+     << ", JMinvJt_damping=" << model.get_damping_factor() << ") " << std::endl;
+  return os;
 }
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/multibody/actions/impulse-fwddyn.hxx
+++ b/include/crocoddyl/multibody/actions/impulse-fwddyn.hxx
@@ -213,7 +213,7 @@ void ActionModelImpulseFwdDynamicsTpl<Scalar>::set_damping_factor(const Scalar d
 template <typename Scalar>
 std::ostream& operator<<(std::ostream& os, const ActionModelImpulseFwdDynamicsTpl<Scalar>& model) {
   os << "ActionModelImpulseFwdDynamics (r_coeff=" << model.get_restitution_coefficient()
-     << ", JMinvJt_damping=" << model.get_damping_factor() << ") " << std::endl;
+     << ", JMinvJt_damping=" << model.get_damping_factor() << ")";
   return os;
 }
 

--- a/src/core/solvers/ddp.cpp
+++ b/src/core/solvers/ddp.cpp
@@ -140,9 +140,6 @@ double SolverDDP::stoppingCriteria() {
   const std::size_t T = this->problem_->get_T();
   const std::vector<boost::shared_ptr<ActionModelAbstract> >& models = problem_->get_runningModels();
 
-#ifdef CROCODDYL_WITH_MULTITHREADING
-#pragma omp simd reduction(+ : stop_)
-#endif
   for (std::size_t t = 0; t < T; ++t) {
     const std::size_t nu = models[t]->get_nu();
     if (nu != 0) {

--- a/src/core/solvers/fddp.cpp
+++ b/src/core/solvers/fddp.cpp
@@ -117,9 +117,6 @@ const Eigen::Vector2d& SolverFDDP::expectedImprovement() {
     dv_ -= fs_.back().dot(fTVxx_p_);
     const std::vector<boost::shared_ptr<ActionModelAbstract> >& models = problem_->get_runningModels();
 
-#ifdef CROCODDYL_WITH_MULTITHREADING
-#pragma omp simd reduction(- : dv_)
-#endif
     for (std::size_t t = 0; t < T; ++t) {
       models[t]->get_state()->diff(xs_try_[t], xs_[t], dx_[t]);
       fTVxx_p_.noalias() = Vxx_[t] * dx_[t];


### PR DESCRIPTION
This PR includes:
1. `operator<<` for shooting problem, action model, and differential action model to enable `print(ddp.problem)` or `print(ddp.running_models[t])` which is useful in debugging to get information on the problem
2. Removes the ineffective OpenMP simd instructions previously pointed out by Justin and also notified by the clang compiler as not optimised
3. Fixes the `MeshcatVisualizer` when using the latest Pinocchio devel branch (not sure when it broke)