### PR TITLE
Align the arguments

### DIFF
--- a/examples/notebooks/cartpole_swing_up.py
+++ b/examples/notebooks/cartpole_swing_up.py
@@ -8,7 +8,7 @@ import crocoddyl
 
 class DifferentialActionModelCartpole(crocoddyl.DifferentialActionModelAbstract):
     def __init__(self):
-        crocoddyl.DifferentialActionModelAbstract.__init__(self, crocoddyl.StateVector(4), 1, 6)  # nu = 1; nr = 6
+        crocoddyl.DifferentialActionModelAbstract.__init__(self, crocoddyl.StateVector(4), 1, 6)  # nv = 1; nu = 6
         self.unone = np.zeros(self.nu)
 
         self.m1 = 1.


### PR DESCRIPTION
Align the arguments based on the documentation `def __init__(self, nq, nv, nu):` in `class DifferentialActionModelAbstract:`[1]

[1] https://github.com/loco-3d/crocoddyl/blob/0985b92098ba70051ec3e5440526a7ec96d7aeca/unittest/python/crocoddyl/differential_action.py#L8