### PR TITLE
Enable profiler at runtime

### DIFF
--- a/bindings/python/crocoddyl/core/utils/stop-watch.cpp
+++ b/bindings/python/crocoddyl/core/utils/stop-watch.cpp
@@ -15,6 +15,10 @@ using namespace boost::python;
 namespace crocoddyl {
 namespace python {
 
+void enable_report() { getProfiler().enable_profiler(); }
+
+void disable_report() { getProfiler().disable_profiler(); }
+
 void stop_watch_report(int precision) { getProfiler().report_all(precision); }
 
 long double stop_watch_get_average_time(const std::string& perf_name) {
@@ -32,6 +36,10 @@ long double stop_watch_get_total_time(const std::string& perf_name) { return get
 void stop_watch_reset_all() { getProfiler().reset_all(); }
 
 void exposeStopWatch() {
+  bp::def("enable_profiler", enable_report, "Enable the profiler report.");
+
+  bp::def("disable_profiler", enable_report, "Disable the profiler report.");
+
   bp::def("stop_watch_report", stop_watch_report, "Report all the times measured by the shared stop-watch.");
 
   bp::def("stop_watch_get_average_time", stop_watch_get_average_time,

--- a/include/crocoddyl/core/optctrl/shooting.hxx
+++ b/include/crocoddyl/core/optctrl/shooting.hxx
@@ -10,6 +10,7 @@
 #ifdef CROCODDYL_WITH_MULTITHREADING
 #include <omp.h>
 #endif  // CROCODDYL_WITH_MULTITHREADING
+#include "crocoddyl/core/utils/stop-watch.hpp"
 
 namespace crocoddyl {
 
@@ -149,6 +150,7 @@ Scalar ShootingProblemTpl<Scalar>::calc(const std::vector<VectorXs>& xs, const s
     throw_pretty("Invalid argument: "
                  << "us has wrong dimension (it should be " + std::to_string(T_) + ")");
   }
+  START_PROFILER("ShootingProblem::calc");
 
 #ifdef CROCODDYL_WITH_MULTITHREADING
 #pragma omp parallel for num_threads(nthreads_)
@@ -171,6 +173,7 @@ Scalar ShootingProblemTpl<Scalar>::calc(const std::vector<VectorXs>& xs, const s
     cost_ += running_datas_[i]->cost;
   }
   cost_ += terminal_data_->cost;
+  STOP_PROFILER("ShootingProblem::calc");
   return cost_;
 }
 
@@ -184,6 +187,7 @@ Scalar ShootingProblemTpl<Scalar>::calcDiff(const std::vector<VectorXs>& xs, con
     throw_pretty("Invalid argument: "
                  << "us has wrong dimension (it should be " + std::to_string(T_) + ")");
   }
+  START_PROFILER("ShootingProblem::calcDiff");
 
 #ifdef CROCODDYL_WITH_MULTITHREADING
 #pragma omp parallel for num_threads(nthreads_)
@@ -207,6 +211,7 @@ Scalar ShootingProblemTpl<Scalar>::calcDiff(const std::vector<VectorXs>& xs, con
   }
   cost_ += terminal_data_->cost;
 
+  STOP_PROFILER("ShootingProblem::calcDiff");
   return cost_;
 }
 
@@ -220,6 +225,7 @@ void ShootingProblemTpl<Scalar>::rollout(const std::vector<VectorXs>& us, std::v
     throw_pretty("Invalid argument: "
                  << "us has wrong dimension (it should be " + std::to_string(T_) + ")");
   }
+  START_PROFILER("ShootingProblem::rollout");
 
   xs[0] = x0_;
   for (std::size_t i = 0; i < T_; ++i) {
@@ -236,6 +242,7 @@ void ShootingProblemTpl<Scalar>::rollout(const std::vector<VectorXs>& us, std::v
     xs[i + 1] = data->xnext;
   }
   terminal_model_->calc(terminal_data_, xs.back());
+  STOP_PROFILER("ShootingProblem::rollout");
 }
 
 template <typename Scalar>

--- a/include/crocoddyl/core/solver-base.hpp
+++ b/include/crocoddyl/core/solver-base.hpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "crocoddyl/core/optctrl/shooting.hpp"
+#include "crocoddyl/core/utils/stop-watch.hpp"
 
 namespace crocoddyl {
 

--- a/include/crocoddyl/core/utils/stop-watch.hpp
+++ b/include/crocoddyl/core/utils/stop-watch.hpp
@@ -34,16 +34,8 @@
 #pragma GCC visibility push(default)
 #endif
 
-// Uncomment the following line to activate the profiler
-//#define PROFILER_ACTIVE
-
-#ifdef PROFILER_ACTIVE
-#define START_PROFILER(name) getProfiler().start(name)
-#define STOP_PROFILER(name) getProfiler().stop(name)
-#else
-#define START_PROFILER(name)
-#define STOP_PROFILER(name)
-#endif
+#define START_PROFILER(name) getProfiler().profiler_status() ? getProfiler().start(name) : void()
+#define STOP_PROFILER(name) getProfiler().profiler_status() ? getProfiler().stop(name) : void()
 
 #define STOP_WATCH_MAX_NAME_LENGTH 60
 #define STOP_WATCH_TIME_WIDTH 10
@@ -163,6 +155,15 @@ class Stopwatch {
   /** @brief Destructor */
   ~Stopwatch();
 
+  /** @brief Enable the profiler **/
+  void enable_profiler();
+
+  /** @brief Disable the profiler **/
+  void disable_profiler();
+
+  /** @brief Return if the profiler is enable or disable **/
+  bool profiler_status();
+
   /** @brief Tells if a performance with a certain ID exists */
   bool performance_exists(std::string perf_name);
 
@@ -238,6 +239,7 @@ class Stopwatch {
   bool active;                                         //!< Flag to hold the clock's status
   StopwatchMode mode;                                  //!< Time taking mode
   std::map<std::string, PerformanceData> *records_of;  //!< Dynamic collection of performance data
+  bool profiler_active;                                //!< Indicates if the profiler is enabled
 };
 
 Stopwatch &getProfiler();

--- a/src/core/solvers/ddp.cpp
+++ b/src/core/solvers/ddp.cpp
@@ -132,7 +132,9 @@ void SolverDDP::computeDirection(const bool recalcDiff) {
 }
 
 double SolverDDP::tryStep(const double steplength) {
+  START_PROFILER("SolverDDP::tryStep");
   forwardPass(steplength);
+  STOP_PROFILER("SolverDDP::tryStep");
   return cost_ - cost_try_;
 }
 

--- a/src/core/solvers/ddp.cpp
+++ b/src/core/solvers/ddp.cpp
@@ -10,7 +10,6 @@
 
 #include "crocoddyl/core/solvers/ddp.hpp"
 #include "crocoddyl/core/utils/exception.hpp"
-#include "crocoddyl/core/utils/stop-watch.hpp"
 
 namespace crocoddyl {
 
@@ -261,11 +260,11 @@ void SolverDDP::backwardPass() {
 }
 
 void SolverDDP::forwardPass(const double steplength) {
-  START_PROFILER("SolverDDP::forwardPass");
   if (steplength > 1. || steplength < 0.) {
     throw_pretty("Invalid argument: "
                  << "invalid step length, value is between 0. to 1.");
   }
+  START_PROFILER("SolverDDP::forwardPass");
   cost_try_ = 0.;
   const std::size_t T = problem_->get_T();
   const std::vector<boost::shared_ptr<ActionModelAbstract> >& models = problem_->get_runningModels();
@@ -289,9 +288,11 @@ void SolverDDP::forwardPass(const double steplength) {
     cost_try_ += d->cost;
 
     if (raiseIfNaN(cost_try_)) {
+      STOP_PROFILER("SolverDDP::forwardPass");
       throw_pretty("forward_error");
     }
     if (raiseIfNaN(xs_try_[t + 1].lpNorm<Eigen::Infinity>())) {
+      STOP_PROFILER("SolverDDP::forwardPass");
       throw_pretty("forward_error");
     }
   }
@@ -302,6 +303,7 @@ void SolverDDP::forwardPass(const double steplength) {
   cost_try_ += d->cost;
 
   if (raiseIfNaN(cost_try_)) {
+    STOP_PROFILER("SolverDDP::forwardPass");
     throw_pretty("forward_error");
   }
   STOP_PROFILER("SolverDDP::forwardPass");
@@ -316,6 +318,7 @@ void SolverDDP::computeGains(const std::size_t t) {
     STOP_PROFILER("SolverDDP::Quu_inv");
     const Eigen::ComputationInfo& info = Quu_llt_[t].info();
     if (info != Eigen::Success) {
+      STOP_PROFILER("SolverDDP::computeGains");
       throw_pretty("backward_error");
     }
     K_[t].topRows(nu) = Qxu_[t].leftCols(nu).transpose();

--- a/src/core/solvers/fddp.cpp
+++ b/src/core/solvers/fddp.cpp
@@ -22,6 +22,7 @@ SolverFDDP::~SolverFDDP() {}
 
 bool SolverFDDP::solve(const std::vector<Eigen::VectorXd>& init_xs, const std::vector<Eigen::VectorXd>& init_us,
                        const std::size_t maxiter, const bool is_feasible, const double reginit) {
+  START_PROFILER("SolverFDDP::solve");
   xs_try_[0] = problem_->get_x0();  // it is needed in case that init_xs[0] is infeasible
   setCandidate(init_xs, init_us, is_feasible);
 
@@ -90,6 +91,7 @@ bool SolverFDDP::solve(const std::vector<Eigen::VectorXd>& init_xs, const std::v
     if (steplength_ <= th_stepinc_) {
       increaseRegularization();
       if (xreg_ == reg_max_) {
+        STOP_PROFILER("SolverFDDP::solve");
         return false;
       }
     }
@@ -102,9 +104,11 @@ bool SolverFDDP::solve(const std::vector<Eigen::VectorXd>& init_xs, const std::v
     }
 
     if (was_feasible_ && stop_ < th_stop_) {
+      STOP_PROFILER("SolverFDDP::solve");
       return true;
     }
   }
+  STOP_PROFILER("SolverFDDP::solve");
   return false;
 }
 
@@ -157,6 +161,7 @@ void SolverFDDP::forwardPass(const double steplength) {
     throw_pretty("Invalid argument: "
                  << "invalid step length, value is between 0. to 1.");
   }
+  START_PROFILER("SolverFDDP::forwardPass");
   cost_try_ = 0.;
   xnext_ = problem_->get_x0();
   const std::size_t T = problem_->get_T();
@@ -180,9 +185,11 @@ void SolverFDDP::forwardPass(const double steplength) {
       cost_try_ += d->cost;
 
       if (raiseIfNaN(cost_try_)) {
+        STOP_PROFILER("SolverFDDP::forwardPass");
         throw_pretty("forward_error");
       }
       if (raiseIfNaN(xnext_.lpNorm<Eigen::Infinity>())) {
+        STOP_PROFILER("SolverFDDP::forwardPass");
         throw_pretty("forward_error");
       }
     }
@@ -194,6 +201,7 @@ void SolverFDDP::forwardPass(const double steplength) {
     cost_try_ += d->cost;
 
     if (raiseIfNaN(cost_try_)) {
+      STOP_PROFILER("SolverFDDP::forwardPass");
       throw_pretty("forward_error");
     }
   } else {
@@ -213,9 +221,11 @@ void SolverFDDP::forwardPass(const double steplength) {
       cost_try_ += d->cost;
 
       if (raiseIfNaN(cost_try_)) {
+        STOP_PROFILER("SolverFDDP::forwardPass");
         throw_pretty("forward_error");
       }
       if (raiseIfNaN(xnext_.lpNorm<Eigen::Infinity>())) {
+        STOP_PROFILER("SolverFDDP::forwardPass");
         throw_pretty("forward_error");
       }
     }
@@ -227,9 +237,11 @@ void SolverFDDP::forwardPass(const double steplength) {
     cost_try_ += d->cost;
 
     if (raiseIfNaN(cost_try_)) {
+      STOP_PROFILER("SolverFDDP::forwardPass");
       throw_pretty("forward_error");
     }
   }
+  STOP_PROFILER("SolverFDDP::forwardPass");
 }
 
 double SolverFDDP::get_th_acceptnegstep() const { return th_acceptnegstep_; }

--- a/src/core/utils/stop-watch.cpp
+++ b/src/core/utils/stop-watch.cpp
@@ -42,11 +42,17 @@ Stopwatch& getProfiler() {
   return s;
 }
 
-Stopwatch::Stopwatch(StopwatchMode _mode) : active(true), mode(_mode) {
+Stopwatch::Stopwatch(StopwatchMode _mode) : active(true), mode(_mode), profiler_active(false) {
   records_of = new map<string, PerformanceData>();
 }
 
 Stopwatch::~Stopwatch() { delete records_of; }
+
+void Stopwatch::enable_profiler() { profiler_active = true; }
+
+void Stopwatch::disable_profiler() { profiler_active = false; }
+
+bool Stopwatch::profiler_status() { return profiler_active; }
 
 void Stopwatch::set_mode(StopwatchMode new_mode) { mode = new_mode; }
 


### PR DESCRIPTION
This PR proposes a method for enabling at runtime the profiler. This will be something like this:
```c++
  getProfiler().enable_profiler();
 \\ run algorithm
  getProfiler().report_all();
```
or
```python
crocoddyl.enable_profiler()
# run algorithm
crocoddyl.stop_watch_report(5)
```

This simplifies at lot the performance analysis.

Additionally, this PR includes other macros for profiling DDP, FDDP and BoxDDP solvers.