### PR TITLE
Corrected the python description of 2norm-barrier activation function

### DIFF
--- a/bindings/python/crocoddyl/core/activations/2norm-barrier.cpp
+++ b/bindings/python/crocoddyl/core/activations/2norm-barrier.cpp
@@ -18,7 +18,7 @@ void exposeActivation2NormBarrier() {
       "ActivationModel2NormBarrier",
       "An 2-norm activation model for a defined barrier alpha\n\n"
       "If the residual is lower than an alpha threshold, this function imposes a quadratic term. \n"
-      "In short, the activation value is 0 if the residual is lower than alpha, otherwise, it is \n"
+      "In short, the activation value is 0 if the residual is major or equals to alpha, otherwise, it is \n"
       "equals to 0.5 *(||r|| - alpha)^2",
       bp::init<std::size_t, bp::optional<double, bool> >(bp::args("self", "nr", "alpha", "true_hessian"),
                                                          "Initialize the activation model.\n\n"


### PR DESCRIPTION
The python description of 2norm-barrier is the opposite of the cpp description. 

Python explanation: if residual < alpha, value = 0
https://github.com/loco-3d/crocoddyl/blob/master/bindings/python/crocoddyl/core/activations/2norm-barrier.cpp#L19

Cpp explanation: if residual > alpha, value = 0
https://github.com/loco-3d/crocoddyl/blob/master/include/crocoddyl/core/activations/2norm-barrier.hpp#L24

The cpp explanation should be the correct one.