### PR TITLE
Only build Python-examples if bindings are built

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,7 +183,11 @@ ENDIF(BUILD_BENCHMARK)
 
 # Build the examples
 IF(BUILD_EXAMPLES)
-  ADD_SUBDIRECTORY(examples)
+  IF(BUILD_PYTHON_INTERFACE)
+    ADD_SUBDIRECTORY(examples)
+  ELSE(BUILD_PYTHON_INTERFACE)
+    MESSAGE(WARNING "Python interface is not built, hence cannot build examples.")
+  ENDIF(BUILD_PYTHON_INTERFACE)
 ENDIF(BUILD_EXAMPLES)
 
 # PkgConfig packaging of the project

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,28 +1,30 @@
-SET(${PROJECT_NAME}_EXAMPLES_PYTHON
-  double_pendulum
-  boxfddp_vs_boxddp
-  quadrotor
-  quadrotor_ubound
-  arm_manipulation
-  quadrupedal_gaits
-  quadrupedal_walk_ubound
-  bipedal_walk
-  bipedal_walk_ubound
-  humanoid_manipulation
-  humanoid_manipulation_ubound
-  humanoid_taichi
-  )
+IF(BUILD_PYTHON_INTERFACE)
+  SET(${PROJECT_NAME}_EXAMPLES_PYTHON
+    double_pendulum
+    boxfddp_vs_boxddp
+    quadrotor
+    quadrotor_ubound
+    arm_manipulation
+    quadrupedal_gaits
+    quadrupedal_walk_ubound
+    bipedal_walk
+    bipedal_walk_ubound
+    humanoid_manipulation
+    humanoid_manipulation_ubound
+    humanoid_taichi
+    )
 
-INSTALL(FILES __init__.py DESTINATION ${PYTHON_SITELIB}/${PROJECT_NAME}/examples)
-FOREACH(examples ${${PROJECT_NAME}_EXAMPLES_PYTHON})
-  PYTHON_BUILD(. "${examples}.py")
-  INSTALL(FILES ${examples}.py DESTINATION ${PYTHON_SITELIB}/${PROJECT_NAME}/examples)
-  ADD_CUSTOM_TARGET("examples-${examples}"
-    ${CMAKE_COMMAND} -E env PYTHONPATH=${PROJECT_BINARY_DIR}/bindings/python:$ENV{PYTHONPATH}
-    ${PYTHON_EXECUTABLE} -c "import ${examples}" \${INPUT})
+  INSTALL(FILES __init__.py DESTINATION ${PYTHON_SITELIB}/${PROJECT_NAME}/examples)
+  FOREACH(examples ${${PROJECT_NAME}_EXAMPLES_PYTHON})
+    PYTHON_BUILD(. "${examples}.py")
+    INSTALL(FILES ${examples}.py DESTINATION ${PYTHON_SITELIB}/${PROJECT_NAME}/examples)
+    ADD_CUSTOM_TARGET("examples-${examples}"
+      ${CMAKE_COMMAND} -E env PYTHONPATH=${PROJECT_BINARY_DIR}/bindings/python:$ENV{PYTHONPATH}
+      ${PYTHON_EXECUTABLE} -c "import ${examples}" \${INPUT})
 
