### PR TITLE
Reduce temporary allocations

### DIFF
--- a/include/crocoddyl/core/actions/lqr.hpp
+++ b/include/crocoddyl/core/actions/lqr.hpp
@@ -87,17 +87,19 @@ struct ActionDataLQRTpl : public ActionDataAbstractTpl<_Scalar> {
   typedef _Scalar Scalar;
   typedef MathBaseTpl<Scalar> MathBase;
   typedef ActionDataAbstractTpl<Scalar> Base;
+  typedef typename MathBase::VectorXs VectorXs;
 
   template <template <typename Scalar> class Model>
-  explicit ActionDataLQRTpl(Model<Scalar>* const model) : Base(model) {
+  explicit ActionDataLQRTpl(Model<Scalar>* const model)
+      : Base(model),
+        Luu_u_tmp(VectorXs::Zero(static_cast<Eigen::Index>(model->get_nu()))),
+        Lxx_x_tmp(VectorXs::Zero(static_cast<Eigen::Index>(model->get_state()->get_ndx()))) {
     // Setting the linear model and quadratic cost here because they are constant
     Fx = model->get_Fx();
     Fu = model->get_Fu();
     Lxx = model->get_Lxx();
     Luu = model->get_Luu();
     Lxu = model->get_Lxu();
-    Hu_tmp.resize(static_cast<Eigen::Index>(model->get_nu()));
-    Hx_tmp.resize(static_cast<Eigen::Index>(model->get_state()->get_ndx()));
   }
 
   using Base::cost;
@@ -110,8 +112,8 @@ struct ActionDataLQRTpl : public ActionDataAbstractTpl<_Scalar> {
   using Base::Lxx;
   using Base::r;
   using Base::xnext;
-  typename MathBase::VectorXs Hu_tmp;  // Temporary variable for storing Hessian-vector product (size: nu)
-  typename MathBase::VectorXs Hx_tmp;  // Temporary variable for storing Hessian-vector product (size: nx)
+  VectorXs Luu_u_tmp;  // Temporary variable for storing Hessian-vector product (size: nu)
+  VectorXs Lxx_x_tmp;  // Temporary variable for storing Hessian-vector product (size: nx)
 };
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/core/actions/lqr.hpp
+++ b/include/crocoddyl/core/actions/lqr.hpp
@@ -96,6 +96,8 @@ struct ActionDataLQRTpl : public ActionDataAbstractTpl<_Scalar> {
     Lxx = model->get_Lxx();
     Luu = model->get_Luu();
     Lxu = model->get_Lxu();
+    Hu_tmp.resize(static_cast<Eigen::Index>(model->get_nu()));
+    Hx_tmp.resize(static_cast<Eigen::Index>(model->get_state()->get_ndx()));
   }
 
   using Base::cost;
@@ -108,6 +110,8 @@ struct ActionDataLQRTpl : public ActionDataAbstractTpl<_Scalar> {
   using Base::Lxx;
   using Base::r;
   using Base::xnext;
+  typename MathBase::VectorXs Hu_tmp;  // Temporary variable for storing Hessian-vector product (size: nu)
+  typename MathBase::VectorXs Hx_tmp;  // Temporary variable for storing Hessian-vector product (size: nx)
 };
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/core/actions/lqr.hxx
+++ b/include/crocoddyl/core/actions/lqr.hxx
@@ -67,7 +67,7 @@ void ActionModelLQRTpl<Scalar>::calc(const boost::shared_ptr<ActionDataAbstract>
     throw_pretty("Invalid argument: "
                  << "x has wrong dimension (it should be " + std::to_string(state_->get_nx()) + ")");
   }
-  boost::shared_ptr<ActionDataLQRTpl<Scalar>> d = boost::static_pointer_cast<ActionDataLQRTpl<Scalar>>(data);
+  Data* d = static_cast<Data*>(data.get());
 
   // cost = 0.5 * x^T*Lxx*x + lx^T*x
   d->Lxx_x_tmp.noalias() = Lxx_ * x;

--- a/include/crocoddyl/core/actions/lqr.hxx
+++ b/include/crocoddyl/core/actions/lqr.hxx
@@ -125,7 +125,7 @@ void ActionModelLQRTpl<Scalar>::calcDiff(const boost::shared_ptr<ActionDataAbstr
 }
 
 template <typename Scalar>
-boost::shared_ptr<ActionDataAbstractTpl<Scalar> > ActionModelLQRTpl<Scalar>::createData() {
+boost::shared_ptr<ActionDataAbstractTpl<Scalar>> ActionModelLQRTpl<Scalar>::createData() {
   return boost::allocate_shared<Data>(Eigen::aligned_allocator<Data>(), this);
 }
 

--- a/include/crocoddyl/core/actions/lqr.hxx
+++ b/include/crocoddyl/core/actions/lqr.hxx
@@ -38,7 +38,7 @@ void ActionModelLQRTpl<Scalar>::calc(const boost::shared_ptr<ActionDataAbstract>
     throw_pretty("Invalid argument: "
                  << "u has wrong dimension (it should be " + std::to_string(nu_) + ")");
   }
-  boost::shared_ptr<ActionDataLQRTpl<Scalar>> d = boost::static_pointer_cast<ActionDataLQRTpl<Scalar>>(data);
+  Data* d = static_cast<Data*>(data.get());
 
   if (drift_free_) {
     data->xnext.noalias() = Fx_ * x;

--- a/include/crocoddyl/core/actions/lqr.hxx
+++ b/include/crocoddyl/core/actions/lqr.hxx
@@ -50,24 +50,13 @@ void ActionModelLQRTpl<Scalar>::calc(const boost::shared_ptr<ActionDataAbstract>
   }
 
   // cost = 0.5 * x^T*Lxx*x + 0.5 * u^T*Luu*u + x^T*Lxu*u + lx^T*x + lu^T*u
-  data->cost = Scalar(0.0);
-
-  // 0.5 * x^T*Lxx*x
-  d->Hx_tmp.noalias() = Lxx_ * x;
-  data->cost += Scalar(0.5) * x.transpose() * d->Hx_tmp;
-
-  // 0.5 * u^T*Luu*u
-  d->Hu_tmp.noalias() = Luu_ * u;
-  data->cost += Scalar(0.5) * u.transpose() * d->Hu_tmp;
-
-  // x^T*Lxu*u
-  d->Hx_tmp.noalias() = Lxu_ * u;
-  data->cost += x.transpose() * d->Hx_tmp;
-
-  // lx^T*x
+  d->Lxx_x_tmp.noalias() = Lxx_ * x;
+  data->cost = Scalar(0.5) * x.dot(d->Lxx_x_tmp);
+  d->Luu_u_tmp.noalias() = Luu_ * u;
+  data->cost += Scalar(0.5) * u.dot(d->Luu_u_tmp);
+  d->Lxx_x_tmp.noalias() = Lxu_ * u;
+  data->cost += x.dot(d->Lxx_x_tmp);
   data->cost += lx_.transpose() * x;
-
-  // lu^T*u
   data->cost += lu_.transpose() * u;
 }
 
@@ -81,8 +70,8 @@ void ActionModelLQRTpl<Scalar>::calc(const boost::shared_ptr<ActionDataAbstract>
   boost::shared_ptr<ActionDataLQRTpl<Scalar>> d = boost::static_pointer_cast<ActionDataLQRTpl<Scalar>>(data);
 
   // cost = 0.5 * x^T*Lxx*x + lx^T*x
-  d->Hx_tmp.noalias() = Lxx_ * x;
-  data->cost = Scalar(0.5) * x.transpose() * d->Hx_tmp;
+  d->Lxx_x_tmp.noalias() = Lxx_ * x;
+  data->cost = Scalar(0.5) * x.dot(d->Lxx_x_tmp);
   data->cost += lx_.dot(x);
 }
 

--- a/include/crocoddyl/core/costs/residual.hxx
+++ b/include/crocoddyl/core/costs/residual.hxx
@@ -60,12 +60,12 @@ void CostModelResidualTpl<Scalar>::calcDiff(const boost::shared_ptr<CostDataAbst
   const std::size_t nv = state_->get_nv();
   if (is_ru) {
     data->Lu.noalias() = data->residual->Ru.transpose() * data->activation->Ar;
-    d->Arr_Ru.noalias() = data->activation->Arr * data->residual->Ru;
+    d->Arr_Ru.noalias() = data->activation->Arr.diagonal().asDiagonal() * data->residual->Ru;
     data->Luu.noalias() = data->residual->Ru.transpose() * d->Arr_Ru;
   }
   if (is_rq && is_rv) {
     data->Lx.noalias() = data->residual->Rx.transpose() * data->activation->Ar;
-    d->Arr_Rx.noalias() = data->activation->Arr * data->residual->Rx;
+    d->Arr_Rx.noalias() = data->activation->Arr.diagonal().asDiagonal() * data->residual->Rx;
     data->Lxx.noalias() = data->residual->Rx.transpose() * d->Arr_Rx;
     if (is_ru) {
       data->Lxu.noalias() = data->residual->Rx.transpose() * d->Arr_Ru;
@@ -73,7 +73,7 @@ void CostModelResidualTpl<Scalar>::calcDiff(const boost::shared_ptr<CostDataAbst
   } else if (is_rq) {
     Eigen::Block<MatrixXs, Eigen::Dynamic, Eigen::Dynamic, true> Rq = data->residual->Rx.leftCols(nv);
     data->Lx.head(nv).noalias() = Rq.transpose() * data->activation->Ar;
-    d->Arr_Rx.leftCols(nv).noalias() = data->activation->Arr * Rq;
+    d->Arr_Rx.leftCols(nv).noalias() = data->activation->Arr.diagonal().asDiagonal() * Rq;
     data->Lxx.topLeftCorner(nv, nv).noalias() = Rq.transpose() * d->Arr_Rx.leftCols(nv);
     if (is_ru) {
       data->Lxu.topRows(nv).noalias() = Rq.transpose() * d->Arr_Ru;
@@ -81,7 +81,7 @@ void CostModelResidualTpl<Scalar>::calcDiff(const boost::shared_ptr<CostDataAbst
   } else if (is_rv) {
     Eigen::Block<MatrixXs, Eigen::Dynamic, Eigen::Dynamic, true> Rv = data->residual->Rx.rightCols(nv);
     data->Lx.tail(nv).noalias() = Rv.transpose() * data->activation->Ar;
-    d->Arr_Rx.rightCols(nv).noalias() = data->activation->Arr * Rv;
+    d->Arr_Rx.rightCols(nv).noalias() = data->activation->Arr.diagonal().asDiagonal() * Rv;
     data->Lxx.bottomRightCorner(nv, nv).noalias() = Rv.transpose() * d->Arr_Rx.rightCols(nv);
     if (is_ru) {
       data->Lxu.bottomRows(nv).noalias() = Rv.transpose() * d->Arr_Ru;
@@ -103,17 +103,17 @@ void CostModelResidualTpl<Scalar>::calcDiff(const boost::shared_ptr<CostDataAbst
   const std::size_t nv = state_->get_nv();
   if (is_rq && is_rv) {
     data->Lx.noalias() = data->residual->Rx.transpose() * data->activation->Ar;
-    d->Arr_Rx.noalias() = data->activation->Arr * data->residual->Rx;
+    d->Arr_Rx.noalias() = data->activation->Arr.diagonal().asDiagonal() * data->residual->Rx;
     data->Lxx.noalias() = data->residual->Rx.transpose() * d->Arr_Rx;
   } else if (is_rq) {
     Eigen::Block<MatrixXs, Eigen::Dynamic, Eigen::Dynamic, true> Rq = data->residual->Rx.leftCols(nv);
     data->Lx.head(nv).noalias() = Rq.transpose() * data->activation->Ar;
-    d->Arr_Rx.leftCols(nv).noalias() = data->activation->Arr * Rq;
+    d->Arr_Rx.leftCols(nv).noalias() = data->activation->Arr.diagonal().asDiagonal() * Rq;
     data->Lxx.topLeftCorner(nv, nv).noalias() = Rq.transpose() * d->Arr_Rx.leftCols(nv);
   } else if (is_rv) {
     Eigen::Block<MatrixXs, Eigen::Dynamic, Eigen::Dynamic, true> Rv = data->residual->Rx.rightCols(nv);
     data->Lx.tail(nv).noalias() = Rv.transpose() * data->activation->Ar;
-    d->Arr_Rx.rightCols(nv).noalias() = data->activation->Arr * Rv;
+    d->Arr_Rx.rightCols(nv).noalias() = data->activation->Arr.diagonal().asDiagonal() * Rv;
     data->Lxx.bottomRightCorner(nv, nv).noalias() = Rv.transpose() * d->Arr_Rx.rightCols(nv);
   }
 }

--- a/src/core/solvers/kkt.cpp
+++ b/src/core/solvers/kkt.cpp
@@ -187,7 +187,7 @@ double SolverKKT::calcDiff() {
   std::size_t ix = 0;
   std::size_t iu = 0;
   const std::size_t T = problem_->get_T();
-  kkt_.block(ndx_ + nu_, 0, ndx_, ndx_) = Eigen::MatrixXd::Identity(ndx_, ndx_);
+  kkt_.block(ndx_ + nu_, 0, ndx_, ndx_).setIdentity();
   for (std::size_t t = 0; t < T; ++t) {
     const boost::shared_ptr<ActionModelAbstract>& m = problem_->get_runningModels()[t];
     const boost::shared_ptr<ActionDataAbstract>& d = problem_->get_runningDatas()[t];


### PR DESCRIPTION
- CostModelResidual: Workaround for heap allocation in the product with the diagonal weighting matrix of the activation. This is a workaround for https://gitlab.com/libeigen/eigen/-/issues/2408
- LQR: Introduces a temporary variable for the Hessian-vector product to eliminate temporaries in the computation of the cost