### PR TITLE
[CI] Add config for 20.04 with clang

### DIFF
--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -13,6 +13,7 @@ jobs:
         env:
           - {ROS_DISTRO: melodic}
           - {ROS_DISTRO: noetic}
+          - {ROS_DISTRO: noetic, ADDITIONAL_DEBS: clang, CC: clang, CXX: clang++}
     env:
       CCACHE_DIR: /github/home/.ccache             # Enable ccache
       UPSTREAM_WORKSPACE: dependencies.rosinstall  # to build example-robot-data from source as it's not released via the ROS buildfarm


### PR DESCRIPTION
#1015 passed CI which is using g++ but fails under clang. This PR adds a clang config to GitHub Actions CI to catch this in the future

Note: We are expecting the clang build to fail, as https://github.com/loco-3d/crocoddyl/runs/4721070535 did