### PR TITLE
Activate all warnings; turn off Wsign-conversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,8 +34,7 @@ ENDIF()
 SET(DOXYGEN_USE_MATHJAX YES)
 SET(DOXYGEN_USE_TEMPLATE_CSS YES)
 
-# Disable -Werror on Unix for now.
-SET(CXX_DISABLE_WERROR True)
+SET(CXX_DISABLE_WERROR False)
 SET(PROJECT_USE_CMAKE_EXPORT True)
 
 # Create different building options

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,11 @@ FILE(GLOB_RECURSE ${PROJECT_NAME}_HEADERS
   )
 
 IF(UNIX)
+  # Build options
+  #   We'd like to deactivate sign conversion since we frequently convert Eigen::Index<>std::size_t
+  #   Otherwise, activate all warnings.
+  ADD_COMPILE_OPTIONS(-Wall -Wpedantic -Wextra -Wno-sign-conversion)
+
   ADD_LIBRARY(${PROJECT_NAME} SHARED ${${PROJECT_NAME}_SOURCES} ${${PROJECT_NAME}_HEADERS})
   SET_TARGET_PROPERTIES(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE CXX)
   TARGET_INCLUDE_DIRECTORIES(${PROJECT_NAME} PUBLIC $<INSTALL_INTERFACE:include>)

--- a/unittest/test_actuation.cpp
+++ b/unittest/test_actuation.cpp
@@ -24,6 +24,7 @@ void test_construct_data(ActuationModelTypes::Type actuation_type, StateModelTyp
 
   // create the corresponding data object
   const boost::shared_ptr<crocoddyl::ActuationDataAbstract>& data = model->createData();
+  if (!data) throw std::runtime_error("[test_construct_data] Data pointer is dead.");
 }
 
 void test_calc_returns_tau(ActuationModelTypes::Type actuation_type, StateModelTypes::Type state_type) {


### PR DESCRIPTION
We have a lot of conversions between `Eigen::Index` and `std::size_t` (e.g. `.head(nu)` etc.) which pollute the compiler output. Fixing those would make part of the code quite unreadable. Instead, this PR activates all warnings and then only turns off `Wsign-conversion`. The remaining warning is fixed.