### PR TITLE
fix include sequence after pinocchio commit c1ff8821c437e2401b80b7aa7f3f118464e2c051

### DIFF
--- a/bindings/python/crocoddyl/core/activations/quadratic-barrier.cpp
+++ b/bindings/python/crocoddyl/core/activations/quadratic-barrier.cpp
@@ -10,7 +10,6 @@
 #include "python/crocoddyl/core/core.hpp"
 #include "python/crocoddyl/core/activation-base.hpp"
 
-
 namespace crocoddyl {
 namespace python {
 

--- a/bindings/python/crocoddyl/core/activations/quadratic-barrier.cpp
+++ b/bindings/python/crocoddyl/core/activations/quadratic-barrier.cpp
@@ -6,9 +6,10 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
+#include "crocoddyl/core/activations/quadratic-barrier.hpp"
 #include "python/crocoddyl/core/core.hpp"
 #include "python/crocoddyl/core/activation-base.hpp"
-#include "crocoddyl/core/activations/quadratic-barrier.hpp"
+
 
 namespace crocoddyl {
 namespace python {

--- a/bindings/python/crocoddyl/core/activations/quadratic-flat-log.cpp
+++ b/bindings/python/crocoddyl/core/activations/quadratic-flat-log.cpp
@@ -5,10 +5,9 @@
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
-
+#include "crocoddyl/core/activations/quadratic-flat-log.hpp"
 #include "python/crocoddyl/core/core.hpp"
 #include "python/crocoddyl/core/activation-base.hpp"
-#include "crocoddyl/core/activations/quadratic-flat-log.hpp"
 
 namespace crocoddyl {
 namespace python {

--- a/bindings/python/crocoddyl/core/activations/weighted-quadratic-barrier.cpp
+++ b/bindings/python/crocoddyl/core/activations/weighted-quadratic-barrier.cpp
@@ -10,7 +10,6 @@
 #include "python/crocoddyl/core/core.hpp"
 #include "python/crocoddyl/core/activation-base.hpp"
 
-
 namespace crocoddyl {
 namespace python {
 

--- a/bindings/python/crocoddyl/core/activations/weighted-quadratic-barrier.cpp
+++ b/bindings/python/crocoddyl/core/activations/weighted-quadratic-barrier.cpp
@@ -6,9 +6,10 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
+#include "crocoddyl/core/activations/weighted-quadratic-barrier.hpp"
 #include "python/crocoddyl/core/core.hpp"
 #include "python/crocoddyl/core/activation-base.hpp"
-#include "crocoddyl/core/activations/weighted-quadratic-barrier.hpp"
+
 
 namespace crocoddyl {
 namespace python {

--- a/bindings/python/crocoddyl/core/actuation-base.hpp
+++ b/bindings/python/crocoddyl/core/actuation-base.hpp
@@ -10,9 +10,9 @@
 #ifndef BINDINGS_PYTHON_CROCODDYL_CORE_ACTUATION_BASE_HPP_
 #define BINDINGS_PYTHON_CROCODDYL_CORE_ACTUATION_BASE_HPP_
 
-#include "python/crocoddyl/core/core.hpp"
 #include "crocoddyl/core/actuation-base.hpp"
 #include "crocoddyl/core/utils/exception.hpp"
+#include "python/crocoddyl/core/core.hpp"
 
 namespace crocoddyl {
 namespace python {

--- a/bindings/python/crocoddyl/core/diff-action-base.hpp
+++ b/bindings/python/crocoddyl/core/diff-action-base.hpp
@@ -9,9 +9,10 @@
 #ifndef BINDINGS_PYTHON_CROCODDYL_CORE_DIFF_ACTION_BASE_HPP_
 #define BINDINGS_PYTHON_CROCODDYL_CORE_DIFF_ACTION_BASE_HPP_
 
-#include "python/crocoddyl/core/core.hpp"
 #include "crocoddyl/core/diff-action-base.hpp"
 #include "crocoddyl/core/utils/exception.hpp"
+
+#include "python/crocoddyl/core/core.hpp"
 
 namespace crocoddyl {
 namespace python {

--- a/bindings/python/crocoddyl/core/state-base.hpp
+++ b/bindings/python/crocoddyl/core/state-base.hpp
@@ -11,9 +11,10 @@
 #define BINDINGS_PYTHON_CROCODDYL_CORE_STATE_BASE_HPP_
 
 #include <string>
-#include "python/crocoddyl/core/core.hpp"
 #include "crocoddyl/core/state-base.hpp"
 #include "crocoddyl/core/utils/exception.hpp"
+
+#include "python/crocoddyl/core/core.hpp"
 
 namespace crocoddyl {
 namespace python {

--- a/bindings/python/crocoddyl/multibody/contact-base.hpp
+++ b/bindings/python/crocoddyl/multibody/contact-base.hpp
@@ -9,9 +9,10 @@
 #ifndef BINDINGS_PYTHON_CROCODDYL_MULTIBODY_CONTACT_BASE_HPP_
 #define BINDINGS_PYTHON_CROCODDYL_MULTIBODY_CONTACT_BASE_HPP_
 
-#include "python/crocoddyl/multibody/multibody.hpp"
 #include "crocoddyl/multibody/contact-base.hpp"
 #include "crocoddyl/core/utils/exception.hpp"
+
+#include "python/crocoddyl/multibody/multibody.hpp"
 
 namespace crocoddyl {
 namespace python {

--- a/bindings/python/crocoddyl/multibody/cop-support.cpp
+++ b/bindings/python/crocoddyl/multibody/cop-support.cpp
@@ -6,8 +6,9 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "python/crocoddyl/multibody/multibody.hpp"
 #include "crocoddyl/multibody/cop-support.hpp"
+
+#include "python/crocoddyl/multibody/multibody.hpp"
 #include "python/crocoddyl/utils/printable.hpp"
 
 namespace crocoddyl {

--- a/bindings/python/crocoddyl/multibody/force-base.cpp
+++ b/bindings/python/crocoddyl/multibody/force-base.cpp
@@ -6,8 +6,9 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "python/crocoddyl/multibody/multibody.hpp"
 #include "crocoddyl/multibody/force-base.hpp"
+
+#include "python/crocoddyl/multibody/multibody.hpp"
 #include "python/crocoddyl/multibody/contact-base.hpp"
 #include "python/crocoddyl/multibody/impulse-base.hpp"
 

--- a/bindings/python/crocoddyl/multibody/frames.cpp
+++ b/bindings/python/crocoddyl/multibody/frames.cpp
@@ -11,12 +11,10 @@
 #include <eigenpy/memory.hpp>
 #include <eigenpy/eigen-to-python.hpp>
 
-
 #include <pinocchio/bindings/python/utils/std-aligned-vector.hpp>
 #include "python/crocoddyl/multibody/multibody.hpp"
 #include "python/crocoddyl/utils/printable.hpp"
 #include "python/crocoddyl/utils/deprecate.hpp"
-
 
 EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(crocoddyl::FrameTranslation)
 EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(crocoddyl::FrameRotation)

--- a/bindings/python/crocoddyl/multibody/frames.cpp
+++ b/bindings/python/crocoddyl/multibody/frames.cpp
@@ -6,15 +6,17 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
+#include "crocoddyl/multibody/frames.hpp"
+
 #include <eigenpy/memory.hpp>
 #include <eigenpy/eigen-to-python.hpp>
 
+
+#include <pinocchio/bindings/python/utils/std-aligned-vector.hpp>
 #include "python/crocoddyl/multibody/multibody.hpp"
-#include "crocoddyl/multibody/frames.hpp"
 #include "python/crocoddyl/utils/printable.hpp"
 #include "python/crocoddyl/utils/deprecate.hpp"
 
-#include "pinocchio/bindings/python/utils/std-aligned-vector.hpp"
 
 EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(crocoddyl::FrameTranslation)
 EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(crocoddyl::FrameRotation)

--- a/bindings/python/crocoddyl/multibody/friction-cone.cpp
+++ b/bindings/python/crocoddyl/multibody/friction-cone.cpp
@@ -6,8 +6,9 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "python/crocoddyl/multibody/multibody.hpp"
 #include "crocoddyl/multibody/friction-cone.hpp"
+
+#include "python/crocoddyl/multibody/multibody.hpp"
 #include "python/crocoddyl/utils/printable.hpp"
 #include "python/crocoddyl/utils/deprecate.hpp"
 

--- a/bindings/python/crocoddyl/multibody/impulse-base.hpp
+++ b/bindings/python/crocoddyl/multibody/impulse-base.hpp
@@ -9,9 +9,10 @@
 #ifndef BINDINGS_PYTHON_CROCODDYL_MULTIBODY_IMPULSE_BASE_HPP_
 #define BINDINGS_PYTHON_CROCODDYL_MULTIBODY_IMPULSE_BASE_HPP_
 
-#include "python/crocoddyl/multibody/multibody.hpp"
 #include "crocoddyl/multibody/impulse-base.hpp"
 #include "crocoddyl/core/utils/exception.hpp"
+
+#include "python/crocoddyl/multibody/multibody.hpp"
 
 namespace crocoddyl {
 namespace python {

--- a/bindings/python/crocoddyl/multibody/impulses/impulse-3d.cpp
+++ b/bindings/python/crocoddyl/multibody/impulses/impulse-3d.cpp
@@ -6,8 +6,8 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "python/crocoddyl/multibody/multibody.hpp"
 #include "crocoddyl/multibody/impulses/impulse-3d.hpp"
+#include "python/crocoddyl/multibody/multibody.hpp"
 
 namespace crocoddyl {
 namespace python {

--- a/bindings/python/crocoddyl/multibody/impulses/impulse-6d.cpp
+++ b/bindings/python/crocoddyl/multibody/impulses/impulse-6d.cpp
@@ -9,7 +9,6 @@
 #include "crocoddyl/multibody/impulses/impulse-6d.hpp"
 #include "python/crocoddyl/multibody/multibody.hpp"
 
-
 namespace crocoddyl {
 namespace python {
 

--- a/bindings/python/crocoddyl/multibody/impulses/impulse-6d.cpp
+++ b/bindings/python/crocoddyl/multibody/impulses/impulse-6d.cpp
@@ -6,8 +6,9 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "python/crocoddyl/multibody/multibody.hpp"
 #include "crocoddyl/multibody/impulses/impulse-6d.hpp"
+#include "python/crocoddyl/multibody/multibody.hpp"
+
 
 namespace crocoddyl {
 namespace python {

--- a/bindings/python/crocoddyl/multibody/impulses/multiple-impulses.cpp
+++ b/bindings/python/crocoddyl/multibody/impulses/multiple-impulses.cpp
@@ -11,9 +11,10 @@
 #include <memory>
 #include <utility>
 #include <string>
+#include "crocoddyl/multibody/impulses/multiple-impulses.hpp"
+
 #include "python/crocoddyl/multibody/multibody.hpp"
 #include "python/crocoddyl/utils/map-converter.hpp"
-#include "crocoddyl/multibody/impulses/multiple-impulses.hpp"
 #include "python/crocoddyl/utils/deprecate.hpp"
 #include "python/crocoddyl/utils/printable.hpp"
 

--- a/bindings/python/crocoddyl/multibody/residuals/centroidal-momentum.cpp
+++ b/bindings/python/crocoddyl/multibody/residuals/centroidal-momentum.cpp
@@ -6,8 +6,8 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "python/crocoddyl/multibody/multibody.hpp"
 #include "crocoddyl/multibody/residuals/centroidal-momentum.hpp"
+#include "python/crocoddyl/multibody/multibody.hpp"
 #include "python/crocoddyl/utils/deprecate.hpp"
 
 namespace crocoddyl {

--- a/bindings/python/crocoddyl/multibody/residuals/com-position.cpp
+++ b/bindings/python/crocoddyl/multibody/residuals/com-position.cpp
@@ -6,8 +6,8 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "python/crocoddyl/multibody/multibody.hpp"
 #include "crocoddyl/multibody/residuals/com-position.hpp"
+#include "python/crocoddyl/multibody/multibody.hpp"
 
 namespace crocoddyl {
 namespace python {

--- a/bindings/python/crocoddyl/multibody/residuals/contact-control-gravity.cpp
+++ b/bindings/python/crocoddyl/multibody/residuals/contact-control-gravity.cpp
@@ -6,8 +6,8 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "python/crocoddyl/multibody/multibody.hpp"
 #include "crocoddyl/multibody/residuals/contact-control-gravity.hpp"
+#include "python/crocoddyl/multibody/multibody.hpp"
 
 namespace crocoddyl {
 namespace python {

--- a/bindings/python/crocoddyl/multibody/residuals/contact-cop-position.cpp
+++ b/bindings/python/crocoddyl/multibody/residuals/contact-cop-position.cpp
@@ -6,8 +6,8 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "python/crocoddyl/multibody/multibody.hpp"
 #include "crocoddyl/multibody/residuals/contact-cop-position.hpp"
+#include "python/crocoddyl/multibody/multibody.hpp"
 
 namespace crocoddyl {
 namespace python {

--- a/bindings/python/crocoddyl/multibody/residuals/contact-force.cpp
+++ b/bindings/python/crocoddyl/multibody/residuals/contact-force.cpp
@@ -6,8 +6,8 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "python/crocoddyl/multibody/multibody.hpp"
 #include "crocoddyl/multibody/residuals/contact-force.hpp"
+#include "python/crocoddyl/multibody/multibody.hpp"
 #include "python/crocoddyl/utils/deprecate.hpp"
 
 namespace crocoddyl {

--- a/bindings/python/crocoddyl/multibody/residuals/contact-friction-cone.cpp
+++ b/bindings/python/crocoddyl/multibody/residuals/contact-friction-cone.cpp
@@ -6,8 +6,9 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "python/crocoddyl/multibody/multibody.hpp"
 #include "crocoddyl/multibody/residuals/contact-friction-cone.hpp"
+#include "python/crocoddyl/multibody/multibody.hpp"
+
 
 namespace crocoddyl {
 namespace python {

--- a/bindings/python/crocoddyl/multibody/residuals/contact-friction-cone.cpp
+++ b/bindings/python/crocoddyl/multibody/residuals/contact-friction-cone.cpp
@@ -9,7 +9,6 @@
 #include "crocoddyl/multibody/residuals/contact-friction-cone.hpp"
 #include "python/crocoddyl/multibody/multibody.hpp"
 
-
 namespace crocoddyl {
 namespace python {
 

--- a/bindings/python/crocoddyl/multibody/residuals/contact-wrench-cone.cpp
+++ b/bindings/python/crocoddyl/multibody/residuals/contact-wrench-cone.cpp
@@ -9,7 +9,6 @@
 #include "crocoddyl/multibody/residuals/contact-wrench-cone.hpp"
 #include "python/crocoddyl/multibody/multibody.hpp"
 
-
 namespace crocoddyl {
 namespace python {
 

--- a/bindings/python/crocoddyl/multibody/residuals/contact-wrench-cone.cpp
+++ b/bindings/python/crocoddyl/multibody/residuals/contact-wrench-cone.cpp
@@ -6,8 +6,9 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "python/crocoddyl/multibody/multibody.hpp"
 #include "crocoddyl/multibody/residuals/contact-wrench-cone.hpp"
+#include "python/crocoddyl/multibody/multibody.hpp"
+
 
 namespace crocoddyl {
 namespace python {

--- a/bindings/python/crocoddyl/multibody/residuals/control-gravity.cpp
+++ b/bindings/python/crocoddyl/multibody/residuals/control-gravity.cpp
@@ -6,8 +6,8 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "python/crocoddyl/multibody/multibody.hpp"
 #include "crocoddyl/multibody/residuals/control-gravity.hpp"
+#include "python/crocoddyl/multibody/multibody.hpp"
 
 namespace crocoddyl {
 namespace python {

--- a/bindings/python/crocoddyl/multibody/residuals/frame-placement.cpp
+++ b/bindings/python/crocoddyl/multibody/residuals/frame-placement.cpp
@@ -6,8 +6,8 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "python/crocoddyl/multibody/multibody.hpp"
 #include "crocoddyl/multibody/residuals/frame-placement.hpp"
+#include "python/crocoddyl/multibody/multibody.hpp"
 
 namespace crocoddyl {
 namespace python {

--- a/bindings/python/crocoddyl/multibody/residuals/frame-rotation.cpp
+++ b/bindings/python/crocoddyl/multibody/residuals/frame-rotation.cpp
@@ -6,8 +6,8 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "python/crocoddyl/multibody/multibody.hpp"
 #include "crocoddyl/multibody/residuals/frame-rotation.hpp"
+#include "python/crocoddyl/multibody/multibody.hpp"
 #include "python/crocoddyl/utils/deprecate.hpp"
 
 namespace crocoddyl {

--- a/bindings/python/crocoddyl/multibody/residuals/frame-translation.cpp
+++ b/bindings/python/crocoddyl/multibody/residuals/frame-translation.cpp
@@ -6,8 +6,8 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "python/crocoddyl/multibody/multibody.hpp"
 #include "crocoddyl/multibody/residuals/frame-translation.hpp"
+#include "python/crocoddyl/multibody/multibody.hpp"
 
 namespace crocoddyl {
 namespace python {

--- a/bindings/python/crocoddyl/multibody/residuals/frame-velocity.cpp
+++ b/bindings/python/crocoddyl/multibody/residuals/frame-velocity.cpp
@@ -6,8 +6,8 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "python/crocoddyl/multibody/multibody.hpp"
 #include "crocoddyl/multibody/residuals/frame-velocity.hpp"
+#include "python/crocoddyl/multibody/multibody.hpp"
 
 namespace crocoddyl {
 namespace python {

--- a/bindings/python/crocoddyl/multibody/residuals/impulse-com.cpp
+++ b/bindings/python/crocoddyl/multibody/residuals/impulse-com.cpp
@@ -6,8 +6,8 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "python/crocoddyl/multibody/multibody.hpp"
 #include "crocoddyl/multibody/residuals/impulse-com.hpp"
+#include "python/crocoddyl/multibody/multibody.hpp"
 
 namespace crocoddyl {
 namespace python {

--- a/bindings/python/crocoddyl/multibody/residuals/state.cpp
+++ b/bindings/python/crocoddyl/multibody/residuals/state.cpp
@@ -6,8 +6,8 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "python/crocoddyl/multibody/multibody.hpp"
 #include "crocoddyl/multibody/costs/state.hpp"
+#include "python/crocoddyl/multibody/multibody.hpp"
 
 namespace crocoddyl {
 namespace python {

--- a/bindings/python/crocoddyl/multibody/states/multibody.cpp
+++ b/bindings/python/crocoddyl/multibody/states/multibody.cpp
@@ -6,9 +6,9 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
+#include "crocoddyl/multibody/states/multibody.hpp"
 #include "python/crocoddyl/multibody/multibody.hpp"
 #include "python/crocoddyl/core/state-base.hpp"
-#include "crocoddyl/multibody/states/multibody.hpp"
 
 namespace crocoddyl {
 namespace python {

--- a/bindings/python/crocoddyl/multibody/wrench-cone.cpp
+++ b/bindings/python/crocoddyl/multibody/wrench-cone.cpp
@@ -6,8 +6,9 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "python/crocoddyl/multibody/multibody.hpp"
 #include "crocoddyl/multibody/wrench-cone.hpp"
+
+#include "python/crocoddyl/multibody/multibody.hpp"
 #include "python/crocoddyl/utils/printable.hpp"
 #include "python/crocoddyl/utils/deprecate.hpp"
 

--- a/include/crocoddyl/core/activation-base.hpp
+++ b/include/crocoddyl/core/activation-base.hpp
@@ -18,6 +18,7 @@
 #include "crocoddyl/core/mathbase.hpp"
 #include "crocoddyl/core/utils/to-string.hpp"
 
+
 namespace crocoddyl {
 
 template <typename _Scalar>

--- a/include/crocoddyl/core/activation-base.hpp
+++ b/include/crocoddyl/core/activation-base.hpp
@@ -18,7 +18,6 @@
 #include "crocoddyl/core/mathbase.hpp"
 #include "crocoddyl/core/utils/to-string.hpp"
 
-
 namespace crocoddyl {
 
 template <typename _Scalar>

--- a/include/crocoddyl/core/activations/quadratic-barrier.hpp
+++ b/include/crocoddyl/core/activations/quadratic-barrier.hpp
@@ -17,7 +17,6 @@
 #include "crocoddyl/core/utils/exception.hpp"
 #include "crocoddyl/core/activation-base.hpp"
 
-
 namespace crocoddyl {
 
 template <typename _Scalar>

--- a/include/crocoddyl/core/activations/quadratic-barrier.hpp
+++ b/include/crocoddyl/core/activations/quadratic-barrier.hpp
@@ -11,12 +11,12 @@
 
 #include <stdexcept>
 #include <math.h>
+#include <pinocchio/utils/static-if.hpp>
 
 #include "crocoddyl/core/fwd.hpp"
 #include "crocoddyl/core/utils/exception.hpp"
 #include "crocoddyl/core/activation-base.hpp"
 
-#include <pinocchio/utils/static-if.hpp>
 
 namespace crocoddyl {
 

--- a/include/crocoddyl/core/activations/weighted-quadratic-barrier.hpp
+++ b/include/crocoddyl/core/activations/weighted-quadratic-barrier.hpp
@@ -9,10 +9,11 @@
 #ifndef CROCODDYL_CORE_ACTIVATIONS_WEIGHTED_QUADRATIC_BARRIER_HPP_
 #define CROCODDYL_CORE_ACTIVATIONS_WEIGHTED_QUADRATIC_BARRIER_HPP_
 
+#include <pinocchio/utils/static-if.hpp>
 #include "crocoddyl/core/fwd.hpp"
 #include "crocoddyl/core/utils/exception.hpp"
 #include "crocoddyl/core/activations/quadratic-barrier.hpp"
-#include <pinocchio/utils/static-if.hpp>
+
 namespace crocoddyl {
 
 template <typename _Scalar>

--- a/include/crocoddyl/core/integrator/euler.hxx
+++ b/include/crocoddyl/core/integrator/euler.hxx
@@ -9,9 +9,7 @@
 #include <iostream>
 #include <typeinfo>
 #include <boost/core/demangle.hpp>
-
 #include "crocoddyl/core/utils/exception.hpp"
-#include "crocoddyl/core/integrator/euler.hpp"
 
 namespace crocoddyl {
 

--- a/include/crocoddyl/multibody/actions/impulse-fwddyn.hpp
+++ b/include/crocoddyl/multibody/actions/impulse-fwddyn.hpp
@@ -11,6 +11,13 @@
 
 #include <stdexcept>
 
+#include <pinocchio/algorithm/compute-all-terms.hpp>
+#include <pinocchio/algorithm/frames.hpp>
+#include <pinocchio/algorithm/contact-dynamics.hpp>
+#include <pinocchio/algorithm/centroidal.hpp>
+#include <pinocchio/algorithm/rnea-derivatives.hpp>
+#include <pinocchio/algorithm/kinematics-derivatives.hpp>
+
 #include "crocoddyl/multibody/fwd.hpp"
 #include "crocoddyl/core/utils/exception.hpp"
 #include "crocoddyl/core/action-base.hpp"
@@ -20,13 +27,6 @@
 #include "crocoddyl/multibody/impulses/multiple-impulses.hpp"
 #include "crocoddyl/multibody/data/impulses.hpp"
 #include "crocoddyl/multibody/actions/impulse-fwddyn.hpp"
-
-#include <pinocchio/algorithm/compute-all-terms.hpp>
-#include <pinocchio/algorithm/frames.hpp>
-#include <pinocchio/algorithm/contact-dynamics.hpp>
-#include <pinocchio/algorithm/centroidal.hpp>
-#include <pinocchio/algorithm/rnea-derivatives.hpp>
-#include <pinocchio/algorithm/kinematics-derivatives.hpp>
 
 namespace crocoddyl {
 

--- a/include/crocoddyl/multibody/contacts/contact-2d.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-2d.hpp
@@ -9,15 +9,15 @@
 #ifndef CROCODDYL_MULTIBODY_CONTACTS_CONTACT_2D_HPP_
 #define CROCODDYL_MULTIBODY_CONTACTS_CONTACT_2D_HPP_
 
-#include "crocoddyl/multibody/fwd.hpp"
-#include "crocoddyl/multibody/frames.hpp"
-#include "crocoddyl/core/utils/exception.hpp"
-#include "crocoddyl/multibody/contact-base.hpp"
-
 #include <pinocchio/spatial/motion.hpp>
 #include <pinocchio/multibody/data.hpp>
 #include <pinocchio/algorithm/frames.hpp>
 #include <pinocchio/algorithm/kinematics-derivatives.hpp>
+
+#include "crocoddyl/multibody/fwd.hpp"
+#include "crocoddyl/multibody/frames.hpp"
+#include "crocoddyl/core/utils/exception.hpp"
+#include "crocoddyl/multibody/contact-base.hpp"
 
 namespace crocoddyl {
 

--- a/include/crocoddyl/multibody/contacts/contact-3d.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-3d.hpp
@@ -9,15 +9,15 @@
 #ifndef CROCODDYL_MULTIBODY_CONTACTS_CONTACT_3D_HPP_
 #define CROCODDYL_MULTIBODY_CONTACTS_CONTACT_3D_HPP_
 
-#include "crocoddyl/multibody/fwd.hpp"
-#include "crocoddyl/multibody/frames.hpp"
-#include "crocoddyl/core/utils/exception.hpp"
-#include "crocoddyl/multibody/contact-base.hpp"
-
 #include <pinocchio/spatial/motion.hpp>
 #include <pinocchio/multibody/data.hpp>
 #include <pinocchio/algorithm/frames.hpp>
 #include <pinocchio/algorithm/kinematics-derivatives.hpp>
+
+#include "crocoddyl/multibody/fwd.hpp"
+#include "crocoddyl/multibody/frames.hpp"
+#include "crocoddyl/core/utils/exception.hpp"
+#include "crocoddyl/multibody/contact-base.hpp"
 
 namespace crocoddyl {
 

--- a/include/crocoddyl/multibody/contacts/contact-6d.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-6d.hpp
@@ -9,12 +9,12 @@
 #ifndef CROCODDYL_MULTIBODY_CONTACTS_CONTACT_6D_HPP_
 #define CROCODDYL_MULTIBODY_CONTACTS_CONTACT_6D_HPP_
 
+#include <pinocchio/spatial/motion.hpp>
+#include <pinocchio/multibody/data.hpp>
+
 #include "crocoddyl/multibody/fwd.hpp"
 #include "crocoddyl/multibody/contact-base.hpp"
 #include "crocoddyl/multibody/frames.hpp"
-
-#include <pinocchio/spatial/motion.hpp>
-#include <pinocchio/multibody/data.hpp>
 
 namespace crocoddyl {
 

--- a/include/crocoddyl/multibody/data/multibody.hpp
+++ b/include/crocoddyl/multibody/data/multibody.hpp
@@ -9,11 +9,11 @@
 #ifndef CROCODDYL_CORE_DATA_MULTIBODY_HPP_
 #define CROCODDYL_CORE_DATA_MULTIBODY_HPP_
 
+#include <pinocchio/multibody/data.hpp>
+
 #include "crocoddyl/multibody/fwd.hpp"
 #include "crocoddyl/core/data-collector-base.hpp"
 #include "crocoddyl/core/data/actuation.hpp"
-
-#include <pinocchio/multibody/data.hpp>
 
 namespace crocoddyl {
 

--- a/include/crocoddyl/multibody/force-base.hpp
+++ b/include/crocoddyl/multibody/force-base.hpp
@@ -9,11 +9,11 @@
 #ifndef CROCODDYL_MULTIBODY_FORCE_BASE_HPP_
 #define CROCODDYL_MULTIBODY_FORCE_BASE_HPP_
 
-#include "crocoddyl/multibody/fwd.hpp"
-#include "crocoddyl/core/mathbase.hpp"
-
 #include <pinocchio/multibody/data.hpp>
 #include <pinocchio/spatial/force.hpp>
+
+#include "crocoddyl/multibody/fwd.hpp"
+#include "crocoddyl/core/mathbase.hpp"
 
 namespace crocoddyl {
 

--- a/include/crocoddyl/multibody/frames.hpp
+++ b/include/crocoddyl/multibody/frames.hpp
@@ -10,15 +10,15 @@
 #ifndef CROCODDYL_MULTIBODY_FRAMES_HPP_
 #define CROCODDYL_MULTIBODY_FRAMES_HPP_
 
-#include "crocoddyl/multibody/fwd.hpp"
-#include "crocoddyl/multibody/friction-cone.hpp"
-#include "crocoddyl/multibody/wrench-cone.hpp"
-#include "crocoddyl/core/mathbase.hpp"
-
 #include <pinocchio/multibody/fwd.hpp>
 #include <pinocchio/spatial/se3.hpp>
 #include <pinocchio/spatial/motion.hpp>
 #include <pinocchio/spatial/force.hpp>
+
+#include "crocoddyl/multibody/fwd.hpp"
+#include "crocoddyl/core/mathbase.hpp"
+#include "crocoddyl/multibody/friction-cone.hpp"
+#include "crocoddyl/multibody/wrench-cone.hpp"
 
 namespace crocoddyl {
 

--- a/include/crocoddyl/multibody/impulses/impulse-3d.hpp
+++ b/include/crocoddyl/multibody/impulses/impulse-3d.hpp
@@ -9,11 +9,11 @@
 #ifndef CROCODDYL_MULTIBODY_IMPULSES_IMPULSE_3D_HPP_
 #define CROCODDYL_MULTIBODY_IMPULSES_IMPULSE_3D_HPP_
 
-#include "crocoddyl/multibody/fwd.hpp"
-#include "crocoddyl/multibody/impulse-base.hpp"
-
 #include <pinocchio/spatial/motion.hpp>
 #include <pinocchio/multibody/data.hpp>
+
+#include "crocoddyl/multibody/fwd.hpp"
+#include "crocoddyl/multibody/impulse-base.hpp"
 
 namespace crocoddyl {
 

--- a/include/crocoddyl/multibody/impulses/impulse-6d.hpp
+++ b/include/crocoddyl/multibody/impulses/impulse-6d.hpp
@@ -9,11 +9,11 @@
 #ifndef CROCODDYL_MULTIBODY_IMPULSES_IMPULSE_6D_HPP_
 #define CROCODDYL_MULTIBODY_IMPULSES_IMPULSE_6D_HPP_
 
-#include "crocoddyl/multibody/fwd.hpp"
-#include "crocoddyl/multibody/impulse-base.hpp"
-
 #include <pinocchio/spatial/motion.hpp>
 #include <pinocchio/multibody/data.hpp>
+
+#include "crocoddyl/multibody/fwd.hpp"
+#include "crocoddyl/multibody/impulse-base.hpp"
 
 namespace crocoddyl {
 

--- a/include/crocoddyl/multibody/states/multibody.hpp
+++ b/include/crocoddyl/multibody/states/multibody.hpp
@@ -9,9 +9,10 @@
 #ifndef CROCODDYL_MULTIBODY_STATES_MULTIBODY_HPP_
 #define CROCODDYL_MULTIBODY_STATES_MULTIBODY_HPP_
 
+#include <pinocchio/multibody/model.hpp>
+
 #include "crocoddyl/multibody/fwd.hpp"
 #include "crocoddyl/core/state-base.hpp"
-#include <pinocchio/multibody/model.hpp>
 
 namespace crocoddyl {
 


### PR DESCRIPTION
Pinocchio commit c1ff8821c437e2401b80b7aa7f3f118464e2c051 forces pinocchio inclusion before boost.
So crocoddyl now fails to compile with pinocchio devel.
This PR is meant to change the header include order based on the following logic:

1) Non-boost system headers
2) pinocchio headers
3) crocoddyl headers
4) pinocchio binding headers
5) crocoddyl binding headers
