### PR TITLE
Few improvements in the solvers

### DIFF
--- a/bindings/python/crocoddyl/core/solver-base.cpp
+++ b/bindings/python/crocoddyl/core/solver-base.cpp
@@ -114,6 +114,8 @@ void exposeSolverAbstract() {
       .add_property("u_reg", bp::make_function(&SolverAbstract_wrap::get_ureg),
                     bp::make_function(&SolverAbstract_wrap::set_ureg), "control regularization")
       .def_readwrite("stepLength", &SolverAbstract_wrap::steplength_, "applied step length")
+      .def_readwrite("dV", &SolverAbstract_wrap::dV_, "reduction in the cost function")
+      .def_readwrite("dVexp", &SolverAbstract_wrap::dVexp_, "expected reduction in the cost function")
       .add_property("th_acceptStep", bp::make_function(&SolverAbstract_wrap::get_th_acceptstep),
                     bp::make_function(&SolverAbstract_wrap::set_th_acceptstep), "threshold for step acceptance")
       .add_property("th_stop", bp::make_function(&SolverAbstract_wrap::get_th_stop),
@@ -122,8 +124,7 @@ void exposeSolverAbstract() {
       .add_property("th_gapTol", bp::make_function(&SolverAbstract_wrap::get_th_gaptol),
                     bp::make_function(&SolverAbstract_wrap::set_th_gaptol),
                     "threshold for accepting a gap as non-zero")
-      .add_property("ffeas", bp::make_function(&SolverAbstract_wrap::get_ffeas),
-                    "feasibility of the dynamic constraint of current guess")
+      .def_readwrite("ffeas", &SolverAbstract_wrap::ffeas_, "feasibility of the dynamic constraint of current guess")
       .add_property("inffeas", bp::make_function(&SolverAbstract_wrap::get_inffeas),
                     bp::make_function(&SolverAbstract_wrap::set_inffeas),
                     "true indicates if we use l-inf norm for computing the feasibility, otherwise false represents "

--- a/bindings/python/crocoddyl/core/solver-base.hpp
+++ b/bindings/python/crocoddyl/core/solver-base.hpp
@@ -2,7 +2,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2019-2021, LAAS-CNRS, University of Edinburgh
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////

--- a/bindings/python/crocoddyl/core/solver-base.hpp
+++ b/bindings/python/crocoddyl/core/solver-base.hpp
@@ -25,7 +25,6 @@ class SolverAbstract_wrap : public SolverAbstract, public bp::wrapper<SolverAbst
   using SolverAbstract::dVexp_;
   using SolverAbstract::ffeas_;
   using SolverAbstract::fs_;
-  using SolverAbstract::hfeas_;
   using SolverAbstract::is_feasible_;
   using SolverAbstract::iter_;
   using SolverAbstract::steplength_;

--- a/bindings/python/crocoddyl/core/solver-base.hpp
+++ b/bindings/python/crocoddyl/core/solver-base.hpp
@@ -21,7 +21,11 @@ class SolverAbstract_wrap : public SolverAbstract, public bp::wrapper<SolverAbst
  public:
   using SolverAbstract::cost_;
   using SolverAbstract::d_;
+  using SolverAbstract::dV_;
+  using SolverAbstract::dVexp_;
+  using SolverAbstract::ffeas_;
   using SolverAbstract::fs_;
+  using SolverAbstract::hfeas_;
   using SolverAbstract::is_feasible_;
   using SolverAbstract::iter_;
   using SolverAbstract::steplength_;

--- a/include/crocoddyl/core/solver-base.hpp
+++ b/include/crocoddyl/core/solver-base.hpp
@@ -315,8 +315,8 @@ class SolverAbstract {
   std::size_t iter_;      //!< Number of iteration performed by the solver
   double th_gaptol_;      //!< Threshold limit to check non-zero gaps
   double ffeas_;          //!< Feasibility of the dynamic constraints
-  bool inffeas_;  //!< True indicates if we use l-inf norm for computing the feasibility, otherwise false represents
-                  //!< the l-1 norm
+  bool inffeas_;     //!< True indicates if we use l-inf norm for computing the feasibility, otherwise false represents
+                     //!< the l-1 norm
   double tmp_feas_;  //!< Temporal variables used for computed the feasibility
 };
 

--- a/include/crocoddyl/core/solver-base.hpp
+++ b/include/crocoddyl/core/solver-base.hpp
@@ -99,10 +99,10 @@ class SolverAbstract {
    * need to run first `computeDirection()`. Additionally it returns the cost improvement along the predefined step
    * length.
    *
-   * @param[in]  stepLength  step length
-   * @return  The cost improvement
+   * @param[in] steplength  Step length
+   * @return  the cost improvement
    */
-  virtual double tryStep(const double step_length = 1) = 0;
+  virtual double tryStep(const double steplength = 1) = 0;
 
   /**
    * @brief Return a positive value that quantifies the algorithm termination
@@ -317,8 +317,6 @@ class SolverAbstract {
   double ffeas_;          //!< Feasibility of the dynamic constraints
   bool inffeas_;  //!< True indicates if we use l-inf norm for computing the feasibility, otherwise false represents
                   //!< the l-1 norm
-
- private:
   double tmp_feas_;  //!< Temporal variables used for computed the feasibility
 };
 

--- a/include/crocoddyl/core/solver-base.hpp
+++ b/include/crocoddyl/core/solver-base.hpp
@@ -317,6 +317,9 @@ class SolverAbstract {
   double ffeas_;          //!< Feasibility of the dynamic constraints
   bool inffeas_;  //!< True indicates if we use l-inf norm for computing the feasibility, otherwise false represents
                   //!< the l-1 norm
+
+ private:
+  double tmp_feas_;  //!< Temporal variables used for computed the feasibility
 };
 
 /**

--- a/include/crocoddyl/core/solver-base.hpp
+++ b/include/crocoddyl/core/solver-base.hpp
@@ -39,13 +39,13 @@ static std::vector<Eigen::VectorXd> DEFAULT_VECTOR;
  * specialize the cost functions, the system evolution and the admissible sets.
  *
  * The main routines are `computeDirection()` and `tryStep()`. The former finds a search direction and typically
- * computes the derivatives of each action model. The latter rollout the dynamics and cost (i.e. the action)
- * to try the search direction found by computeDirection. Both functions used the current guess defined by
- * setCandidate. Finally solve function is used to define when the search direction and length are
- * computed in each iterate. It also describes the globalization strategy (i.e. regularization) of the
+ * computes the derivatives of each action model. The latter rollout the dynamics and cost (i.e., the action)
+ * to try the search direction found by `computeDirection`. Both functions used the current guess defined by
+ * `setCandidate()`. Finally, `solve()` function is used to define when the search direction and length are
+ * computed in each iterate. It also describes the globalization strategy (i.e., regularization) of the
  * numerical optimization.
  *
- * \sa `computeDirection()` and `tryStep()`
+ * \sa `solve()`, `computeDirection()`, `tryStep()`, `stoppingCriteria()`
  */
 class SolverAbstract {
  public:
@@ -54,7 +54,7 @@ class SolverAbstract {
   /**
    * @brief Initialize the solver
    *
-   * @param[in] problem  Shooting problem
+   * @param[in] problem  shooting problem
    */
   explicit SolverAbstract(boost::shared_ptr<ShootingProblem> problem);
   virtual ~SolverAbstract();
@@ -80,26 +80,26 @@ class SolverAbstract {
                      const bool is_feasible = false, const double reg_init = 1e-9) = 0;
 
   /**
-   * @brief Compute the search direction \f$(\delta\mathbf{x},\delta\mathbf{u})\f$ for the current guess
-   * \f$(\mathbf{x}_s,\mathbf{u}_s)\f$
+   * @brief Compute the search direction \f$(\delta\mathbf{x}^k,\delta\mathbf{u}^k)\f$ for the current guess
+   * \f$(\mathbf{x}^k_s,\mathbf{u}^k_s)\f$.
    *
-   * You must call setCandidate first in order to define the current guess. A current guess defines a state
-   * and control trajectory \f$(\mathbf{x}_s,\mathbf{u}_s)\f$ of \f$T+1\f$ and \f$T\f$ elements, respectively.
+   * You must call `setCandidate()` first in order to define the current guess. A current guess defines a state
+   * and control trajectory \f$(\mathbf{x}^k_s,\mathbf{u}^k_s)\f$ of \f$T+1\f$ and \f$T\f$ elements, respectively.
    *
-   * @param[in] recalc  True for recalculating the derivatives at current state and control
+   * @param[in] recalc  true for recalculating the derivatives at current state and control
    * @return  The search direction \f$(\delta\mathbf{x},\delta\mathbf{u})\f$ and the dual lambdas as lists of
    * \f$T+1\f$, \f$T\f$ and \f$T+1\f$ lengths, respectively
    */
   virtual void computeDirection(const bool recalc) = 0;
 
   /**
-   * @brief Try a predefined step length and compute its cost improvement
+   * @brief Try a predefined step length \f$\alpha\f$ and compute its cost improvement \f$dV\f$.
    *
-   * It uses the search direction found by `computeDirection()` to try a determined step length \f$\alpha\f$; so you
-   * need to run first `computeDirection()`. Additionally it returns the cost improvement along the predefined step
-   * length.
+   * It uses the search direction found by `computeDirection()` to try a determined step length \f$\alpha\f$.
+   * Therefore, it assumes that we have run `computeDirection()` first. Additionally, it returns the cost improvement
+   * \f$dV\f$ along the predefined step length \f$\alpha\f$.
    *
-   * @param[in] steplength  Step length
+   * @param[in] steplength  applied step length (\f$0\leq\alpha\leq1\f$)
    * @return  the cost improvement
    */
   virtual double tryStep(const double steplength = 1) = 0;
@@ -108,34 +108,37 @@ class SolverAbstract {
    * @brief Return a positive value that quantifies the algorithm termination
    *
    * These values typically represents the gradient norm which tell us that it's been reached the local minima.
-   * This function is used to evaluate the algorithm convergence. The stopping criteria strictly speaking depends on
-   * the search direction (calculated by `computeDirection()`) but it could also depend on the chosen step length,
-   * tested by `tryStep()`.
+   * The stopping criteria strictly speaking depends on  the search direction (calculated by `computeDirection()`) but
+   * it could also depend on the chosen step length, tested by `tryStep()`.
    */
   virtual double stoppingCriteria() = 0;
 
   /**
-   * @brief Return the expected improvement from a given current search direction
+   * @brief Return the expected improvement \f$dV_{exp}\f$ from a given current search direction
+   * \f$(\delta\mathbf{x}^k,\delta\mathbf{u}^k)\f$
    *
-   * For computing the expected improvement, you need to compute first the search direction by running
-   * `computeDirection()`.
+   * For computing the expected improvement, you need to compute the search direction first via `computeDirection()`.
    */
   virtual const Eigen::Vector2d& expectedImprovement() = 0;
 
   /**
-   * @brief Compute the dynamic feasibility for the current guess
+   * @brief Compute the dynamic feasibility \f$\|\mathbf{f}_{\mathbf{s}}\|_{\infty,1}\f$ for
+   * the current guess \f$(\mathbf{x}^k,\mathbf{u}^k)\f$
    *
-   * The feasibility can be computed using the computed using the l-1 and l-inf norms.
-   * By default we use the l-inf norm, however, we can use the l-1 norm by doing set_inffeas(false).
+   * The feasibility can be computed using the computed using the \f$\ell_\infty\f$ and \f$\ell_1\f$ norms.
+   * By default we use the \f$\ell_\infty\f$ norm; however, we can use the \f$\ell_1\f$ norm via `set_inffeas()`.
+   * Note that \f$\mathbf{f}_{\mathbf{s}}\f$ are the gaps on the dynamics, which are computed at each node as
+   * \f$\mathbf{x}^{'}-\mathbf{f}(\mathbf{x},\mathbf{u})\f$.
    */
   double computeDynamicFeasibility();
 
   /**
-   * @brief Set the solver candidate warm-point values \f$(\mathbf{x}_s,\mathbf{u}_s)\f$
+   * @brief Set the solver candidate trajectories \f$(\mathbf{x}_s,\mathbf{u}_s)\f$
    *
    * The solver candidates are defined as a state and control trajectories \f$(\mathbf{x}_s,\mathbf{u}_s)\f$ of
-   * \f$T+1\f$ and \f$T\f$ elements, respectively. Additionally, we need to define is \f$(\mathbf{x}_s,\mathbf{u}_s)\f$
-   * pair is feasible, this means that the dynamics rollout give us produces \f$\mathbf{x}_s\f$.
+   * \f$T+1\f$ and \f$T\f$ elements, respectively. Additionally, we need to define the dynamic feasibility of the
+   * \f$(\mathbf{x}_s,\mathbf{u}_s)\f$ pair. Note that the trajectories are feasible if \f$\mathbf{x}_s\f$ is the
+   * resulting trajectory from the system rollout with \f$\mathbf{u}_s\f$ inputs.
    *
    * @param[in] xs          state trajectory of \f$T+1\f$ elements (default [])
    * @param[in] us          control trajectory of \f$T\f$ elements (default [])
@@ -145,7 +148,7 @@ class SolverAbstract {
                     const std::vector<Eigen::VectorXd>& us_warm = DEFAULT_VECTOR, const bool is_feasible = false);
 
   /**
-   * @brief Set a list of callback functions using for diagnostic
+   * @brief Set a list of callback functions using for the solver diagnostic
    *
    * Each iteration, the solver calls these set of functions in order to allowed user the diagnostic of its
    * performance.
@@ -155,7 +158,7 @@ class SolverAbstract {
   void setCallbacks(const std::vector<boost::shared_ptr<CallbackAbstract> >& callbacks);
 
   /**
-   * @brief "Return the list of callback functions using for diagnostic
+   * @brief Return the list of callback functions using for diagnostic
    */
   const std::vector<boost::shared_ptr<CallbackAbstract> >& getCallbacks() const;
 
@@ -175,7 +178,7 @@ class SolverAbstract {
   const std::vector<Eigen::VectorXd>& get_us() const;
 
   /**
-   * @brief Return the gaps \f$\mathbf{\bar{f}}_{s}\f$
+   * @brief Return the gaps \f$\mathbf{f}_{s}\f$
    */
   const std::vector<Eigen::VectorXd>& get_fs() const;
 
@@ -210,17 +213,17 @@ class SolverAbstract {
   double get_ureg() const;
 
   /**
-   * @brief Return the step length
+   * @brief Return the step length \f$\alpha\f$
    */
   double get_steplength() const;
 
   /**
-   * @brief Return the cost reduction
+   * @brief Return the cost reduction \f$dV\f$
    */
   double get_dV() const;
 
   /**
-   * @brief Return the expected cost reduction
+   * @brief Return the expected cost reduction \f$dV_{exp}\f$
    */
   double get_dVexp() const;
 
@@ -245,12 +248,13 @@ class SolverAbstract {
   double get_th_gaptol() const;
 
   /**
-   * @brief Return the feasibility of the dynamic constraints of the current guess
+   * @brief Return the feasibility of the dynamic constraints \f$\|\mathbf{f}_{\mathbf{s}}\|_{\infty,1}\f$ of the
+   * current guess
    */
   double get_ffeas() const;
 
   /**
-   * @brief Return the norm used for the computing the feasibility (true for l-inf, false for l-1)
+   * @brief Return the norm used for the computing the feasibility (true for \f$\ell_\infty\f$, false for \f$\ell_1\f$)
    */
   bool get_inffeas() const;
 

--- a/include/crocoddyl/core/solvers/fddp.hpp
+++ b/include/crocoddyl/core/solvers/fddp.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2019-2021, LAAS-CNRS, University of Edinburgh
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -45,7 +45,7 @@ namespace crocoddyl {
  * For more details about the feasibility-driven differential dynamic programming algorithm see:
  * \include mastalli-icra20.bib
  *
- * \sa `backwardPass()`, `forwardPass()`, `expectedImprovement()` and `updateExpectedImprovement()`
+ * \sa `SolverDDP()`, `backwardPass()`, `forwardPass()`, `expectedImprovement()` and `updateExpectedImprovement()`
  */
 class SolverFDDP : public SolverDDP {
  public:
@@ -53,6 +53,8 @@ class SolverFDDP : public SolverDDP {
 
   /**
    * @brief Initialize the FDDP solver
+   *
+   * @param[in] problem  shooting problem
    */
   explicit SolverFDDP(boost::shared_ptr<ShootingProblem> problem);
   virtual ~SolverFDDP();

--- a/src/core/solver-base.cpp
+++ b/src/core/solver-base.cpp
@@ -81,11 +81,6 @@ double SolverAbstract::computeDynamicFeasibility() {
         tmp_feas_ += fs_[t + 1].lpNorm<1>();
       }
     }
-    if (tmp_feas_ <= th_gaptol_) {
-      is_feasible_ = true;
-    } else {
-      is_feasible_ = false;
-    }
   } else if (!was_feasible_) {  // closing the gaps
     for (std::vector<Eigen::VectorXd>::iterator it = fs_.begin(); it != fs_.end(); ++it) {
       it->setZero();

--- a/src/core/solvers/ddp.cpp
+++ b/src/core/solvers/ddp.cpp
@@ -203,7 +203,7 @@ void SolverDDP::backwardPass() {
     START_PROFILER("SolverDDP::Qx");
     Qx_[t] = d->Lx;
     Qx_[t].noalias() += d->Fx.transpose() * Vx_p;
-    STOP_PROFILER("SolverDDP::Qxx");
+    STOP_PROFILER("SolverDDP::Qx");
     START_PROFILER("SolverDDP::Qxx");
     Qxx_[t] = d->Lxx;
     Qxx_[t].noalias() += FxTVxx_p_ * d->Fx;

--- a/src/core/solvers/ddp.cpp
+++ b/src/core/solvers/ddp.cpp
@@ -199,26 +199,29 @@ void SolverDDP::backwardPass() {
     const Eigen::VectorXd& Vx_p = Vx_[t + 1];
     const std::size_t nu = m->get_nu();
 
-    Qxx_[t] = d->Lxx;
-    Qx_[t] = d->Lx;
-    START_PROFILER("SolverDDP::Qxx");
     FxTVxx_p_.noalias() = d->Fx.transpose() * Vxx_p;
+    START_PROFILER("SolverDDP::Qx");
+    Qx_[t] = d->Lx;
+    Qx_[t].noalias() += d->Fx.transpose() * Vx_p;
+    STOP_PROFILER("SolverDDP::Qxx");
+    START_PROFILER("SolverDDP::Qxx");
+    Qxx_[t] = d->Lxx;
     Qxx_[t].noalias() += FxTVxx_p_ * d->Fx;
     STOP_PROFILER("SolverDDP::Qxx");
-    Qx_[t].noalias() += d->Fx.transpose() * Vx_p;
     if (nu != 0) {
-      Qxu_[t].leftCols(nu) = d->Lxu;
-      Quu_[t].topLeftCorner(nu, nu) = d->Luu;
-      Qu_[t].head(nu) = d->Lu;
-      START_PROFILER("SolverDDP::Qxu");
-      Qxu_[t].leftCols(nu).noalias() += FxTVxx_p_ * d->Fu;
-      STOP_PROFILER("SolverDDP::Qxu");
-      START_PROFILER("SolverDDP::Quu");
       FuTVxx_p_[t].topRows(nu).noalias() = d->Fu.transpose() * Vxx_p;
+      START_PROFILER("SolverDDP::Qu");
+      Qu_[t].head(nu) = d->Lu;
+      Qu_[t].head(nu).noalias() += d->Fu.transpose() * Vx_p;
+      STOP_PROFILER("SolverDDP::Qu");
+      START_PROFILER("SolverDDP::Quu");
+      Quu_[t].topLeftCorner(nu, nu) = d->Luu;
       Quu_[t].topLeftCorner(nu, nu).noalias() += FuTVxx_p_[t].topRows(nu) * d->Fu;
       STOP_PROFILER("SolverDDP::Quu");
-      Qu_[t].head(nu).noalias() += d->Fu.transpose() * Vx_p;
-
+      START_PROFILER("SolverDDP::Qxu");
+      Qxu_[t].leftCols(nu) = d->Lxu;
+      Qxu_[t].leftCols(nu).noalias() += FxTVxx_p_ * d->Fu;
+      STOP_PROFILER("SolverDDP::Qxu");
       if (!std::isnan(ureg_)) {
         Quu_[t].diagonal().head(nu).array() += ureg_;
       }

--- a/src/core/solvers/ddp.cpp
+++ b/src/core/solvers/ddp.cpp
@@ -172,7 +172,7 @@ double SolverDDP::calcDiff() {
   }
   cost_ = problem_->calcDiff(xs_, us_);
 
-  computeDynamicFeasibility();
+  ffeas_ = computeDynamicFeasibility();
   STOP_PROFILER("SolverDDP::calcDiff");
   return cost_;
 }


### PR DESCRIPTION
This PR proposes
  1. Improve the documentation of the DDP, FDDP and Solver abstraction
  2. Allocate temporal for internally storing the dynamic feasibility
  3. Wrap dV, dVexp in Python
  4.  Remove the setting of`is_feasible` in `computeDynamicFeasibility` (it could affect any solver that relies on it)