### PR TITLE
Add GitHub Actions CI with ROS dependency resolution

### DIFF
--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -1,7 +1,7 @@
 # This config uses industrial_ci (https://github.com/ros-industrial/industrial_ci.git).
 # For troubleshooting, see readme (https://github.com/ros-industrial/industrial_ci/blob/master/README.rst)
 
-name: CI
+name: ROS-CI
 
 # This determines when this workflow is run
 on: [push, pull_request] # on all pushes and PRs

--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          submodules: true
+          submodules: recursive
       # This step will fetch/store the directory used by ccache before/after the ci run
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: true
       # This step will fetch/store the directory used by ccache before/after the ci run
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -1,0 +1,30 @@
+# This config uses industrial_ci (https://github.com/ros-industrial/industrial_ci.git).
+# For troubleshooting, see readme (https://github.com/ros-industrial/industrial_ci/blob/master/README.rst)
+
+name: CI
+
+# This determines when this workflow is run
+on: [push, pull_request] # on all pushes and PRs
+
+jobs:
+  CI:
+    strategy:
+      matrix:
+        env:
+          - {ROS_DISTRO: melodic}
+          - {ROS_DISTRO: noetic}
+    env:
+      CCACHE_DIR: /github/home/.ccache # Enable ccache
+      UPSTREAM_WORKSPACE: dependencies.rosinstall
+      BUILDER: catkin_tools
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # This step will fetch/store the directory used by ccache before/after the ci run
+      - uses: actions/cache@v2
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-${{ matrix.env.ROS_DISTRO }}-${{ matrix.env.ROS_REPO }}
+      # Run industrial_ci
+      - uses: 'ros-industrial/industrial_ci@master'
+        env: ${{ matrix.env }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,12 @@ jobs:
   allow_failures:
     - dist: bionic
       env: CMAKE_BUILD_TYPE=Debug DIST=bionic CTEST_OUTPUT_ON_FAILURE=1
+    - dist: bionic
+      env: CMAKE_BUILD_TYPE=Release DIST=bionic CTEST_OUTPUT_ON_FAILURE=1
     - dist: xenial
       env: CMAKE_BUILD_TYPE=Debug DIST=xenial CTEST_OUTPUT_ON_FAILURE=1 CMAKE_CXX_STANDARD=11
+    - dist: xenial
+      env: CMAKE_BUILD_TYPE=Release DIST=xenial CTEST_OUTPUT_ON_FAILURE=1 CMAKE_CXX_STANDARD=11
 
 before_install:
   - echo "deb [arch=amd64] http://robotpkg.openrobots.org/wip/packages/debian/pub $(lsb_release -sc) robotpkg" | sudo tee -a /etc/apt/sources.list.d/robotpkg.list && echo "deb [arch=amd64] http://robotpkg.openrobots.org/packages/debian/pub $(lsb_release -sc) robotpkg" | sudo tee -a /etc/apt/sources.list.d/robotpkg.list && curl http://robotpkg.openrobots.org/packages/debian/robotpkg.key | sudo apt-key add -

--- a/dependencies.rosinstall
+++ b/dependencies.rosinstall
@@ -1,0 +1,4 @@
+- git:
+    uri: https://github.com/Gepetto/example-robot-data.git
+    version: master
+    local-name: example-robot-data

--- a/include/crocoddyl/core/activations/smooth-abs.hpp
+++ b/include/crocoddyl/core/activations/smooth-abs.hpp
@@ -36,7 +36,7 @@ struct ActivationDataSmoothAbsTpl : public ActivationDataSmooth1NormTpl<Scalar> 
 
   template <typename Activation>
   DEPRECATED("Use ActivationDataSmooth1Norm", explicit ActivationDataSmoothAbsTpl(Activation* const activation)
-             : Base(activation){};)
+             : Base(activation){})
 };
 
 }  // namespace crocoddyl


### PR DESCRIPTION
This adds a GitHub Actions-based CI on 18.04 and 20.04 resolving Pinocchio/EigenPy via ROS and using catkin tools to build and run tests on Crocoddyl. Part of the motivation is that a) Travis is being phased out, b) Crocoddyl can and is being used within ROS workspaces e.g. for robot deployment, and c) that RobotPkg without staging fails CI jobs every now and then when packages are out of sync (e.g. in #932 and #931 right now). This augments the more extensive coverage and set of configurations Gepgitlab is providing and is more of a stand-in replacement for Travis.