### PR TITLE
Fix compiler error due to unincluded iostream

### DIFF
--- a/include/crocoddyl/core/utils/exception.hpp
+++ b/include/crocoddyl/core/utils/exception.hpp
@@ -11,6 +11,7 @@
 
 #include <exception>
 #include <sstream>
+#include <iostream>
 
 #define NOEXCEPT noexcept
 


### PR DESCRIPTION
This fix applies to later versions of C++ compilers. I checked on my machine for GCC 11.2 & clang 13 installed through apt, clang 12 installed through conda.

I think this is related to backwards compatibility for recent versions of GCC, where now the iostream header might required for cout and cin