### PR TITLE
Make example-robot-data an optional dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,11 @@ SET(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/find-external/CppAD/" ${CMAKE_M
 
 # Add the different required and optional dependencies
 ADD_PROJECT_DEPENDENCY(pinocchio 2.6.3 REQUIRED PKG_CONFIG_REQUIRES "pinocchio >= 2.6.3")
-ADD_PROJECT_DEPENDENCY(example-robot-data 3.7.0 REQUIRED PKG_CONFIG_REQUIRES "example-robot-data >= 3.7.0")
+IF(BUILD_EXAMPLES OR BUILD_TESTING OR BUILD_BENCHMARK)
+  ADD_PROJECT_DEPENDENCY(example-robot-data 3.7.0 REQUIRED PKG_CONFIG_REQUIRES "example-robot-data >= 3.7.0")
+ELSE()
+  ADD_OPTIONAL_DEPENDENCY(example-robot-data)
+ENDIF()
 ADD_OPTIONAL_DEPENDENCY("scipy")
 
 OPTION(BUILD_WITH_CODEGEN_SUPPORT "Build the library with the Code Generation support (required CppADCodeGen)" OFF)


### PR DESCRIPTION
Per Element chat - example-robot-data is required for unittests, benchmarking, and examples. If all three options are OFF, we don't need to add this required dependency