### PR TITLE
[Update] Manage 2d contact friction in xz plane

### DIFF
--- a/include/crocoddyl/multibody/residuals/contact-friction-cone.hpp
+++ b/include/crocoddyl/multibody/residuals/contact-friction-cone.hpp
@@ -234,7 +234,7 @@ struct ResidualDataContactFrictionConeTpl : public ResidualDataAbstractTpl<_Scal
             contact = it->second;
             break;
           }
-          throw_pretty("Domain error: there isn't defined at least a 3d contact for " + frame_name);
+          throw_pretty("Domain error: there isn't defined at least a 2d contact for " + frame_name);
           break;
         }
       }

--- a/include/crocoddyl/multibody/residuals/contact-friction-cone.hpp
+++ b/include/crocoddyl/multibody/residuals/contact-friction-cone.hpp
@@ -15,6 +15,7 @@
 #include "crocoddyl/multibody/contact-base.hpp"
 #include "crocoddyl/multibody/impulse-base.hpp"
 #include "crocoddyl/multibody/contacts/multiple-contacts.hpp"
+#include "crocoddyl/multibody/contacts/contact-2d.hpp"
 #include "crocoddyl/multibody/contacts/contact-3d.hpp"
 #include "crocoddyl/multibody/contacts/contact-6d.hpp"
 #include "crocoddyl/multibody/impulses/multiple-impulses.hpp"
@@ -189,7 +190,8 @@ struct ResidualDataContactFrictionConeTpl : public ResidualDataAbstractTpl<_Scal
 
   template <template <typename Scalar> class Model>
   ResidualDataContactFrictionConeTpl(Model<Scalar>* const model, DataCollectorAbstract* const data)
