### PR TITLE
Manage 2d contact friction in xz plane

### DIFF
--- a/include/crocoddyl/multibody/residuals/contact-friction-cone.hpp
+++ b/include/crocoddyl/multibody/residuals/contact-friction-cone.hpp
@@ -15,6 +15,7 @@
 #include "crocoddyl/multibody/contact-base.hpp"
 #include "crocoddyl/multibody/impulse-base.hpp"
 #include "crocoddyl/multibody/contacts/multiple-contacts.hpp"
+#include "crocoddyl/multibody/contacts/contact-2d.hpp"
 #include "crocoddyl/multibody/contacts/contact-3d.hpp"
 #include "crocoddyl/multibody/contacts/contact-6d.hpp"
 #include "crocoddyl/multibody/impulses/multiple-impulses.hpp"
@@ -189,7 +190,9 @@ struct ResidualDataContactFrictionConeTpl : public ResidualDataAbstractTpl<_Scal
 
   template <template <typename Scalar> class Model>
   ResidualDataContactFrictionConeTpl(Model<Scalar>* const model, DataCollectorAbstract* const data)
-      : Base(model, data), more_than_3_constraints(false) {
+      : Base(model, data) {
+    contact_type = ContactUndefined;
+
     // Check that proper shared data has been passed
     bool is_contact = true;
     DataCollectorContactTpl<Scalar>* d1 = dynamic_cast<DataCollectorContactTpl<Scalar>*>(shared);
@@ -211,20 +214,28 @@ struct ResidualDataContactFrictionConeTpl : public ResidualDataAbstractTpl<_Scal
       for (typename ContactModelMultiple::ContactDataContainer::iterator it = d1->contacts->contacts.begin();
            it != d1->contacts->contacts.end(); ++it) {
         if (it->second->frame == id) {
+          ContactData2DTpl<Scalar>* d2d = dynamic_cast<ContactData2DTpl<Scalar> *>(it->second.get());
+          if (d2d != NULL) {
+            contact_type = Contact2D;
+            found_contact = true;
+            contact = it->second;
+            break;
+          }
           ContactData3DTpl<Scalar>* d3d = dynamic_cast<ContactData3DTpl<Scalar>*>(it->second.get());
           if (d3d != NULL) {
+            contact_type = Contact3D;
             found_contact = true;
             contact = it->second;
             break;
           }
           ContactData6DTpl<Scalar>* d6d = dynamic_cast<ContactData6DTpl<Scalar>*>(it->second.get());
           if (d6d != NULL) {
-            more_than_3_constraints = true;
+            contact_type = Contact6D;
             found_contact = true;
             contact = it->second;
             break;
           }
-          throw_pretty("Domain error: there isn't defined at least a 3d contact for " + frame_name);
+          throw_pretty("Domain error: there isn't defined at least a 2d contact for " + frame_name);
           break;
         }
       }
@@ -234,13 +245,14 @@ struct ResidualDataContactFrictionConeTpl : public ResidualDataAbstractTpl<_Scal
         if (it->second->frame == id) {
           ImpulseData3DTpl<Scalar>* d3d = dynamic_cast<ImpulseData3DTpl<Scalar>*>(it->second.get());
           if (d3d != NULL) {
+            contact_type = Contact3D;
             found_contact = true;
             contact = it->second;
             break;
           }
           ImpulseData6DTpl<Scalar>* d6d = dynamic_cast<ImpulseData6DTpl<Scalar>*>(it->second.get());
           if (d6d != NULL) {
-            more_than_3_constraints = true;
+            contact_type = Contact6D;
             found_contact = true;
             contact = it->second;
             break;
@@ -256,7 +268,8 @@ struct ResidualDataContactFrictionConeTpl : public ResidualDataAbstractTpl<_Scal
   }
 
   boost::shared_ptr<ForceDataAbstractTpl<Scalar> > contact;  //!< Contact force data
-  bool more_than_3_constraints;                              //!< Label that indicates if the contact is bigger than 3D
+  ContactType contact_type; //!< Type of contact (2D / 3D / 6D)
+  
   using Base::r;
   using Base::Ru;
   using Base::Rx;

--- a/include/crocoddyl/multibody/residuals/contact-friction-cone.hxx
+++ b/include/crocoddyl/multibody/residuals/contact-friction-cone.hxx
@@ -50,12 +50,25 @@ void ResidualModelContactFrictionConeTpl<Scalar>::calcDiff(const boost::shared_p
   const MatrixXs& df_dx = d->contact->df_dx;
   const MatrixXs& df_du = d->contact->df_du;
   const MatrixX3s& A = fref_.get_A();
-  if (d->more_than_3_constraints) {
-    data->Rx.noalias() = A * df_dx.template topRows<3>();
-    data->Ru.noalias() = A * df_du.template topRows<3>();
-  } else {
+  
+  switch (d->contact_type) {
+  case Contact2D: {
+    MatrixXs A_2d(A.rows(), 2);
+    A_2d << A.col(0), A.col(2);
+    data->Rx.noalias() = A_2d * df_dx;
+    data->Ru.noalias() = A_2d * df_du;
+    break;
+  }
+  case Contact3D:
     data->Rx.noalias() = A * df_dx;
     data->Ru.noalias() = A * df_du;
+    break;
+  case Contact6D:
+    data->Rx.noalias() = A * df_dx.template topRows<3>();
+    data->Ru.noalias() = A * df_du.template topRows<3>();
+    break;
+  default:
+    break;
   }
 }
 


### PR DESCRIPTION
In reference of #986 problem I have added some changes in order to have 2d contact taken into account for residual value calculation (before it was only possible for at least 3d contact). Drawbacks:

1. This solution works for xz plane for now (now I am able to generate motion with one legged robot stand):
![image](https://user-images.githubusercontent.com/30003101/133800336-058595af-ceb1-460f-9a52-27ef1e479524.png) 
I am not sure how to make it more general. I would assume that for other cases I just need to take different columns of the A matrix, but not sure what would be the best way to get the axis of the plane of interest.

2. Maybe formatting is wrong since docker container image from [Developer-Guide](https://github.com/loco-3d/crocoddyl/wiki/Developer-Guide) would change almost all files in the repo. 