-  # examples are too slow in Debug mode to be used as tests
-  IF(CMAKE_BUILD_TYPE STREQUAL "Release")
-    ADD_PYTHON_UNIT_TEST("example-python-${examples}" "examples/${examples}.py" bindings/python)
-  ENDIF(CMAKE_BUILD_TYPE STREQUAL "Release")
-ENDFOREACH(examples ${${PROJECT_NAME}_EXAMPLES_PYTHON})
+    # examples are too slow in Debug mode to be used as tests
+    IF(CMAKE_BUILD_TYPE STREQUAL "Release")
+      ADD_PYTHON_UNIT_TEST("example-python-${examples}" "examples/${examples}.py" bindings/python)
+    ENDIF(CMAKE_BUILD_TYPE STREQUAL "Release")
+  ENDFOREACH(examples ${${PROJECT_NAME}_EXAMPLES_PYTHON})
+ENDIF(BUILD_PYTHON_INTERFACE)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,30 +1,28 @@
-IF(BUILD_PYTHON_INTERFACE)
-  SET(${PROJECT_NAME}_EXAMPLES_PYTHON
-    double_pendulum
-    boxfddp_vs_boxddp
-    quadrotor
-    quadrotor_ubound
-    arm_manipulation
-    quadrupedal_gaits
-    quadrupedal_walk_ubound
-    bipedal_walk
-    bipedal_walk_ubound
-    humanoid_manipulation
-    humanoid_manipulation_ubound
-    humanoid_taichi
-    )
+SET(${PROJECT_NAME}_EXAMPLES_PYTHON
+  double_pendulum
+  boxfddp_vs_boxddp
+  quadrotor
+  quadrotor_ubound
+  arm_manipulation
+  quadrupedal_gaits
+  quadrupedal_walk_ubound
+  bipedal_walk
+  bipedal_walk_ubound
+  humanoid_manipulation
+  humanoid_manipulation_ubound
+  humanoid_taichi
+  )
 
-  INSTALL(FILES __init__.py DESTINATION ${PYTHON_SITELIB}/${PROJECT_NAME}/examples)
-  FOREACH(examples ${${PROJECT_NAME}_EXAMPLES_PYTHON})
-    PYTHON_BUILD(. "${examples}.py")
-    INSTALL(FILES ${examples}.py DESTINATION ${PYTHON_SITELIB}/${PROJECT_NAME}/examples)
-    ADD_CUSTOM_TARGET("examples-${examples}"
-      ${CMAKE_COMMAND} -E env PYTHONPATH=${PROJECT_BINARY_DIR}/bindings/python:$ENV{PYTHONPATH}
-      ${PYTHON_EXECUTABLE} -c "import ${examples}" \${INPUT})
+INSTALL(FILES __init__.py DESTINATION ${PYTHON_SITELIB}/${PROJECT_NAME}/examples)
+FOREACH(examples ${${PROJECT_NAME}_EXAMPLES_PYTHON})
+  PYTHON_BUILD(. "${examples}.py")
+  INSTALL(FILES ${examples}.py DESTINATION ${PYTHON_SITELIB}/${PROJECT_NAME}/examples)
+  ADD_CUSTOM_TARGET("examples-${examples}"
+    ${CMAKE_COMMAND} -E env PYTHONPATH=${PROJECT_BINARY_DIR}/bindings/python:$ENV{PYTHONPATH}
+    ${PYTHON_EXECUTABLE} -c "import ${examples}" \${INPUT})
 
-    # examples are too slow in Debug mode to be used as tests
-    IF(CMAKE_BUILD_TYPE STREQUAL "Release")
-      ADD_PYTHON_UNIT_TEST("example-python-${examples}" "examples/${examples}.py" bindings/python)
-    ENDIF(CMAKE_BUILD_TYPE STREQUAL "Release")
-  ENDFOREACH(examples ${${PROJECT_NAME}_EXAMPLES_PYTHON})
-ENDIF(BUILD_PYTHON_INTERFACE)
+  # examples are too slow in Debug mode to be used as tests
+  IF(CMAKE_BUILD_TYPE STREQUAL "Release")
+    ADD_PYTHON_UNIT_TEST("example-python-${examples}" "examples/${examples}.py" bindings/python)
+  ENDIF(CMAKE_BUILD_TYPE STREQUAL "Release")
+ENDFOREACH(examples ${${PROJECT_NAME}_EXAMPLES_PYTHON})


### PR DESCRIPTION
Currently we have a configuration option that can break build: `cmake .. -DBUILD_PYTHON_INTERFACE=OFF` will still try to build the Python examples. This PR fixes this.