### PR TITLE
Run unittests in ROS-CI, deactivate Travis-CI

### DIFF
--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -14,9 +14,18 @@ jobs:
           - {ROS_DISTRO: melodic}
           - {ROS_DISTRO: noetic}
     env:
-      CCACHE_DIR: /github/home/.ccache # Enable ccache
-      UPSTREAM_WORKSPACE: dependencies.rosinstall
+      CCACHE_DIR: /github/home/.ccache             # Enable ccache
+      UPSTREAM_WORKSPACE: dependencies.rosinstall  # to build example-robot-data from source as it's not released via the ROS buildfarm
+      # The following is a work-around for ROS tooling in conjunction with jrl-cmakemodules:
+      #  - catkin_make_isolated has issues with Industrial-CI right now
+      #  - colcon cannot find example-robot-data's python bindings due to ROS1 workspace integration hooks
+      #  - catkin_tools correctly finds example-robot-data in the upstream_ws, but does not execute the 'run_tests' target
+      #    as catkin-tools performs tests as '--catkin-make-args' instead of '--make-args' as colcon and catkin_make_isolated
+      # The work-around is thus to use catkin_tools for building and sourcing, and to manually specify execution of the test
+      # target after completion of the regular test target. The output of this step does affect the output of the CI process.
+      # Note, this does not affect projects that do not have pure CMake projects in their upstream_ws.
       BUILDER: catkin_tools
+      AFTER_RUN_TARGET_TEST: 'source /root/target_ws/install/setup.bash && cd /root/target_ws/build/crocoddyl && make test'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,12 @@ jobs:
   allow_failures:
     - dist: bionic
       env: CMAKE_BUILD_TYPE=Debug DIST=bionic CTEST_OUTPUT_ON_FAILURE=1 PYTHONPATH=/opt/openrobots/lib/python2.7/site-packages:$PYTHONPATH
+    - dist: bionic
+      env: CMAKE_BUILD_TYPE=Release DIST=bionic CTEST_OUTPUT_ON_FAILURE=1 PYTHONPATH=/opt/openrobots/lib/python2.7/site-packages:$PYTHONPATH
     - dist: focal
       env: CMAKE_BUILD_TYPE=Debug DIST=focal CTEST_OUTPUT_ON_FAILURE=1 PYTHONPATH=/opt/openrobots/lib/python3.8/site-packages:$PYTHONPATH
+    - dist: focal
+      env: CMAKE_BUILD_TYPE=Release DIST=focal CTEST_OUTPUT_ON_FAILURE=1 PYTHONPATH=/opt/openrobots/lib/python3.8/site-packages:$PYTHONPATH
 
 before_install:
   - echo "deb [arch=amd64] http://robotpkg.openrobots.org/wip/packages/debian/pub $(lsb_release -sc) robotpkg" | sudo tee -a /etc/apt/sources.list.d/robotpkg.list && echo "deb [arch=amd64] http://robotpkg.openrobots.org/packages/debian/pub $(lsb_release -sc) robotpkg" | sudo tee -a /etc/apt/sources.list.d/robotpkg.list && curl http://robotpkg.openrobots.org/packages/debian/robotpkg.key | sudo apt-key add -

--- a/package.xml
+++ b/package.xml
@@ -21,6 +21,8 @@
   <depend condition="$ROS_PYTHON_VERSION == 2">python-numpy</depend>
   <depend condition="$ROS_PYTHON_VERSION == 3">python3</depend>
   <depend condition="$ROS_PYTHON_VERSION == 3">python3-numpy</depend>
+  <test_depend condition="$ROS_PYTHON_VERSION == 2">python-scipy</test_depend>
+  <test_depend condition="$ROS_PYTHON_VERSION == 3">python3-scipy</test_depend>
   <depend>boost</depend>
   <depend>eigenpy</depend>
   <depend>example-robot-data</depend>

--- a/unittest/bindings/test_shooting.py
+++ b/unittest/bindings/test_shooting.py
@@ -24,9 +24,10 @@ class ShootingProblemTestCase(unittest.TestCase):
             self.xs.append(state.rand())
             self.us.append(np.matrix(np.random.rand(self.MODEL.nu)).T)
         self.PROBLEM = crocoddyl.ShootingProblem(self.xs[0], [self.MODEL] * self.T, self.MODEL)
-        self.PROBLEM.nthreads = 1  # TODO(cmastalli): Remove after Crocoddyl supports multithreading with Python-derived models
         self.PROBLEM_DER = crocoddyl.ShootingProblem(self.xs[0], [self.MODEL_DER] * self.T, self.MODEL_DER)
-        self.PROBLEM_DER.nthreads = 1  # TODO(cmastalli): Remove after Crocoddyl supports multithreading with Python-derived models
+        # TODO(cmastalli): Remove the following lines once Crocoddyl supports multithreading with Python-derived models
+        self.PROBLEM.nthreads = 1
+        self.PROBLEM_DER.nthreads = 1
 
     def test_number_of_nodes(self):
         self.assertEqual(self.T, self.PROBLEM.T, "Wrong number of nodes")


### PR DESCRIPTION
This PR addresses two items:

1. Execution of unit tests on the ROS-CI running on GitHub Actions. In turn, allows failures on Travis which is prone to spurious failures (thus reverts #948)
2. Updates the cmake submodule to include a packaging fix (https://github.com/jrl-umi3218/jrl-cmakemodules/pull/479) important for use of Crocoddyl in downstream projects 

Resolves #944 