### PR TITLE
Add ContactModel1D

### DIFF
--- a/bindings/python/crocoddyl/multibody/contacts/contact-1d.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/contact-1d.cpp
@@ -8,7 +8,6 @@
 
 #include "python/crocoddyl/multibody/multibody.hpp"
 #include "crocoddyl/multibody/contacts/contact-1d.hpp"
-#include "python/crocoddyl/utils/deprecate.hpp"
 
 namespace crocoddyl {
 namespace python {

--- a/bindings/python/crocoddyl/multibody/contacts/contact-1d.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/contact-1d.cpp
@@ -16,8 +16,6 @@ namespace python {
 void exposeContact1D() {
   bp::register_ptr_to_python<boost::shared_ptr<ContactModel1D> >();
 
-#pragma GCC diagnostic push  // TODO: Remove once the deprecated FrameXX has been removed in a future release
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
   bp::class_<ContactModel1D, bp::bases<ContactModelAbstract> >(
       "ContactModel1D",
@@ -89,7 +87,6 @@ void exposeContact1D() {
                     bp::make_function(&ContactModel1D::get_gains, bp::return_value_policy<bp::return_by_value>()),
                     "contact gains");
 
-#pragma GCC diagnostic pop
 
   bp::register_ptr_to_python<boost::shared_ptr<ContactData1D> >();
 

--- a/bindings/python/crocoddyl/multibody/contacts/contact-1d.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/contact-1d.cpp
@@ -20,8 +20,8 @@ void exposeContact1D() {
   bp::class_<ContactModel1D, bp::bases<ContactModelAbstract> >(
       "ContactModel1D",
       "Rigid 1D contact model.\n\n"
-      "It defines a rigid 1D contact models (point contact) based on acceleration-based holonomic constraints, in x,z "
-      "directions.\n"
+      "It defines a rigid 1D contact model (point contact) based on acceleration-based holonomic constraints, in the z "
+      "direction.\n"
       "The calc and calcDiff functions compute the contact Jacobian and drift (holonomic constraint) or\n"
       "the derivatives of the holonomic constraint, respectively.",
       bp::init<boost::shared_ptr<StateMultibody>, pinocchio::FrameIndex, double, std::size_t,
@@ -40,19 +40,6 @@ void exposeContact1D() {
           ":param id: reference frame id of the contact\n"
           ":param xref: contact position used for the Baumgarte stabilization\n"
           ":param gains: gains of the contact model (default np.matrix([0.,0.]))"))
-      .def(bp::init<boost::shared_ptr<StateMultibody>, FrameTranslation, std::size_t, bp::optional<Eigen::Vector2d> >(
-          bp::args("self", "state", "xref", "nu", "gains"),
-          "Initialize the contact model.\n\n"
-          ":param state: state of the multibody system\n"
-          ":param xref: reference frame translation\n"
-          ":param nu: dimension of control vector\n"
-          ":param gains: gains of the contact model (default np.matrix([ [0.],[0.] ]))"))
-      .def(bp::init<boost::shared_ptr<StateMultibody>, FrameTranslation, bp::optional<Eigen::Vector2d> >(
-          bp::args("self", "state", "xref", "gains"),
-          "Initialize the contact model.\n\n"
-          ":param state: state of the multibody system\n"
-          ":param Mref: reference frame translation\n"
-          ":param gains: gains of the contact model (default np.matrix([ [0.],[0.] ]))"))
       .def("calc", &ContactModel1D::calc, bp::args("self", "data", "x"),
            "Compute the 1D contact Jacobian and drift.\n\n"
            "The rigid contact model throught acceleration-base holonomic constraint\n"
@@ -80,9 +67,6 @@ void exposeContact1D() {
       .add_property("reference",
                     bp::make_function(&ContactModel1D::get_reference, bp::return_value_policy<bp::return_by_value>()),
                     &ContactModel1D::set_reference, "reference contact translation")
-      .add_property("xref",
-                    bp::make_function(&ContactModel1D::get_xref, deprecated<>("Deprecated. Use id or reference.")),
-                    "reference frame translation")
       .add_property("gains",
                     bp::make_function(&ContactModel1D::get_gains, bp::return_value_policy<bp::return_by_value>()),
                     "contact gains");

--- a/bindings/python/crocoddyl/multibody/contacts/contact-1d.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/contact-1d.cpp
@@ -1,0 +1,122 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2020-2021, LAAS-CNRS, University of Edinburgh
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#include "python/crocoddyl/multibody/multibody.hpp"
+#include "crocoddyl/multibody/contacts/contact-1d.hpp"
+#include "python/crocoddyl/utils/deprecate.hpp"
+
+namespace crocoddyl {
+namespace python {
+
+void exposeContact1D() {
+  bp::register_ptr_to_python<boost::shared_ptr<ContactModel1D> >();
+
+#pragma GCC diagnostic push  // TODO: Remove once the deprecated FrameXX has been removed in a future release
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+  bp::class_<ContactModel1D, bp::bases<ContactModelAbstract> >(
+      "ContactModel1D",
+      "Rigid 1D contact model.\n\n"
+      "It defines a rigid 1D contact models (point contact) based on acceleration-based holonomic constraints, in x,z "
+      "directions.\n"
+      "The calc and calcDiff functions compute the contact Jacobian and drift (holonomic constraint) or\n"
+      "the derivatives of the holonomic constraint, respectively.",
+      bp::init<boost::shared_ptr<StateMultibody>, pinocchio::FrameIndex, double, std::size_t,
+               bp::optional<Eigen::Vector2d> >(
+          bp::args("self", "state", "id", "xref", "nu", "gains"),
+          "Initialize the contact model.\n\n"
+          ":param state: state of the multibody system\n"
+          ":param id: reference frame id of the contact\n"
+          ":param xref: contact position used for the Baumgarte stabilization\n"
+          ":param nu: dimension of control vector\n"
+          ":param gains: gains of the contact model (default np.matrix([0.,0.]))"))
+      .def(bp::init<boost::shared_ptr<StateMultibody>, pinocchio::FrameIndex, double, bp::optional<Eigen::Vector2d> >(
+          bp::args("self", "state", "id", "xref", "gains"),
+          "Initialize the contact model.\n\n"
+          ":param state: state of the multibody system\n"
+          ":param id: reference frame id of the contact\n"
+          ":param xref: contact position used for the Baumgarte stabilization\n"
+          ":param gains: gains of the contact model (default np.matrix([0.,0.]))"))
+      .def(bp::init<boost::shared_ptr<StateMultibody>, FrameTranslation, std::size_t, bp::optional<Eigen::Vector2d> >(
+          bp::args("self", "state", "xref", "nu", "gains"),
+          "Initialize the contact model.\n\n"
+          ":param state: state of the multibody system\n"
+          ":param xref: reference frame translation\n"
+          ":param nu: dimension of control vector\n"
+          ":param gains: gains of the contact model (default np.matrix([ [0.],[0.] ]))"))
+      .def(bp::init<boost::shared_ptr<StateMultibody>, FrameTranslation, bp::optional<Eigen::Vector2d> >(
+          bp::args("self", "state", "xref", "gains"),
+          "Initialize the contact model.\n\n"
+          ":param state: state of the multibody system\n"
+          ":param Mref: reference frame translation\n"
+          ":param gains: gains of the contact model (default np.matrix([ [0.],[0.] ]))"))
+      .def("calc", &ContactModel1D::calc, bp::args("self", "data", "x"),
+           "Compute the 1D contact Jacobian and drift.\n\n"
+           "The rigid contact model throught acceleration-base holonomic constraint\n"
+           "of the contact frame placement.\n"
+           ":param data: contact data\n"
+           ":param x: state point (dim. state.nx)")
+      .def("calcDiff", &ContactModel1D::calcDiff, bp::args("self", "data", "x"),
+           "Compute the derivatives of the 1D contact holonomic constraint.\n\n"
+           "The rigid contact model throught acceleration-base holonomic constraint\n"
+           "of the contact frame placement.\n"
+           "It assumes that calc has been run first.\n"
+           ":param data: cost data\n"
+           ":param x: state point (dim. state.nx)")
+      .def("updateForce", &ContactModel1D::updateForce, bp::args("self", "data", "force"),
+           "Convert the force into a stack of spatial forces.\n\n"
+           ":param data: cost data\n"
+           ":param force: force vector (dimension 1)")
+      .def("createData", &ContactModel1D::createData, bp::with_custodian_and_ward_postcall<0, 2>(),
+           bp::args("self", "data"),
+           "Create the 1D contact data.\n\n"
+           "Each contact model has its own data that needs to be allocated. This function\n"
+           "returns the allocated data for a predefined cost.\n"
+           ":param data: Pinocchio data\n"
+           ":return contact data.")
+      .add_property("reference",
+                    bp::make_function(&ContactModel1D::get_reference, bp::return_value_policy<bp::return_by_value>()),
+                    &ContactModel1D::set_reference, "reference contact translation")
+      .add_property("xref",
+                    bp::make_function(&ContactModel1D::get_xref, deprecated<>("Deprecated. Use id or reference.")),
+                    "reference frame translation")
+      .add_property("gains",
+                    bp::make_function(&ContactModel1D::get_gains, bp::return_value_policy<bp::return_by_value>()),
+                    "contact gains");
+
+#pragma GCC diagnostic pop
+
+  bp::register_ptr_to_python<boost::shared_ptr<ContactData1D> >();
+
+  bp::class_<ContactData1D, bp::bases<ContactDataAbstract> >(
+      "ContactData1D", "Data for 1D contact.\n\n",
+      bp::init<ContactModel1D*, pinocchio::Data*>(
+          bp::args("self", "model", "data"),
+          "Create 1D contact data.\n\n"
+          ":param model: 1D contact model\n"
+          ":param data: Pinocchio data")[bp::with_custodian_and_ward<1, 2, bp::with_custodian_and_ward<1, 3> >()])
+      .add_property("v", bp::make_getter(&ContactData1D::v, bp::return_value_policy<bp::return_by_value>()),
+                    "spatial velocity of the contact body")
+      .add_property("a", bp::make_getter(&ContactData1D::a, bp::return_value_policy<bp::return_by_value>()),
+                    "spatial acceleration of the contact body")
+      .add_property("fJf", bp::make_getter(&ContactData1D::fJf, bp::return_internal_reference<>()),
+                    "local Jacobian of the contact frame")
+      .add_property("v_partial_dq", bp::make_getter(&ContactData1D::v_partial_dq, bp::return_internal_reference<>()),
+                    "Jacobian of the spatial body velocity")
+      .add_property("a_partial_dq", bp::make_getter(&ContactData1D::a_partial_dq, bp::return_internal_reference<>()),
+                    "Jacobian of the spatial body acceleration")
+      .add_property("a_partial_dv", bp::make_getter(&ContactData1D::a_partial_dv, bp::return_internal_reference<>()),
+                    "Jacobian of the spatial body acceleration")
+      .add_property("a_partial_da", bp::make_getter(&ContactData1D::a_partial_da, bp::return_internal_reference<>()),
+                    "Jacobian of the spatial body acceleration")
+      .add_property("oRf", bp::make_getter(&ContactData1D::oRf, bp::return_internal_reference<>()),
+                    "Rotation matrix of the contact body expressed in the world frame");
+}
+
+}  // namespace python
+}  // namespace crocoddyl

--- a/bindings/python/crocoddyl/multibody/contacts/contact-1d.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/contact-1d.cpp
@@ -16,11 +16,11 @@ namespace python {
 void exposeContact1D() {
   bp::register_ptr_to_python<boost::shared_ptr<ContactModel1D> >();
 
-
   bp::class_<ContactModel1D, bp::bases<ContactModelAbstract> >(
       "ContactModel1D",
       "Rigid 1D contact model.\n\n"
-      "It defines a rigid 1D contact model (point contact) based on acceleration-based holonomic constraints, in the z "
+      "It defines a rigid 1D contact model (point contact) based on acceleration-based holonomic constraints, in the "
+      "z "
       "direction.\n"
       "The calc and calcDiff functions compute the contact Jacobian and drift (holonomic constraint) or\n"
       "the derivatives of the holonomic constraint, respectively.",
@@ -70,7 +70,6 @@ void exposeContact1D() {
       .add_property("gains",
                     bp::make_function(&ContactModel1D::get_gains, bp::return_value_policy<bp::return_by_value>()),
                     "contact gains");
-
 
   bp::register_ptr_to_python<boost::shared_ptr<ContactData1D> >();
 

--- a/bindings/python/crocoddyl/multibody/multibody.cpp
+++ b/bindings/python/crocoddyl/multibody/multibody.cpp
@@ -68,6 +68,7 @@ void exposeMultibody() {
   exposeCostImpulseFrictionCone();
   exposeCostImpulseWrenchCone();
   exposeCostImpulseCoPPosition();
+  exposeContact1D();
   exposeContact2D();
   exposeContact3D();
   exposeContact6D();

--- a/bindings/python/crocoddyl/multibody/multibody.hpp
+++ b/bindings/python/crocoddyl/multibody/multibody.hpp
@@ -71,6 +71,7 @@ void exposeCostImpulseFrictionCone();
 void exposeCostImpulseWrenchCone();
 void exposeCostImpulseCoPPosition();
 void exposeCostImpulseCoM();
+void exposeContact1D();
 void exposeContact2D();
 void exposeContact3D();
 void exposeContact6D();

--- a/include/crocoddyl/multibody/contacts/contact-1d.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-1d.hpp
@@ -63,12 +63,7 @@ class ContactModel1DTpl : public ContactModelAbstractTpl<_Scalar> {
    */
   ContactModel1DTpl(boost::shared_ptr<StateMultibody> state, const pinocchio::FrameIndex id, const Scalar xref,
                     const Vector2s& gains = Vector2s::Zero());
-  DEPRECATED("Use constructor which is not based on FrameTranslation.",
-             ContactModel1DTpl(boost::shared_ptr<StateMultibody> state, const FrameTranslationTpl<Scalar>& xref,
-                               const std::size_t nu, const Vector2s& gains = Vector2s::Zero());)
-  DEPRECATED("Use constructor which is not based on FrameTranslation.",
-             ContactModel1DTpl(boost::shared_ptr<StateMultibody> state, const FrameTranslationTpl<Scalar>& xref,
-                               const Vector2s& gains = Vector2s::Zero());)
+
   virtual ~ContactModel1DTpl();
 
   /**

--- a/include/crocoddyl/multibody/contacts/contact-1d.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-1d.hpp
@@ -1,0 +1,216 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2020-2021, LAAS-CNRS, University of Edinburgh
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef CROCODDYL_MULTIBODY_CONTACTS_CONTACT_1D_HPP_
+#define CROCODDYL_MULTIBODY_CONTACTS_CONTACT_1D_HPP_
+
+#include <pinocchio/spatial/motion.hpp>
+#include <pinocchio/multibody/data.hpp>
+#include <pinocchio/algorithm/frames.hpp>
+#include <pinocchio/algorithm/kinematics-derivatives.hpp>
+
+#include "crocoddyl/multibody/fwd.hpp"
+#include "crocoddyl/core/utils/exception.hpp"
+#include "crocoddyl/multibody/contact-base.hpp"
+#include "crocoddyl/core/utils/deprecate.hpp"
+
+#include "crocoddyl/multibody/frames-deprecated.hpp"
+
+namespace crocoddyl {
+
+template <typename _Scalar>
+class ContactModel1DTpl : public ContactModelAbstractTpl<_Scalar> {
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  typedef _Scalar Scalar;
+  typedef MathBaseTpl<Scalar> MathBase;
+  typedef ContactModelAbstractTpl<Scalar> Base;
+  typedef ContactData1DTpl<Scalar> Data;
+  typedef StateMultibodyTpl<Scalar> StateMultibody;
+  typedef ContactDataAbstractTpl<Scalar> ContactDataAbstract;
+  typedef typename MathBase::Vector2s Vector2s;
+  typedef typename MathBase::Vector3s Vector3s;
+  typedef typename MathBase::VectorXs VectorXs;
+  typedef typename MathBase::Matrix3s Matrix3s;
+
+  /**
+   * @brief Initialize the 1d contact model
+   *
+   * @param[in] state  State of the multibody system
+   * @param[in] id     Reference frame id of the contact
+   * @param[in] xref   Contact position used for the Baumgarte stabilization
+   * @param[in] nu     Dimension of the control vector
+   * @param[in] gains  Baumgarte stabilization gains
+   */
+  ContactModel1DTpl(boost::shared_ptr<StateMultibody> state, const pinocchio::FrameIndex id, const Scalar xref,
+                    const std::size_t nu, const Vector2s& gains = Vector2s::Zero());
+
+  /**
+   * @brief Initialize the 1d contact model
+   *
+   * The default `nu` is obtained from `StateAbstractTpl::get_nv()`.
+   *
+   * @param[in] state  State of the multibody system
+   * @param[in] id     Reference frame id of the contact
+   * @param[in] xref   Contact position used for the Baumgarte stabilization
+   * @param[in] gains  Baumgarte stabilization gains
+   */
+  ContactModel1DTpl(boost::shared_ptr<StateMultibody> state, const pinocchio::FrameIndex id, const Scalar xref,
+                    const Vector2s& gains = Vector2s::Zero());
+  DEPRECATED("Use constructor which is not based on FrameTranslation.",
+             ContactModel1DTpl(boost::shared_ptr<StateMultibody> state, const FrameTranslationTpl<Scalar>& xref,
+                               const std::size_t nu, const Vector2s& gains = Vector2s::Zero());)
+  DEPRECATED("Use constructor which is not based on FrameTranslation.",
+             ContactModel1DTpl(boost::shared_ptr<StateMultibody> state, const FrameTranslationTpl<Scalar>& xref,
+                               const Vector2s& gains = Vector2s::Zero());)
+  virtual ~ContactModel1DTpl();
+
+  /**
+   * @brief Compute the 1d contact Jacobian and drift
+   *
+   * @param[in] data  1d contact data
+   * @param[in] x     State point \f$\mathbf{x}\in\mathbb{R}^{ndx}\f$
+   * @param[in] u     Control input \f$\mathbf{u}\in\mathbb{R}^{nu}\f$
+   */
+  virtual void calc(const boost::shared_ptr<ContactDataAbstract>& data, const Eigen::Ref<const VectorXs>& x);
+
+  /**
+   * @brief Compute the derivatives of the 1d contact holonomic constraint
+   *
+   * @param[in] data  1d contact data
+   * @param[in] x     State point \f$\mathbf{x}\in\mathbb{R}^{ndx}\f$
+   * @param[in] u     Control input \f$\mathbf{u}\in\mathbb{R}^{nu}\f$
+   */
+  virtual void calcDiff(const boost::shared_ptr<ContactDataAbstract>& data, const Eigen::Ref<const VectorXs>& x);
+
+  /**
+   * @brief Convert the force into a stack of spatial forces
+   *
+   * @param[in] data   1d contact data
+   * @param[in] force  1d force
+   */
+  virtual void updateForce(const boost::shared_ptr<ContactDataAbstract>& data, const VectorXs& force);
+
+  /**
+   * @brief Create the 1d contact data
+   */
+  virtual boost::shared_ptr<ContactDataAbstract> createData(pinocchio::DataTpl<Scalar>* const data);
+
+  /**
+   * @brief Return the reference frame translation
+   */
+  const Scalar get_reference() const;
+
+  DEPRECATED("Use get_reference() or get_id()", FrameTranslationTpl<Scalar> get_xref() const;)
+
+  /**
+   * @brief Create the 1d contact data
+   */
+  const Vector2s& get_gains() const;
+
+  /**
+   * @brief Modify the reference frame translation
+   */
+  void set_reference(const Scalar reference);
+
+  /**
+   * @brief Print relevant information of the 1d contact model
+   *
+   * @param[out] os  Output stream object
+   */
+  virtual void print(std::ostream& os) const;
+
+ protected:
+  using Base::id_;
+  using Base::nc_;
+  using Base::nu_;
+  using Base::state_;
+
+ private:
+  Scalar xref_;     //!< Contact position used for the Baumgarte stabilization
+  Vector2s gains_;  //!< Baumgarte stabilization gains
+};
+
+template <typename _Scalar>
+struct ContactData1DTpl : public ContactDataAbstractTpl<_Scalar> {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  typedef _Scalar Scalar;
+  typedef MathBaseTpl<Scalar> MathBase;
+  typedef ContactDataAbstractTpl<Scalar> Base;
+  typedef typename MathBase::Matrix2s Matrix2s;
+  typedef typename MathBase::Matrix3s Matrix3s;
+  typedef typename MathBase::Matrix6xs Matrix6xs;
+  typedef typename MathBase::Vector3s Vector3s;
+
+  template <template <typename Scalar> class Model>
+  ContactData1DTpl(Model<Scalar>* const model, pinocchio::DataTpl<Scalar>* const data)
+      : Base(model, data),
+        fJf(6, model->get_state()->get_nv()),
+        v_partial_dq(6, model->get_state()->get_nv()),
+        a_partial_dq(6, model->get_state()->get_nv()),
+        a_partial_dv(6, model->get_state()->get_nv()),
+        a_partial_da(6, model->get_state()->get_nv()),
+        fXjdv_dq(6, model->get_state()->get_nv()),
+        fXjda_dq(6, model->get_state()->get_nv()),
+        fXjda_dv(6, model->get_state()->get_nv()) {
+    frame = model->get_id();
+    jMf = model->get_state()->get_pinocchio()->frames[frame].placement;
+    fXj = jMf.inverse().toActionMatrix();
+    fJf.setZero();
+    v_partial_dq.setZero();
+    a_partial_dq.setZero();
+    a_partial_dv.setZero();
+    a_partial_da.setZero();
+    fXjdv_dq.setZero();
+    fXjda_dq.setZero();
+    fXjda_dv.setZero();
+    vv.setZero();
+    vw.setZero();
+    vv_skew.setZero();
+    vw_skew.setZero();
+    oRf.setZero();
+  }
+
+  using Base::a0;
+  using Base::da0_dx;
+  using Base::df_du;
+  using Base::df_dx;
+  using Base::f;
+  using Base::frame;
+  using Base::fXj;
+  using Base::Jc;
+  using Base::jMf;
+  using Base::pinocchio;
+
+  pinocchio::MotionTpl<Scalar> v;
+  pinocchio::MotionTpl<Scalar> a;
+  Matrix6xs fJf;
+  Matrix6xs v_partial_dq;
+  Matrix6xs a_partial_dq;
+  Matrix6xs a_partial_dv;
+  Matrix6xs a_partial_da;
+  Matrix6xs fXjdv_dq;
+  Matrix6xs fXjda_dq;
+  Matrix6xs fXjda_dv;
+  Vector3s vv;
+  Vector3s vw;
+  Matrix3s vv_skew;
+  Matrix3s vw_skew;
+  Matrix2s oRf;
+};
+
+}  // namespace crocoddyl
+
+/* --- Details -------------------------------------------------------------- */
+/* --- Details -------------------------------------------------------------- */
+/* --- Details -------------------------------------------------------------- */
+#include "crocoddyl/multibody/contacts/contact-1d.hxx"
+
+#endif  // CROCODDYL_MULTIBODY_CONTACTS_CONTACT_1D_HPP_

--- a/include/crocoddyl/multibody/contacts/contact-1d.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-1d.hpp
@@ -17,7 +17,6 @@
 #include "crocoddyl/multibody/fwd.hpp"
 #include "crocoddyl/core/utils/exception.hpp"
 #include "crocoddyl/multibody/contact-base.hpp"
-#include "crocoddyl/core/utils/deprecate.hpp"
 
 #include "crocoddyl/multibody/frames-deprecated.hpp"
 

--- a/include/crocoddyl/multibody/contacts/contact-1d.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-1d.hpp
@@ -107,8 +107,6 @@ class ContactModel1DTpl : public ContactModelAbstractTpl<_Scalar> {
    */
   const Scalar get_reference() const;
 
-  DEPRECATED("Use get_reference() or get_id()", FrameTranslationTpl<Scalar> get_xref() const;)
-
   /**
    * @brief Create the 1d contact data
    */

--- a/include/crocoddyl/multibody/contacts/contact-1d.hxx
+++ b/include/crocoddyl/multibody/contacts/contact-1d.hxx
@@ -22,27 +22,6 @@ ContactModel1DTpl<Scalar>::ContactModel1DTpl(boost::shared_ptr<StateMultibody> s
   id_ = id;
 }
 
-#pragma GCC diagnostic push  // TODO: Remove once the deprecated FrameXX has been removed in a future release
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
-template <typename Scalar>
-ContactModel1DTpl<Scalar>::ContactModel1DTpl(boost::shared_ptr<StateMultibody> state,
-                                             const FrameTranslationTpl<Scalar>& xref, const std::size_t nu,
-                                             const Vector2s& gains)
-    : Base(state, 1, nu), xref_(Scalar(xref.translation[2])), gains_(gains) {
-  id_ = xref.id;
-  std::cerr << "Deprecated: Use constructor which is not based on FrameTranslation." << std::endl;
-}
-
-template <typename Scalar>
-ContactModel1DTpl<Scalar>::ContactModel1DTpl(boost::shared_ptr<StateMultibody> state,
-                                             const FrameTranslationTpl<Scalar>& xref, const Vector2s& gains)
-    : Base(state, 1), xref_(Scalar(xref.translation[2])), gains_(gains) {
-  id_ = xref.id;
-  std::cerr << "Deprecated: Use constructor which is not based on FrameTranslation." << std::endl;
-}
-
-#pragma GCC diagnostic pop
 
 template <typename Scalar>
 ContactModel1DTpl<Scalar>::~ContactModel1DTpl() {}
@@ -133,16 +112,6 @@ const Scalar ContactModel1DTpl<Scalar>::get_reference() const {
   return xref_;
 }
 
-#pragma GCC diagnostic push  // TODO: Remove once the deprecated FrameXX has been removed in a future release
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
-template <typename Scalar>
-FrameTranslationTpl<Scalar> ContactModel1DTpl<Scalar>::get_xref() const {
-  Vector3s x(0., 0., xref_);
-  return FrameTranslationTpl<Scalar>(id_, x);
-}
-
-#pragma GCC diagnostic pop
 
 template <typename Scalar>
 const typename MathBaseTpl<Scalar>::Vector2s& ContactModel1DTpl<Scalar>::get_gains() const {

--- a/include/crocoddyl/multibody/contacts/contact-1d.hxx
+++ b/include/crocoddyl/multibody/contacts/contact-1d.hxx
@@ -1,0 +1,157 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2020-2021, LAAS-CNRS, University of Edinburgh
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+namespace crocoddyl {
+
+template <typename Scalar>
+ContactModel1DTpl<Scalar>::ContactModel1DTpl(boost::shared_ptr<StateMultibody> state, const pinocchio::FrameIndex id,
+                                             const Scalar xref, const std::size_t nu, const Vector2s& gains)
+    : Base(state, 1, nu), xref_(xref), gains_(gains) {
+  id_ = id;
+}
+
+template <typename Scalar>
+ContactModel1DTpl<Scalar>::ContactModel1DTpl(boost::shared_ptr<StateMultibody> state, const pinocchio::FrameIndex id,
+                                             const Scalar xref, const Vector2s& gains)
+    : Base(state, 1), xref_(xref), gains_(gains) {
+  id_ = id;
+}
+
+#pragma GCC diagnostic push  // TODO: Remove once the deprecated FrameXX has been removed in a future release
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+template <typename Scalar>
+ContactModel1DTpl<Scalar>::ContactModel1DTpl(boost::shared_ptr<StateMultibody> state,
+                                             const FrameTranslationTpl<Scalar>& xref, const std::size_t nu,
+                                             const Vector2s& gains)
+    : Base(state, 1, nu), xref_(Scalar(xref.translation[2])), gains_(gains) {
+  id_ = xref.id;
+  std::cerr << "Deprecated: Use constructor which is not based on FrameTranslation." << std::endl;
+}
+
+template <typename Scalar>
+ContactModel1DTpl<Scalar>::ContactModel1DTpl(boost::shared_ptr<StateMultibody> state,
+                                             const FrameTranslationTpl<Scalar>& xref, const Vector2s& gains)
+    : Base(state, 1), xref_(Scalar(xref.translation[2])), gains_(gains) {
+  id_ = xref.id;
+  std::cerr << "Deprecated: Use constructor which is not based on FrameTranslation." << std::endl;
+}
+
+#pragma GCC diagnostic pop
+
+template <typename Scalar>
+ContactModel1DTpl<Scalar>::~ContactModel1DTpl() {}
+
+template <typename Scalar>
+void ContactModel1DTpl<Scalar>::calc(const boost::shared_ptr<ContactDataAbstract>& data,
+                                     const Eigen::Ref<const VectorXs>&) {
+  Data* d = static_cast<Data*>(data.get());
+  pinocchio::updateFramePlacement(*state_->get_pinocchio().get(), *d->pinocchio, id_);
+  pinocchio::getFrameJacobian(*state_->get_pinocchio().get(), *d->pinocchio, id_, pinocchio::LOCAL, d->fJf);
+  d->v = pinocchio::getFrameVelocity(*state_->get_pinocchio().get(), *d->pinocchio, id_);
+  d->a = pinocchio::getFrameAcceleration(*state_->get_pinocchio().get(), *d->pinocchio, id_);
+
+  d->Jc.row(0) = d->fJf.row(2);
+
+  d->vw = d->v.angular();
+  d->vv = d->v.linear();
+
+  d->a0[0] = d->a.linear()[2] + d->vw[0] * d->vv[1] - d->vw[1] * d->vv[0];
+
+  if (gains_[0] != 0.) {
+    d->a0[0] += gains_[0] * (d->pinocchio->oMf[id_].translation()[2] - xref_);
+  }
+  if (gains_[1] != 0.) {
+    d->a0[0] += gains_[1] * d->vv[2];
+  }
+}
+
+template <typename Scalar>
+void ContactModel1DTpl<Scalar>::calcDiff(const boost::shared_ptr<ContactDataAbstract>& data,
+                                         const Eigen::Ref<const VectorXs>&) {
+  Data* d = static_cast<Data*>(data.get());
+  const pinocchio::JointIndex joint = state_->get_pinocchio()->frames[d->frame].parent;
+  pinocchio::getJointAccelerationDerivatives(*state_->get_pinocchio().get(), *d->pinocchio, joint, pinocchio::LOCAL,
+                                             d->v_partial_dq, d->a_partial_dq, d->a_partial_dv, d->a_partial_da);
+  const std::size_t nv = state_->get_nv();
+  pinocchio::skew(d->vv, d->vv_skew);
+  pinocchio::skew(d->vw, d->vw_skew);
+  d->fXjdv_dq.noalias() = d->fXj * d->v_partial_dq;
+  d->fXjda_dq.noalias() = d->fXj * d->a_partial_dq;
+  d->fXjda_dv.noalias() = d->fXj * d->a_partial_dv;
+
+  d->da0_dx.leftCols(nv).row(0) = d->fXjda_dq.row(2);
+  d->da0_dx.leftCols(nv).row(0).noalias() += d->vw_skew.row(2) * d->fXjdv_dq.template topRows<3>();
+  d->da0_dx.leftCols(nv).row(0).noalias() -= d->vv_skew.row(2) * d->fXjdv_dq.template bottomRows<3>();
+
+  d->da0_dx.rightCols(nv).row(0) = d->fXjda_dv.row(2);
+  d->da0_dx.rightCols(nv).row(0).noalias() += d->vw_skew.row(2) * d->fJf.template topRows<3>();
+  d->da0_dx.rightCols(nv).row(0).noalias() -= d->vv_skew.row(2) * d->fJf.template bottomRows<3>();
+
+  if (gains_[0] != 0.) {
+    const Eigen::Ref<const Matrix3s> oRf = d->pinocchio->oMf[id_].rotation();
+    d->oRf(0, 0) = oRf(2, 2);
+    d->da0_dx.leftCols(nv).noalias() += gains_[0] * d->oRf * d->Jc;
+  }
+  if (gains_[1] != 0.) {
+    d->da0_dx.leftCols(nv).row(0).noalias() += gains_[1] * d->fXj.row(2) * d->v_partial_dq;
+    d->da0_dx.rightCols(nv).row(0).noalias() += gains_[1] * d->fXj.row(2) * d->a_partial_da;
+  }
+}
+
+template <typename Scalar>
+void ContactModel1DTpl<Scalar>::updateForce(const boost::shared_ptr<ContactDataAbstract>& data,
+                                            const VectorXs& force) {
+  if (force.size() != 1) {
+    throw_pretty("Invalid argument: "
+                 << "lambda has wrong dimension (it should be 1)");
+  }
+  Data* d = static_cast<Data*>(data.get());
+  const Eigen::Ref<const Matrix3s> R = d->jMf.rotation();
+  data->f.linear() = R.col(2) * force[0];
+  data->f.angular() = d->jMf.translation().cross(data->f.linear());
+}
+
+template <typename Scalar>
+boost::shared_ptr<ContactDataAbstractTpl<Scalar> > ContactModel1DTpl<Scalar>::createData(
+    pinocchio::DataTpl<Scalar>* const data) {
+  return boost::allocate_shared<Data>(Eigen::aligned_allocator<Data>(), this, data);
+}
+
+template <typename Scalar>
+void ContactModel1DTpl<Scalar>::print(std::ostream& os) const {
+  os << "ContactModel1D {frame=" << state_->get_pinocchio()->frames[id_].name << "}";
+}
+
+template <typename Scalar>
+const Scalar ContactModel1DTpl<Scalar>::get_reference() const {
+  return xref_;
+}
+
+#pragma GCC diagnostic push  // TODO: Remove once the deprecated FrameXX has been removed in a future release
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+template <typename Scalar>
+FrameTranslationTpl<Scalar> ContactModel1DTpl<Scalar>::get_xref() const {
+  Vector3s x(0., 0., xref_);
+  return FrameTranslationTpl<Scalar>(id_, x);
+}
+
+#pragma GCC diagnostic pop
+
+template <typename Scalar>
+const typename MathBaseTpl<Scalar>::Vector2s& ContactModel1DTpl<Scalar>::get_gains() const {
+  return gains_;
+}
+
+template <typename Scalar>
+void ContactModel1DTpl<Scalar>::set_reference(const Scalar reference) {
+  xref_ = reference;
+}
+
+}  // namespace crocoddyl

--- a/include/crocoddyl/multibody/contacts/contact-1d.hxx
+++ b/include/crocoddyl/multibody/contacts/contact-1d.hxx
@@ -35,7 +35,7 @@ void ContactModel1DTpl<Scalar>::calc(const boost::shared_ptr<ContactDataAbstract
   d->v = pinocchio::getFrameVelocity(*state_->get_pinocchio().get(), *d->pinocchio, id_);
   d->a = pinocchio::getFrameAcceleration(*state_->get_pinocchio().get(), *d->pinocchio, id_);
 
-  d->Jc.row(0) = d->fJf.row(2);
+  d->Jc.template row(0) = d->fJf.template row(2);
 
   d->vw = d->v.angular();
   d->vv = d->v.linear();
@@ -64,22 +64,22 @@ void ContactModel1DTpl<Scalar>::calcDiff(const boost::shared_ptr<ContactDataAbst
   d->fXjda_dq.noalias() = d->fXj * d->a_partial_dq;
   d->fXjda_dv.noalias() = d->fXj * d->a_partial_dv;
 
-  d->da0_dx.leftCols(nv).row(0) = d->fXjda_dq.row(2);
-  d->da0_dx.leftCols(nv).row(0).noalias() += d->vw_skew.row(2) * d->fXjdv_dq.template topRows<3>();
-  d->da0_dx.leftCols(nv).row(0).noalias() -= d->vv_skew.row(2) * d->fXjdv_dq.template bottomRows<3>();
+  d->da0_dx.template leftCols(nv).template row(0).noalias() = d->fXjda_dq.template row(2);
+  d->da0_dx.template leftCols(nv).template row(0).noalias() += d->vw_skew.template row(2) * d->fXjdv_dq.template topRows<3>();
+  d->da0_dx.template leftCols(nv).template row(0).noalias() -= d->vv_skew.template row(2) * d->fXjdv_dq.template bottomRows<3>();
 
-  d->da0_dx.rightCols(nv).row(0) = d->fXjda_dv.row(2);
-  d->da0_dx.rightCols(nv).row(0).noalias() += d->vw_skew.row(2) * d->fJf.template topRows<3>();
-  d->da0_dx.rightCols(nv).row(0).noalias() -= d->vv_skew.row(2) * d->fJf.template bottomRows<3>();
+  d->da0_dx.template rightCols(nv).template row(0).noalias() = d->fXjda_dv.template row(2);
+  d->da0_dx.template rightCols(nv).template row(0).noalias() += d->vw_skew.template row(2) * d->fJf.template topRows<3>();
+  d->da0_dx.template rightCols(nv).template row(0).noalias() -= d->vv_skew.template row(2) * d->fJf.template bottomRows<3>();
 
   if (gains_[0] != 0.) {
     const Eigen::Ref<const Matrix3s> oRf = d->pinocchio->oMf[id_].rotation();
     d->oRf(0, 0) = oRf(2, 2);
-    d->da0_dx.leftCols(nv).noalias() += gains_[0] * d->oRf * d->Jc;
+    d->da0_dx.template leftCols(nv).noalias() += gains_[0] * d->oRf * d->Jc;
   }
   if (gains_[1] != 0.) {
-    d->da0_dx.leftCols(nv).row(0).noalias() += gains_[1] * d->fXj.row(2) * d->v_partial_dq;
-    d->da0_dx.rightCols(nv).row(0).noalias() += gains_[1] * d->fXj.row(2) * d->a_partial_da;
+    d->da0_dx.template leftCols(nv).template row(0).noalias() += gains_[1] * d->fXj.template row(2) * d->v_partial_dq;
+    d->da0_dx.template rightCols(nv).template row(0).noalias() += gains_[1] * d->fXj.template row(2) * d->a_partial_da;
   }
 }
 

--- a/include/crocoddyl/multibody/contacts/contact-1d.hxx
+++ b/include/crocoddyl/multibody/contacts/contact-1d.hxx
@@ -22,7 +22,6 @@ ContactModel1DTpl<Scalar>::ContactModel1DTpl(boost::shared_ptr<StateMultibody> s
   id_ = id;
 }
 
-
 template <typename Scalar>
 ContactModel1DTpl<Scalar>::~ContactModel1DTpl() {}
 
@@ -65,12 +64,16 @@ void ContactModel1DTpl<Scalar>::calcDiff(const boost::shared_ptr<ContactDataAbst
   d->fXjda_dv.noalias() = d->fXj * d->a_partial_dv;
 
   d->da0_dx.template leftCols(nv).template row(0).noalias() = d->fXjda_dq.template row(2);
-  d->da0_dx.template leftCols(nv).template row(0).noalias() += d->vw_skew.template row(2) * d->fXjdv_dq.template topRows<3>();
-  d->da0_dx.template leftCols(nv).template row(0).noalias() -= d->vv_skew.template row(2) * d->fXjdv_dq.template bottomRows<3>();
+  d->da0_dx.template leftCols(nv).template row(0).noalias() +=
+      d->vw_skew.template row(2) * d->fXjdv_dq.template topRows<3>();
+  d->da0_dx.template leftCols(nv).template row(0).noalias() -=
+      d->vv_skew.template row(2) * d->fXjdv_dq.template bottomRows<3>();
 
   d->da0_dx.template rightCols(nv).template row(0).noalias() = d->fXjda_dv.template row(2);
-  d->da0_dx.template rightCols(nv).template row(0).noalias() += d->vw_skew.template row(2) * d->fJf.template topRows<3>();
-  d->da0_dx.template rightCols(nv).template row(0).noalias() -= d->vv_skew.template row(2) * d->fJf.template bottomRows<3>();
+  d->da0_dx.template rightCols(nv).template row(0).noalias() +=
+      d->vw_skew.template row(2) * d->fJf.template topRows<3>();
+  d->da0_dx.template rightCols(nv).template row(0).noalias() -=
+      d->vv_skew.template row(2) * d->fJf.template bottomRows<3>();
 
   if (gains_[0] != 0.) {
     const Eigen::Ref<const Matrix3s> oRf = d->pinocchio->oMf[id_].rotation();
@@ -111,7 +114,6 @@ template <typename Scalar>
 const Scalar ContactModel1DTpl<Scalar>::get_reference() const {
   return xref_;
 }
-
 
 template <typename Scalar>
 const typename MathBaseTpl<Scalar>::Vector2s& ContactModel1DTpl<Scalar>::get_gains() const {

--- a/include/crocoddyl/multibody/fwd.hpp
+++ b/include/crocoddyl/multibody/fwd.hpp
@@ -472,8 +472,8 @@ DEPRECATED("Use ResidualDataContactWrenchCone", typedef CostDataResidualTpl<doub
 typedef ImpulseModelAbstractTpl<double> ImpulseModelAbstract;
 typedef ImpulseDataAbstractTpl<double> ImpulseDataAbstract;
 
-enum ContactType { Contact1D, Contact2D, Contact3D, Contact6D, ContactUndefined };
-enum ImpulseType { Impulse3D, Impulse6D, ImpulseUndefined };
+enum ContactType { ContactUndefined, Contact1D, Contact2D, Contact3D, Contact6D };
+enum ImpulseType { ImpulseUndefined, Impulse3D, Impulse6D };
 
 typedef ContactItemTpl<double> ContactItem;
 typedef ContactModelMultipleTpl<double> ContactModelMultiple;

--- a/include/crocoddyl/multibody/fwd.hpp
+++ b/include/crocoddyl/multibody/fwd.hpp
@@ -271,6 +271,11 @@ template <typename Scalar>
 struct ContactDataMultipleTpl;
 
 template <typename Scalar>
+class ContactModel1DTpl;
+template <typename Scalar>
+struct ContactData1DTpl;
+
+template <typename Scalar>
 class ContactModel2DTpl;
 template <typename Scalar>
 struct ContactData2DTpl;
@@ -467,12 +472,14 @@ DEPRECATED("Use ResidualDataContactWrenchCone", typedef CostDataResidualTpl<doub
 typedef ImpulseModelAbstractTpl<double> ImpulseModelAbstract;
 typedef ImpulseDataAbstractTpl<double> ImpulseDataAbstract;
 
-enum ContactType { Contact2D, Contact3D, Contact6D, ContactUndefined };
+enum ContactType { Contact1D, Contact2D, Contact3D, Contact6D, ContactUndefined };
 enum ImpulseType { Impulse3D, Impulse6D, ImpulseUndefined };
 
 typedef ContactItemTpl<double> ContactItem;
 typedef ContactModelMultipleTpl<double> ContactModelMultiple;
 typedef ContactDataMultipleTpl<double> ContactDataMultiple;
+typedef ContactModel1DTpl<double> ContactModel1D;
+typedef ContactData1DTpl<double> ContactData1D;
 typedef ContactModel2DTpl<double> ContactModel2D;
 typedef ContactData2DTpl<double> ContactData2D;
 typedef ContactModel3DTpl<double> ContactModel3D;

--- a/include/crocoddyl/multibody/residuals/contact-force.hpp
+++ b/include/crocoddyl/multibody/residuals/contact-force.hpp
@@ -15,6 +15,7 @@
 #include "crocoddyl/multibody/contact-base.hpp"
 #include "crocoddyl/multibody/impulse-base.hpp"
 #include "crocoddyl/multibody/contacts/multiple-contacts.hpp"
+#include "crocoddyl/multibody/contacts/contact-1d.hpp"
 #include "crocoddyl/multibody/contacts/contact-3d.hpp"
 #include "crocoddyl/multibody/contacts/contact-6d.hpp"
 #include "crocoddyl/multibody/impulses/multiple-impulses.hpp"
@@ -223,6 +224,13 @@ struct ResidualDataContactForceTpl : public ResidualDataAbstractTpl<_Scalar> {
       for (typename ContactModelMultiple::ContactDataContainer::iterator it = d1->contacts->contacts.begin();
            it != d1->contacts->contacts.end(); ++it) {
         if (it->second->frame == id) {
+          ContactData1DTpl<Scalar>* d1d = dynamic_cast<ContactData1DTpl<Scalar>*>(it->second.get());
+          if (d1d != NULL) {
+            contact_type = Contact1D;
+            found_contact = true;
+            contact = it->second;
+            break;
+          }
           ContactData3DTpl<Scalar>* d3d = dynamic_cast<ContactData3DTpl<Scalar>*>(it->second.get());
           if (d3d != NULL) {
             contact_type = Contact3D;

--- a/include/crocoddyl/multibody/residuals/contact-force.hxx
+++ b/include/crocoddyl/multibody/residuals/contact-force.hxx
@@ -41,7 +41,7 @@ void ResidualModelContactForceTpl<Scalar>::calc(const boost::shared_ptr<Residual
   // We transform the force to the contact frame
   switch (d->contact_type) {
     case Contact1D:
-      data->r = Eigen::Matrix<Scalar, 1, 1>((d->contact->jMf.actInv(d->contact->f) - fref_).linear()[2]);
+      data->r = ((d->contact->jMf.actInv(d->contact->f) - fref_).linear()).row(2);
       break;
     case Contact3D:
       data->r = (d->contact->jMf.actInv(d->contact->f) - fref_).linear();
@@ -70,8 +70,8 @@ void ResidualModelContactForceTpl<Scalar>::calcDiff(const boost::shared_ptr<Resi
   const MatrixXs& df_du = d->contact->df_du;
   switch (d->contact_type) {
     case Contact1D:
-      data->Rx = df_dx;
-      data->Ru = df_du;
+      data->Rx = df_dx.template topRows<1>();
+      data->Ru = df_du.template topRows<1>();
       break;
     case Contact3D:
       data->Rx = df_dx.template topRows<3>();

--- a/include/crocoddyl/multibody/residuals/contact-force.hxx
+++ b/include/crocoddyl/multibody/residuals/contact-force.hxx
@@ -40,6 +40,9 @@ void ResidualModelContactForceTpl<Scalar>::calc(const boost::shared_ptr<Residual
 
   // We transform the force to the contact frame
   switch (d->contact_type) {
+    case Contact1D:
+      data->r = Eigen::Matrix<Scalar, 1, 1>((d->contact->jMf.actInv(d->contact->f) - fref_).linear()[2]);
+      break;
     case Contact3D:
       data->r = (d->contact->jMf.actInv(d->contact->f) - fref_).linear();
       break;
@@ -66,6 +69,10 @@ void ResidualModelContactForceTpl<Scalar>::calcDiff(const boost::shared_ptr<Resi
   const MatrixXs& df_dx = d->contact->df_dx;
   const MatrixXs& df_du = d->contact->df_du;
   switch (d->contact_type) {
+    case Contact1D:
+      data->Rx = df_dx;
+      data->Ru = df_du;
+      break;
     case Contact3D:
       data->Rx = df_dx.template topRows<3>();
       data->Ru = df_du.template topRows<3>();

--- a/unittest/factory/contact.cpp
+++ b/unittest/factory/contact.cpp
@@ -64,7 +64,7 @@ boost::shared_ptr<crocoddyl::ContactModelAbstract> ContactModelFactory::create(C
   }
   switch (contact_type) {
     case ContactModelTypes::ContactModel1D:
-      contact = boost::make_shared<crocoddyl::ContactModel1D>(state, frame_id, double(0.), nu);
+      contact = boost::make_shared<crocoddyl::ContactModel1D>(state, frame_id, 0., nu);
       break;
     case ContactModelTypes::ContactModel2D:
       contact = boost::make_shared<crocoddyl::ContactModel2D>(state, frame_id, Eigen::Vector2d::Zero(), nu);

--- a/unittest/factory/contact.cpp
+++ b/unittest/factory/contact.cpp
@@ -7,6 +7,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "contact.hpp"
+#include "crocoddyl/multibody/contacts/contact-1d.hpp"
 #include "crocoddyl/multibody/contacts/contact-2d.hpp"
 #include "crocoddyl/multibody/contacts/contact-3d.hpp"
 #include "crocoddyl/multibody/contacts/contact-6d.hpp"
@@ -19,6 +20,9 @@ const std::vector<ContactModelTypes::Type> ContactModelTypes::all(ContactModelTy
 
 std::ostream& operator<<(std::ostream& os, const ContactModelTypes::Type& type) {
   switch (type) {
+    case ContactModelTypes::ContactModel1D:
+      os << "ContactModel1D";
+      break;
     case ContactModelTypes::ContactModel2D:
       os << "ContactModel2D";
       break;
@@ -59,6 +63,9 @@ boost::shared_ptr<crocoddyl::ContactModelAbstract> ContactModelFactory::create(C
     nu = state->get_nv();
   }
   switch (contact_type) {
+    case ContactModelTypes::ContactModel1D:
+      contact = boost::make_shared<crocoddyl::ContactModel1D>(state, frame_id, double(0.), nu);
+      break;
     case ContactModelTypes::ContactModel2D:
       contact = boost::make_shared<crocoddyl::ContactModel2D>(state, frame_id, Eigen::Vector2d::Zero(), nu);
       break;
@@ -83,9 +90,11 @@ boost::shared_ptr<crocoddyl::ContactModelAbstract> create_random_contact() {
   }
   boost::shared_ptr<crocoddyl::ContactModelAbstract> contact;
   ContactModelFactory factory;
-  if (rand() % 3 == 0) {
+  if (rand() % 4 == 0) {
+    contact = factory.create(ContactModelTypes::ContactModel1D, PinocchioModelTypes::RandomHumanoid);
+  } else if (rand() % 4 == 1) {
     contact = factory.create(ContactModelTypes::ContactModel2D, PinocchioModelTypes::RandomHumanoid);
-  } else if (rand() % 3 == 1) {
+  } else if (rand() % 4 == 2) {
     contact = factory.create(ContactModelTypes::ContactModel3D, PinocchioModelTypes::RandomHumanoid);
   } else {
     contact = factory.create(ContactModelTypes::ContactModel6D, PinocchioModelTypes::RandomHumanoid);

--- a/unittest/factory/contact.hpp
+++ b/unittest/factory/contact.hpp
@@ -21,7 +21,7 @@ namespace crocoddyl {
 namespace unittest {
 
 struct ContactModelTypes {
-  enum Type { ContactModel2D, ContactModel3D, ContactModel6D, NbContactModelTypes };
+  enum Type { ContactModel1D, ContactModel2D, ContactModel3D, ContactModel6D, NbContactModelTypes };
   static std::vector<Type> init_all() {
     std::vector<Type> v;
     v.clear();

--- a/unittest/test_contacts.cpp
+++ b/unittest/test_contacts.cpp
@@ -15,6 +15,7 @@
 #include <pinocchio/algorithm/kinematics-derivatives.hpp>
 #include <pinocchio/algorithm/frames.hpp>
 
+#include "crocoddyl/multibody/contacts/contact-1d.hpp"
 #include "crocoddyl/multibody/contacts/contact-2d.hpp"
 #include "crocoddyl/multibody/contacts/contact-3d.hpp"
 #include "crocoddyl/multibody/contacts/contact-6d.hpp"


### PR DESCRIPTION
Implementation of a contact model 1D that constrains only the translation along z-axis . It allows to apply a normal force while moving tangentially, which is useful for e.g. scraping or sanding tasks, but not allowed by current contact models (2D, 3D, 6D). 

More specifically : 
- implementation of ContactModel1D 
- completion the contacts unittests factory 
- implemention of python binding
- completion of ResidualModelContactForce to allow normal force cost

I'm not sure if things are missing, please let me know !