-      : Base(model, data), more_than_3_constraints(false) {
+      : Base(model, data) {
+    contact_type = ContactUndefined;
     // Check that proper shared data has been passed
     bool is_contact = true;
     DataCollectorContactTpl<Scalar>* d1 = dynamic_cast<DataCollectorContactTpl<Scalar>*>(shared);
@@ -211,15 +213,23 @@ struct ResidualDataContactFrictionConeTpl : public ResidualDataAbstractTpl<_Scal
       for (typename ContactModelMultiple::ContactDataContainer::iterator it = d1->contacts->contacts.begin();
            it != d1->contacts->contacts.end(); ++it) {
         if (it->second->frame == id) {
+          ContactData2DTpl<Scalar>* d2d = dynamic_cast<ContactData2DTpl<Scalar>*>(it->second.get());
+          if (d2d != NULL) {
+            contact_type = Contact2D;
+            found_contact = true;
+            contact = it->second;
+            break;
+          }
           ContactData3DTpl<Scalar>* d3d = dynamic_cast<ContactData3DTpl<Scalar>*>(it->second.get());
           if (d3d != NULL) {
+            contact_type = Contact3D;
             found_contact = true;
             contact = it->second;
             break;
           }
           ContactData6DTpl<Scalar>* d6d = dynamic_cast<ContactData6DTpl<Scalar>*>(it->second.get());
           if (d6d != NULL) {
-            more_than_3_constraints = true;
+            contact_type = Contact6D;
             found_contact = true;
             contact = it->second;
             break;
@@ -234,13 +244,14 @@ struct ResidualDataContactFrictionConeTpl : public ResidualDataAbstractTpl<_Scal
         if (it->second->frame == id) {
           ImpulseData3DTpl<Scalar>* d3d = dynamic_cast<ImpulseData3DTpl<Scalar>*>(it->second.get());
           if (d3d != NULL) {
+            contact_type = Contact3D;
             found_contact = true;
             contact = it->second;
             break;
           }
           ImpulseData6DTpl<Scalar>* d6d = dynamic_cast<ImpulseData6DTpl<Scalar>*>(it->second.get());
           if (d6d != NULL) {
-            more_than_3_constraints = true;
+            contact_type = Contact6D;
             found_contact = true;
             contact = it->second;
             break;
@@ -256,7 +267,7 @@ struct ResidualDataContactFrictionConeTpl : public ResidualDataAbstractTpl<_Scal
   }
 
   boost::shared_ptr<ForceDataAbstractTpl<Scalar> > contact;  //!< Contact force data
-  bool more_than_3_constraints;                              //!< Label that indicates if the contact is bigger than 3D
+  ContactType contact_type;                                  //!< Type of contact (2D / 3D / 6D)
   using Base::r;
   using Base::Ru;
   using Base::Rx;

--- a/include/crocoddyl/multibody/residuals/contact-friction-cone.hxx
+++ b/include/crocoddyl/multibody/residuals/contact-friction-cone.hxx
@@ -54,8 +54,8 @@ void ResidualModelContactFrictionConeTpl<Scalar>::calcDiff(const boost::shared_p
   switch (d->contact_type) {
     case Contact2D: {
       // Valid for xz plane
-      data->Rx.noalias() = A(Eigen::all, {0, 2}) * df_dx;
-      data->Ru.noalias() = A(Eigen::all, {0, 2}) * df_du;
+      data->Rx.noalias() = A.col(0) * df_dx.row(0) + A.col(2) * df_dx.row(1);
+      data->Ru.noalias() = A.col(0) * df_du.row(0) + A.col(2) * df_du.row(1);
       break;
     }
     case Contact3D:

--- a/include/crocoddyl/multibody/residuals/contact-friction-cone.hxx
+++ b/include/crocoddyl/multibody/residuals/contact-friction-cone.hxx
@@ -50,12 +50,24 @@ void ResidualModelContactFrictionConeTpl<Scalar>::calcDiff(const boost::shared_p
   const MatrixXs& df_dx = d->contact->df_dx;
   const MatrixXs& df_du = d->contact->df_du;
   const MatrixX3s& A = fref_.get_A();
-  if (d->more_than_3_constraints) {
-    data->Rx.noalias() = A * df_dx.template topRows<3>();
-    data->Ru.noalias() = A * df_du.template topRows<3>();
-  } else {
-    data->Rx.noalias() = A * df_dx;
-    data->Ru.noalias() = A * df_du;
+
+  switch (d->contact_type) {
+    case Contact2D: {
+      // Valid for xz plane
+      data->Rx.noalias() = A(Eigen::all, {0, 2}) * df_dx;
+      data->Ru.noalias() = A(Eigen::all, {0, 2}) * df_du;
+      break;
+    }
+    case Contact3D:
+      data->Rx.noalias() = A * df_dx;
+      data->Ru.noalias() = A * df_du;
+      break;
+    case Contact6D:
+      data->Rx.noalias() = A * df_dx.template topRows<3>();
+      data->Ru.noalias() = A * df_du.template topRows<3>();
+      break;
+    default:
+      break;
   }
 }
 

--- a/unittest/factory/diff_action.cpp
+++ b/unittest/factory/diff_action.cpp
@@ -48,6 +48,9 @@ std::ostream& operator<<(std::ostream& os, DifferentialActionModelTypes::Type ty
     case DifferentialActionModelTypes::DifferentialActionModelContactFwdDynamics_TalosArm:
       os << "DifferentialActionModelContactFwdDynamics_TalosArm";
       break;
+    case DifferentialActionModelTypes::DifferentialActionModelContact2DFwdDynamics_TalosArm:
+      os << "DifferentialActionModelContact2DFwdDynamics_TalosArm";
+      break;
     case DifferentialActionModelTypes::DifferentialActionModelContactFwdDynamics_HyQ:
       os << "DifferentialActionModelContactFwdDynamics_HyQ";
       break;
@@ -56,6 +59,9 @@ std::ostream& operator<<(std::ostream& os, DifferentialActionModelTypes::Type ty
       break;
     case DifferentialActionModelTypes::DifferentialActionModelContactFwdDynamicsWithFriction_TalosArm:
       os << "DifferentialActionModelContactFwdDynamicsWithFriction_TalosArm";
+      break;
+    case DifferentialActionModelTypes::DifferentialActionModelContact2DFwdDynamicsWithFriction_TalosArm:
+      os << "DifferentialActionModelContact2DFwdDynamicsWithFriction_TalosArm";
       break;
     case DifferentialActionModelTypes::DifferentialActionModelContactFwdDynamicsWithFriction_HyQ:
       os << "DifferentialActionModelContactFwdDynamicsWithFriction_HyQ";
@@ -97,6 +103,10 @@ boost::shared_ptr<crocoddyl::DifferentialActionModelAbstract> DifferentialAction
       action = create_contactFwdDynamics(StateModelTypes::StateMultibody_TalosArm,
                                          ActuationModelTypes::ActuationModelFull, false);
       break;
+    case DifferentialActionModelTypes::DifferentialActionModelContact2DFwdDynamics_TalosArm:
+      action = create_contactFwdDynamics(StateModelTypes::StateMultibodyContact2D_TalosArm,
+                                         ActuationModelTypes::ActuationModelFull, false);
+      break;
     case DifferentialActionModelTypes::DifferentialActionModelContactFwdDynamics_HyQ:
       action = create_contactFwdDynamics(StateModelTypes::StateMultibody_HyQ,
                                          ActuationModelTypes::ActuationModelFloatingBase, false);
@@ -108,6 +118,10 @@ boost::shared_ptr<crocoddyl::DifferentialActionModelAbstract> DifferentialAction
     case DifferentialActionModelTypes::DifferentialActionModelContactFwdDynamicsWithFriction_TalosArm:
       action =
           create_contactFwdDynamics(StateModelTypes::StateMultibody_TalosArm, ActuationModelTypes::ActuationModelFull);
+      break;
+    case DifferentialActionModelTypes::DifferentialActionModelContact2DFwdDynamicsWithFriction_TalosArm:
+      action = create_contactFwdDynamics(StateModelTypes::StateMultibodyContact2D_TalosArm,
+                                         ActuationModelTypes::ActuationModelFull);
       break;
     case DifferentialActionModelTypes::DifferentialActionModelContactFwdDynamicsWithFriction_HyQ:
       action = create_contactFwdDynamics(StateModelTypes::StateMultibody_HyQ,
@@ -195,6 +209,22 @@ DifferentialActionModelFactory::create_contactFwdDynamics(StateModelTypes::Type 
                                      state, state->get_pinocchio()->getFrameId("gripper_left_fingertip_1_link"), force,
                                      3, actuation->get_nu())),
                       0.1);
+      }
+      break;
+    case StateModelTypes::StateMultibodyContact2D_TalosArm:
+      contact->addContact("lf", boost::make_shared<crocoddyl::ContactModel2D>(
+                                    state, state->get_pinocchio()->getFrameId("gripper_left_fingertip_1_link"),
+                                    Eigen::Vector2d::Zero(), actuation->get_nu()));
+      if (with_friction) {
+        // friction cone
+        cost->addCost("lf_cone",
+                      boost::make_shared<crocoddyl::CostModelResidual>(
+                          state, friction_activation,
+                          boost::make_shared<crocoddyl::ResidualModelContactFrictionCone>(
+                              state, state->get_pinocchio()->getFrameId("gripper_left_fingertip_1_link"),
+                              friction_cone, actuation->get_nu())),
+                      0.1);
+        // TODO: enable force regularization once it would support Contact2D
       }
       break;
     case StateModelTypes::StateMultibody_HyQ:

--- a/unittest/factory/diff_action.hpp
+++ b/unittest/factory/diff_action.hpp
@@ -26,9 +26,11 @@ struct DifferentialActionModelTypes {
     DifferentialActionModelFreeFwdDynamics_TalosArm,
     DifferentialActionModelFreeFwdDynamics_TalosArm_Squashed,
     DifferentialActionModelContactFwdDynamics_TalosArm,
+    DifferentialActionModelContact2DFwdDynamics_TalosArm,
     DifferentialActionModelContactFwdDynamics_HyQ,
     DifferentialActionModelContactFwdDynamics_Talos,
     DifferentialActionModelContactFwdDynamicsWithFriction_TalosArm,
+    DifferentialActionModelContact2DFwdDynamicsWithFriction_TalosArm,
     DifferentialActionModelContactFwdDynamicsWithFriction_HyQ,
     DifferentialActionModelContactFwdDynamicsWithFriction_Talos,
     NbDifferentialActionModelTypes

--- a/unittest/factory/state.cpp
+++ b/unittest/factory/state.cpp
@@ -29,6 +29,9 @@ std::ostream& operator<<(std::ostream& os, StateModelTypes::Type type) {
     case StateModelTypes::StateMultibody_TalosArm:
       os << "StateMultibody_TalosArm";
       break;
+    case StateModelTypes::StateMultibodyContact2D_TalosArm:
+      os << "StateMultibodyContact2D_TalosArm";
+      break;
     case StateModelTypes::StateMultibody_HyQ:
       os << "StateMultibody_HyQ";
       break;
@@ -58,6 +61,10 @@ boost::shared_ptr<crocoddyl::StateAbstract> StateModelFactory::create(StateModel
       state = boost::make_shared<crocoddyl::StateVector>(80);
       break;
     case StateModelTypes::StateMultibody_TalosArm:
+      model = PinocchioModelFactory(PinocchioModelTypes::TalosArm).create();
+      state = boost::make_shared<crocoddyl::StateMultibody>(model);
+      break;
+    case StateModelTypes::StateMultibodyContact2D_TalosArm:
       model = PinocchioModelFactory(PinocchioModelTypes::TalosArm).create();
       state = boost::make_shared<crocoddyl::StateMultibody>(model);
       break;

--- a/unittest/factory/state.hpp
+++ b/unittest/factory/state.hpp
@@ -21,6 +21,7 @@ struct StateModelTypes {
   enum Type {
     StateVector,
     StateMultibody_TalosArm,
+    StateMultibodyContact2D_TalosArm,
     StateMultibody_HyQ,
     StateMultibody_Talos,
     StateMultibody_RandomHumanoid,

--- a/unittest/test_residuals.cpp
+++ b/unittest/test_residuals.cpp
@@ -195,7 +195,8 @@ bool init_function() {
         if (ActuationModelTypes::all[actuation_type] != ActuationModelTypes::ActuationModelMultiCopterBase) {
           register_residual_model_unit_tests(ResidualModelTypes::all[residual_type], StateModelTypes::all[state_type],
                                              ActuationModelTypes::all[actuation_type]);
-        } else if (StateModelTypes::all[state_type] != StateModelTypes::StateMultibody_TalosArm) {
+        } else if (StateModelTypes::all[state_type] != StateModelTypes::StateMultibody_TalosArm &&
+                   StateModelTypes::all[state_type] != StateModelTypes::StateMultibodyContact2D_TalosArm) {
           register_residual_model_unit_tests(ResidualModelTypes::all[residual_type], StateModelTypes::all[state_type],
                                              ActuationModelTypes::all[actuation_type]);
         }


### PR DESCRIPTION
In reference of #986 problem, and as an update to #1000 I have found some time to add changes in order to accommodate previous mistakes and requests. It was decided to use new branch for cleaner history (I couldn't merge newest changes from develop without an additional merge commit).  I am using the newest Eigen 3.4 release for matrix multiplication. 

Notes to have in mind: 

1. This solution still only works for xz plane for now, I have tested it with my implementation of a test-stand, it works ok
2. In `unittest/factory/diff_action.cpp` I have not added force regularization when testing with friction (force regularization is not implemented yet for 2D contact) 
3. In `include/crocoddyl/multibody/residuals/contact-friction-cone.hpp` I dont have a cast for ImpulseData for 2D contact since that would require additional implementation  