### PR TITLE
Fixed computation of coefficient in  poly-two-rk4 parametrization

### DIFF
--- a/include/crocoddyl/core/controls/poly-two-rk4.hxx
+++ b/include/crocoddyl/core/controls/poly-two-rk4.hxx
@@ -29,8 +29,8 @@ void ControlParametrizationModelPolyTwoRK4Tpl<Scalar>::calc(
   const Eigen::VectorBlock<const Eigen::Ref<const VectorXs> >& p2 = u.tail(nw_);
   d->tmp_t2 = t * t;
   d->c[2] = 2 * d->tmp_t2 - t;
-  d->c[1] = -2 * d->c[2];
-  d->c[0] = 1 - 2 * t + d->c[2];
+  d->c[1] = -2 * d->c[2] + 2 * t;
+  d->c[0] = d->c[2] - 2 * t + 1;
   d->w = d->c[2] * p2 + d->c[1] * p1 + d->c[0] * p0;
 }
 


### PR DESCRIPTION
Hey @andreadelprete!

I noticed we have an error in the computation of `c[1]`, which it is fixed in this PR.
Additionally, this fixes the numerical-convergence issues on the MPC algorithm which I reported to you.

Thanks for sharing your notes.
I will later (no in this PR) work on RK3 integrator and its parametrization.