### PR TITLE
Allowing WORLD and LOCAL_WORLD_ALIGNED in ContactModel1D

### DIFF
--- a/bindings/python/crocoddyl/__init__.py
+++ b/bindings/python/crocoddyl/__init__.py
@@ -29,7 +29,6 @@ def rotationMatrixFromTwoVectors(a, b):
 
 
 class DisplayAbstract:
-
     def __init__(self, rate=-1, freq=1):
         self.rate = rate
         self.freq = freq
@@ -64,7 +63,6 @@ class DisplayAbstract:
 
 
 class GepettoDisplay(DisplayAbstract):
-
     def __init__(self, robot, rate=-1, freq=1, cameraTF=None, floor=True, frameNames=[], visibility=False):
         DisplayAbstract.__init__(self, rate, freq)
         self.robot = robot
@@ -338,7 +336,6 @@ class GepettoDisplay(DisplayAbstract):
 
 
 class MeshcatDisplay(DisplayAbstract):
-
     def __init__(self, robot, rate=-1, freq=1, openWindow=True):
         DisplayAbstract.__init__(self, rate, freq)
         self.robot = robot
@@ -365,7 +362,6 @@ class MeshcatDisplay(DisplayAbstract):
 
 
 class CallbackDisplay(libcrocoddyl_pywrap.CallbackAbstract):
-
     def __init__(self, display):
         libcrocoddyl_pywrap.CallbackAbstract.__init__(self)
         self.visualization = display
@@ -377,7 +373,6 @@ class CallbackDisplay(libcrocoddyl_pywrap.CallbackAbstract):
 
 
 class CallbackLogger(libcrocoddyl_pywrap.CallbackAbstract):
-
     def __init__(self):
         libcrocoddyl_pywrap.CallbackAbstract.__init__(self)
         self.xs = []

--- a/bindings/python/crocoddyl/deprecated.py
+++ b/bindings/python/crocoddyl/deprecated.py
@@ -12,12 +12,10 @@ def deprecated(instructions):
         instructions: A human-friendly string of instructions, such
             as: 'Please migrate to add_proxy() ASAP.'
     """
-
     def decorator(func):
         '''This is a decorator which can be used to mark functions
         as deprecated. It will result in a warning being emitted
         when the function is used.'''
-
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             message = 'Call to deprecated function {}. {}'.format(func.__name__, instructions)
@@ -35,7 +33,6 @@ def deprecated(instructions):
 
 
 class DeprecationHelper(object):
-
     def __init__(self, new_target, old_name):
         self.new_target = new_target
         self.warning_str = '%s is deprecated: Use %s' % (old_name, new_target.__name__)

--- a/bindings/python/crocoddyl/multibody/contacts/contact-1d.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/contact-1d.cpp
@@ -15,6 +15,12 @@ namespace python {
 void exposeContact1D() {
   bp::register_ptr_to_python<boost::shared_ptr<ContactModel1D> >();
 
+  bp::enum_<pinocchio::ReferenceFrame>("ReferenceFrame")
+      .value("LOCAL", pinocchio::LOCAL)
+      .value("WORLD", pinocchio::WORLD)
+      .value("LOCAL_WORLD_ALIGNED", pinocchio::LOCAL_WORLD_ALIGNED)
+      .export_values();
+
   bp::class_<ContactModel1D, bp::bases<ContactModelAbstract> >(
       "ContactModel1D",
       "Rigid 1D contact model.\n\n"
@@ -24,21 +30,23 @@ void exposeContact1D() {
       "The calc and calcDiff functions compute the contact Jacobian and drift (holonomic constraint) or\n"
       "the derivatives of the holonomic constraint, respectively.",
       bp::init<boost::shared_ptr<StateMultibody>, pinocchio::FrameIndex, double, std::size_t,
-               bp::optional<Eigen::Vector2d> >(
-          bp::args("self", "state", "id", "xref", "nu", "gains"),
+               bp::optional<Eigen::Vector2d, std::size_t, pinocchio::ReferenceFrame> >(
+          bp::args("self", "state", "id", "xref", "nu", "gains", "type", "pinRefFrame"),
           "Initialize the contact model.\n\n"
           ":param state: state of the multibody system\n"
           ":param id: reference frame id of the contact\n"
           ":param xref: contact position used for the Baumgarte stabilization\n"
           ":param nu: dimension of control vector\n"
-          ":param gains: gains of the contact model (default np.matrix([0.,0.]))"))
-      .def(bp::init<boost::shared_ptr<StateMultibody>, pinocchio::FrameIndex, double, bp::optional<Eigen::Vector2d> >(
+          ":param gains: gains of the contact model (default np.matrix([0.,0.]))\n"
+          ":param type: axis of the contact constraint (0=x, 1=y or 2=z)\n"
+          ":param pinRefFrame: pin.ReferenceFrame in {LOCAL, WORLD, LOCAL_WORLD_ALIGNED}"))
+      .def(bp::init<boost::shared_ptr<StateMultibody>, pinocchio::FrameIndex, double, bp::optional<Eigen::Vector2d, pinocchio::ReferenceFrame> >(
           bp::args("self", "state", "id", "xref", "gains"),
           "Initialize the contact model.\n\n"
           ":param state: state of the multibody system\n"
           ":param id: reference frame id of the contact\n"
           ":param xref: contact position used for the Baumgarte stabilization\n"
-          ":param gains: gains of the contact model (default np.matrix([0.,0.]))"))
+          ":param gains: gains of the contact model (default np.matrix([0.,0.]))\n"))
       .def("calc", &ContactModel1D::calc, bp::args("self", "data", "x"),
            "Compute the 1D contact Jacobian and drift.\n\n"
            "The rigid contact model throught acceleration-base holonomic constraint\n"
@@ -68,7 +76,10 @@ void exposeContact1D() {
                     &ContactModel1D::set_reference, "reference contact translation")
       .add_property("gains",
                     bp::make_function(&ContactModel1D::get_gains, bp::return_value_policy<bp::return_by_value>()),
-                    "contact gains");
+                    "contact gains")
+      .add_property("pinReferenceFrame",
+                    bp::make_function(&ContactModel1D::get_pinReferenceFrame, bp::return_value_policy<bp::return_by_value>()),
+                    &ContactModel1D::set_pinReferenceFrame, "pin.ReferenceFrame");
 
   bp::register_ptr_to_python<boost::shared_ptr<ContactData1D> >();
 

--- a/bindings/python/crocoddyl/multibody/contacts/contact-1d.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/contact-1d.cpp
@@ -15,10 +15,10 @@ namespace python {
 void exposeContact1D() {
   bp::register_ptr_to_python<boost::shared_ptr<ContactModel1D> >();
 
-  bp::enum_<Contact1DMaskType>("Contact1DMaskType")
-      .value("X_MASK", X_MASK)
-      .value("Y_MASK", Y_MASK)
-      .value("Z_MASK", Z_MASK)
+  bp::enum_<Vector3MaskType>("Vector3MaskType")
+      .value("x", x)
+      .value("y", y)
+      .value("z", z)
       .export_values();
 
   bp::class_<ContactModel1D, bp::bases<ContactModelAbstract> >(
@@ -29,7 +29,7 @@ void exposeContact1D() {
       "The calc and calcDiff functions compute the contact Jacobian and drift (holonomic constraint) or\n"
       "the derivatives of the holonomic constraint, respectively.",
       bp::init<boost::shared_ptr<StateMultibody>, pinocchio::FrameIndex, double, std::size_t,
-               bp::optional<Eigen::Vector2d, Contact1DMaskType, pinocchio::ReferenceFrame> >(
+               bp::optional<Eigen::Vector2d, Vector3MaskType, pinocchio::ReferenceFrame> >(
           bp::args("self", "state", "id", "xref", "nu", "gains", "mask", "type"),
           "Initialize the contact model.\n\n"
           ":param state: state of the multibody system\n"
@@ -37,7 +37,7 @@ void exposeContact1D() {
           ":param xref: contact position used for the Baumgarte stabilization\n"
           ":param nu: dimension of control vector\n"
           ":param gains: gains of the contact model (default np.matrix([0.,0.]))\n"
-          ":param mask: axis of the contact constraint (0=x, 1=y or 2=z)\n"
+          ":param mask: axis of the contact constraint (default z)\n"
           ":param type: reference type of contact"))
       .def(bp::init<boost::shared_ptr<StateMultibody>, pinocchio::FrameIndex, double,
                     bp::optional<Eigen::Vector2d, pinocchio::ReferenceFrame> >(

--- a/bindings/python/crocoddyl/multibody/contacts/contact-1d.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/contact-1d.cpp
@@ -15,11 +15,7 @@ namespace python {
 void exposeContact1D() {
   bp::register_ptr_to_python<boost::shared_ptr<ContactModel1D> >();
 
-  bp::enum_<Vector3MaskType>("Vector3MaskType")
-      .value("x", x)
-      .value("y", y)
-      .value("z", z)
-      .export_values();
+  bp::enum_<Vector3MaskType>("Vector3MaskType").value("x", x).value("y", y).value("z", z).export_values();
 
   bp::class_<ContactModel1D, bp::bases<ContactModelAbstract> >(
       "ContactModel1D",

--- a/bindings/python/crocoddyl/multibody/contacts/contact-1d.cpp
+++ b/bindings/python/crocoddyl/multibody/contacts/contact-1d.cpp
@@ -15,38 +15,38 @@ namespace python {
 void exposeContact1D() {
   bp::register_ptr_to_python<boost::shared_ptr<ContactModel1D> >();
 
-  bp::enum_<pinocchio::ReferenceFrame>("ReferenceFrame")
-      .value("LOCAL", pinocchio::LOCAL)
-      .value("WORLD", pinocchio::WORLD)
-      .value("LOCAL_WORLD_ALIGNED", pinocchio::LOCAL_WORLD_ALIGNED)
+  bp::enum_<Contact1DMaskType>("Contact1DMaskType")
+      .value("X_MASK", X_MASK)
+      .value("Y_MASK", Y_MASK)
+      .value("Z_MASK", Z_MASK)
       .export_values();
 
   bp::class_<ContactModel1D, bp::bases<ContactModelAbstract> >(
       "ContactModel1D",
       "Rigid 1D contact model.\n\n"
       "It defines a rigid 1D contact model (point contact) based on acceleration-based holonomic constraints, in the "
-      "z "
-      "direction.\n"
+      "x, y or z direction.\n"
       "The calc and calcDiff functions compute the contact Jacobian and drift (holonomic constraint) or\n"
       "the derivatives of the holonomic constraint, respectively.",
       bp::init<boost::shared_ptr<StateMultibody>, pinocchio::FrameIndex, double, std::size_t,
-               bp::optional<Eigen::Vector2d, std::size_t, pinocchio::ReferenceFrame> >(
-          bp::args("self", "state", "id", "xref", "nu", "gains", "type", "pinRefFrame"),
+               bp::optional<Eigen::Vector2d, Contact1DMaskType, pinocchio::ReferenceFrame> >(
+          bp::args("self", "state", "id", "xref", "nu", "gains", "mask", "type"),
           "Initialize the contact model.\n\n"
           ":param state: state of the multibody system\n"
           ":param id: reference frame id of the contact\n"
           ":param xref: contact position used for the Baumgarte stabilization\n"
           ":param nu: dimension of control vector\n"
           ":param gains: gains of the contact model (default np.matrix([0.,0.]))\n"
-          ":param type: axis of the contact constraint (0=x, 1=y or 2=z)\n"
-          ":param pinRefFrame: pin.ReferenceFrame in {LOCAL, WORLD, LOCAL_WORLD_ALIGNED}"))
-      .def(bp::init<boost::shared_ptr<StateMultibody>, pinocchio::FrameIndex, double, bp::optional<Eigen::Vector2d, pinocchio::ReferenceFrame> >(
+          ":param mask: axis of the contact constraint (0=x, 1=y or 2=z)\n"
+          ":param type: reference type of contact"))
+      .def(bp::init<boost::shared_ptr<StateMultibody>, pinocchio::FrameIndex, double,
+                    bp::optional<Eigen::Vector2d, pinocchio::ReferenceFrame> >(
           bp::args("self", "state", "id", "xref", "gains"),
           "Initialize the contact model.\n\n"
           ":param state: state of the multibody system\n"
           ":param id: reference frame id of the contact\n"
           ":param xref: contact position used for the Baumgarte stabilization\n"
-          ":param gains: gains of the contact model (default np.matrix([0.,0.]))\n"))
+          ":param gains: gains of the contact model (default np.matrix([0.,0.]))"))
       .def("calc", &ContactModel1D::calc, bp::args("self", "data", "x"),
            "Compute the 1D contact Jacobian and drift.\n\n"
            "The rigid contact model throught acceleration-base holonomic constraint\n"
@@ -77,9 +77,12 @@ void exposeContact1D() {
       .add_property("gains",
                     bp::make_function(&ContactModel1D::get_gains, bp::return_value_policy<bp::return_by_value>()),
                     "contact gains")
-      .add_property("pinReferenceFrame",
-                    bp::make_function(&ContactModel1D::get_pinReferenceFrame, bp::return_value_policy<bp::return_by_value>()),
-                    &ContactModel1D::set_pinReferenceFrame, "pin.ReferenceFrame");
+      .add_property("mask",
+                    bp::make_function(&ContactModel1D::get_mask, bp::return_value_policy<bp::return_by_value>()),
+                    &ContactModel1D::set_mask, "mask")
+      .add_property("type",
+                    bp::make_function(&ContactModel1D::get_type, bp::return_value_policy<bp::return_by_value>()),
+                    &ContactModel1D::set_type, "type");
 
   bp::register_ptr_to_python<boost::shared_ptr<ContactData1D> >();
 

--- a/bindings/python/crocoddyl/utils/__init__.py
+++ b/bindings/python/crocoddyl/utils/__init__.py
@@ -28,7 +28,6 @@ def raiseIfNan(A, error=None):
 
 
 class StateVectorDerived(crocoddyl.StateAbstract):
-
     def __init__(self, nx):
         crocoddyl.StateAbstract.__init__(self, nx, nx)
 
@@ -65,7 +64,6 @@ class StateVectorDerived(crocoddyl.StateAbstract):
 
 
 class StateMultibodyDerived(crocoddyl.StateAbstract):
-
     def __init__(self, pinocchioModel):
         crocoddyl.StateAbstract.__init__(self, pinocchioModel.nq + pinocchioModel.nv, 2 * pinocchioModel.nv)
         self.model = pinocchioModel
@@ -130,7 +128,6 @@ class StateMultibodyDerived(crocoddyl.StateAbstract):
 
 
 class SquashingSmoothSatDerived(crocoddyl.SquashingModelAbstract):
-
     def __init__(self, u_lb, u_ub, ns):
         self.u_lb = u_lb
         self.u_ub = u_ub
@@ -151,7 +148,6 @@ class SquashingSmoothSatDerived(crocoddyl.SquashingModelAbstract):
 
 
 class FreeFloatingActuationDerived(crocoddyl.ActuationModelAbstract):
-
     def __init__(self, state):
         assert (state.pinocchio.joints[1].shortname() == 'JointModelFreeFlyer')
         crocoddyl.ActuationModelAbstract.__init__(self, state, state.nv - 6)
@@ -164,7 +160,6 @@ class FreeFloatingActuationDerived(crocoddyl.ActuationModelAbstract):
 
 
 class FullActuationDerived(crocoddyl.ActuationModelAbstract):
-
     def __init__(self, state):
         assert (state.pinocchio.joints[1].shortname() != 'JointModelFreeFlyer')
         crocoddyl.ActuationModelAbstract.__init__(self, state, state.nv)
@@ -177,7 +172,6 @@ class FullActuationDerived(crocoddyl.ActuationModelAbstract):
 
 
 class UnicycleModelDerived(crocoddyl.ActionModelAbstract):
-
     def __init__(self):
         crocoddyl.ActionModelAbstract.__init__(self, crocoddyl.StateVector(3), 2, 5)
         self.dt = .1
@@ -220,7 +214,6 @@ class UnicycleModelDerived(crocoddyl.ActionModelAbstract):
 
 
 class UnicycleDataDerived(crocoddyl.ActionDataAbstract):
-
     def __init__(self, model):
         crocoddyl.ActionDataAbstract.__init__(self, model)
         nx, nu = model.state.nx, model.nu
@@ -232,7 +225,6 @@ class UnicycleDataDerived(crocoddyl.ActionDataAbstract):
 
 
 class LQRModelDerived(crocoddyl.ActionModelAbstract):
-
     def __init__(self, nx, nu, driftFree=True):
         crocoddyl.ActionModelAbstract.__init__(self, crocoddyl.StateVector(nx), nu)
 
@@ -266,7 +258,6 @@ class LQRModelDerived(crocoddyl.ActionModelAbstract):
 
 
 class LQRDataDerived(crocoddyl.ActionDataAbstract):
-
     def __init__(self, model):
         crocoddyl.ActionDataAbstract.__init__(self, model)
         self.Fx[:, :] = model.Fx
@@ -277,7 +268,6 @@ class LQRDataDerived(crocoddyl.ActionDataAbstract):
 
 
 class DifferentialLQRModelDerived(crocoddyl.DifferentialActionModelAbstract):
-
     def __init__(self, nq, nu, driftFree=True):
         crocoddyl.DifferentialActionModelAbstract.__init__(self, crocoddyl.StateVector(2 * nq), nu)
 
@@ -313,7 +303,6 @@ class DifferentialLQRModelDerived(crocoddyl.DifferentialActionModelAbstract):
 
 
 class DifferentialLQRDataDerived(crocoddyl.DifferentialActionDataAbstract):
-
     def __init__(self, model):
         crocoddyl.DifferentialActionDataAbstract.__init__(self, model)
         self.Lxx[:, :] = model.Lxx
@@ -324,7 +313,6 @@ class DifferentialLQRDataDerived(crocoddyl.DifferentialActionDataAbstract):
 
 
 class DifferentialFreeFwdDynamicsModelDerived(crocoddyl.DifferentialActionModelAbstract):
-
     def __init__(self, state, actuationModel, costModel):
         crocoddyl.DifferentialActionModelAbstract.__init__(self, state, actuationModel.nu, costModel.nr)
         self.actuation = actuationModel
@@ -391,7 +379,6 @@ class DifferentialFreeFwdDynamicsModelDerived(crocoddyl.DifferentialActionModelA
 
 
 class DifferentialFreeFwdDynamicsDataDerived(crocoddyl.DifferentialActionDataAbstract):
-
     def __init__(self, model):
         crocoddyl.DifferentialActionDataAbstract.__init__(self, model)
         self.pinocchio = pinocchio.Model.createData(model.state.pinocchio)
@@ -403,7 +390,6 @@ class DifferentialFreeFwdDynamicsDataDerived(crocoddyl.DifferentialActionDataAbs
 
 
 class IntegratedActionModelEulerDerived(crocoddyl.ActionModelAbstract):
-
     def __init__(self, diffModel, timeStep=1e-3, withCostResiduals=True):
         crocoddyl.ActionModelAbstract.__init__(self, diffModel.state, diffModel.nv, diffModel.nr)
         self.differential = diffModel
@@ -446,14 +432,12 @@ class IntegratedActionModelEulerDerived(crocoddyl.ActionModelAbstract):
 
 
 class IntegratedActionDataEulerDerived(crocoddyl.ActionDataAbstract):
-
     def __init__(self, model):
         crocoddyl.ActionDataAbstract.__init__(self, model)
         self.differential = model.differential.createData(self)
 
 
 class IntegratedActionModelRK4Derived(crocoddyl.ActionModelAbstract):
-
     def __init__(self, diffModel, timeStep=1e-3, withCostResiduals=True):
         crocoddyl.ActionModelAbstract.__init__(self, diffModel.state, diffModel.nu, diffModel.nr)
         self.differential = diffModel
@@ -569,7 +553,6 @@ class IntegratedActionModelRK4Derived(crocoddyl.ActionModelAbstract):
 
 
 class IntegratedActionDataRK4Derived(crocoddyl.ActionDataAbstract):
-
     def __init__(self, model):
         crocoddyl.ActionDataAbstract.__init__(self, model)
 
@@ -617,7 +600,6 @@ class IntegratedActionDataRK4Derived(crocoddyl.ActionDataAbstract):
 
 
 class StateCostModelDerived(crocoddyl.CostModelAbstract):
-
     def __init__(self, state, activation=None, xref=None, nu=None):
         activation = activation if activation is not None else crocoddyl.ActivationModelQuad(state.ndx)
         self.xref = xref if xref is not None else state.zero()
@@ -639,7 +621,6 @@ class StateCostModelDerived(crocoddyl.CostModelAbstract):
 
 
 class ControlCostModelDerived(crocoddyl.CostModelAbstract):
-
     def __init__(self, state, activation=None, uref=None, nu=None):
         nu = nu if nu is not None else state.nv
         activation = activation if activation is not None else crocoddyl.ActivationModelQuad(nu)
@@ -658,7 +639,6 @@ class ControlCostModelDerived(crocoddyl.CostModelAbstract):
 
 
 class CoMPositionCostModelDerived(crocoddyl.CostModelAbstract):
-
     def __init__(self, state, activation=None, cref=None, nu=None):
         activation = activation if activation is not None else crocoddyl.ActivationModelQuad(3)
         if nu is None:
@@ -688,7 +668,6 @@ class CoMPositionCostModelDerived(crocoddyl.CostModelAbstract):
 
 
 class FramePlacementCostModelDerived(crocoddyl.CostModelAbstract):
-
     def __init__(self, state, activation=None, frame_id=None, placement=None, nu=None):
         activation = activation if activation is not None else crocoddyl.ActivationModelQuad(6)
         if nu is None:
@@ -726,7 +705,6 @@ class FramePlacementCostModelDerived(crocoddyl.CostModelAbstract):
 
 
 class FramePlacementCostDataDerived(crocoddyl.CostDataAbstract):
-
     def __init__(self, model, collector):
         crocoddyl.CostDataAbstract.__init__(self, model, collector)
         self.rMf = pinocchio.SE3.Identity()
@@ -737,7 +715,6 @@ class FramePlacementCostDataDerived(crocoddyl.CostDataAbstract):
 
 
 class FrameTranslationCostModelDerived(crocoddyl.CostModelAbstract):
-
     def __init__(self, state, activation=None, frame_id=None, translation=None, nu=None):
         activation = activation if activation is not None else crocoddyl.ActivationModelQuad(3)
         if nu is None:
@@ -775,7 +752,6 @@ class FrameTranslationCostModelDerived(crocoddyl.CostModelAbstract):
 
 
 class FrameTranslationDataDerived(crocoddyl.CostDataAbstract):
-
     def __init__(self, model, collector):
         crocoddyl.CostDataAbstract.__init__(self, model, collector)
         self.R = np.eye(3)
@@ -783,7 +759,6 @@ class FrameTranslationDataDerived(crocoddyl.CostDataAbstract):
 
 
 class FrameRotationCostModelDerived(crocoddyl.CostModelAbstract):
-
     def __init__(self, state, activation=None, frame_id=None, rotation=None, nu=None):
         activation = activation if activation is not None else crocoddyl.ActivationModelQuad(3)
         if nu is None:
@@ -821,7 +796,6 @@ class FrameRotationCostModelDerived(crocoddyl.CostModelAbstract):
 
 
 class FrameRotationCostDataDerived(crocoddyl.CostDataAbstract):
-
     def __init__(self, model, collector):
         crocoddyl.CostDataAbstract.__init__(self, model, collector)
         self.rRf = np.eye(3)
@@ -831,7 +805,6 @@ class FrameRotationCostDataDerived(crocoddyl.CostDataAbstract):
 
 
 class FrameVelocityCostModelDerived(crocoddyl.CostModelAbstract):
-
     def __init__(self, state, activation=None, frame_id=None, velocity=None, nu=None):
         activation = activation if activation is not None else crocoddyl.ActivationModelQuad(6)
         if nu is None:
@@ -863,7 +836,6 @@ class FrameVelocityCostModelDerived(crocoddyl.CostModelAbstract):
 
 
 class FrameVelocityCostDataDerived(crocoddyl.CostDataAbstract):
-
     def __init__(self, model, collector):
         crocoddyl.CostDataAbstract.__init__(self, model, collector)
         self.fXj = model.state.pinocchio.frames[model._frame_id].placement.inverse().action
@@ -871,7 +843,6 @@ class FrameVelocityCostDataDerived(crocoddyl.CostDataAbstract):
 
 
 class Contact3DModelDerived(crocoddyl.ContactModelAbstract):
-
     def __init__(self, state, xref, gains=[0., 0.]):
         crocoddyl.ContactModelAbstract.__init__(self, state, 3)
         self.xref = xref
@@ -928,7 +899,6 @@ class Contact3DModelDerived(crocoddyl.ContactModelAbstract):
 
 
 class Contact3DDataDerived(crocoddyl.ContactDataAbstract):
-
     def __init__(self, model, data):
         crocoddyl.ContactDataAbstract.__init__(self, model, data)
         self.fXj = model.state.pinocchio.frames[model.xref.id].placement.inverse().action
@@ -940,7 +910,6 @@ class Contact3DDataDerived(crocoddyl.ContactDataAbstract):
 
 
 class Contact6DModelDerived(crocoddyl.ContactModelAbstract):
-
     def __init__(self, state, Mref, gains=[0., 0.]):
         crocoddyl.ContactModelAbstract.__init__(self, state, 6)
         self.Mref = Mref
@@ -978,7 +947,6 @@ class Contact6DModelDerived(crocoddyl.ContactModelAbstract):
 
 
 class Contact6DDataDerived(crocoddyl.ContactDataAbstract):
-
     def __init__(self, model, data):
         crocoddyl.ContactDataAbstract.__init__(self, model, data)
         self.fXj = model.state.pinocchio.frames[model.Mref.id].placement.inverse().action
@@ -989,7 +957,6 @@ class Contact6DDataDerived(crocoddyl.ContactDataAbstract):
 
 
 class Impulse3DModelDerived(crocoddyl.ImpulseModelAbstract):
-
     def __init__(self, state, frame):
         crocoddyl.ImpulseModelAbstract.__init__(self, state, 3)
         self.frame = frame
@@ -1009,7 +976,6 @@ class Impulse3DModelDerived(crocoddyl.ImpulseModelAbstract):
 
 
 class Impulse3DDataDerived(crocoddyl.ImpulseDataAbstract):
-
     def __init__(self, model, data):
         crocoddyl.ImpulseDataAbstract.__init__(self, model, data)
         self.fXj = model.state.pinocchio.frames[model.frame].placement.inverse().action
@@ -1017,7 +983,6 @@ class Impulse3DDataDerived(crocoddyl.ImpulseDataAbstract):
 
 
 class Impulse6DModelDerived(crocoddyl.ImpulseModelAbstract):
-
     def __init__(self, state, frame):
         crocoddyl.ImpulseModelAbstract.__init__(self, state, 6)
         self.frame = frame
@@ -1037,7 +1002,6 @@ class Impulse6DModelDerived(crocoddyl.ImpulseModelAbstract):
 
 
 class Impulse6DDataDerived(crocoddyl.ImpulseDataAbstract):
-
     def __init__(self, model, data):
         crocoddyl.ImpulseDataAbstract.__init__(self, model, data)
         self.fXj = model.state.pinocchio.frames[model.frame].placement.inverse().action
@@ -1045,7 +1009,6 @@ class Impulse6DDataDerived(crocoddyl.ImpulseDataAbstract):
 
 
 class DDPDerived(crocoddyl.SolverAbstract):
-
     def __init__(self, shootingProblem):
         crocoddyl.SolverAbstract.__init__(self, shootingProblem)
         self.allocateData()  # TODO remove it?
@@ -1248,7 +1211,6 @@ class DDPDerived(crocoddyl.SolverAbstract):
 
 
 class FDDPDerived(DDPDerived):
-
     def __init__(self, shootingProblem):
         DDPDerived.__init__(self, shootingProblem)
 

--- a/bindings/python/crocoddyl/utils/biped.py
+++ b/bindings/python/crocoddyl/utils/biped.py
@@ -13,7 +13,6 @@ class SimpleBipedGaitProblem:
     through a strict process of deprecation.
     Thus, we advice any user to DO NOT develop their application based on this class.
     """
-
     def __init__(self, rmodel, rightFoot, leftFoot, integrator='euler', control='zero'):
         """ Construct biped-gait problem.
 

--- a/bindings/python/crocoddyl/utils/pendulum.py
+++ b/bindings/python/crocoddyl/utils/pendulum.py
@@ -3,7 +3,6 @@ import numpy as np
 
 
 class CostModelDoublePendulum(crocoddyl.CostModelAbstract):
-
     def __init__(self, state, activation, nu):
         activation = activation if activation is not None else crocoddyl.ActivationModelQuad(state.ndx)
         crocoddyl.CostModelAbstract.__init__(self, state, activation, nu=nu)
@@ -37,14 +36,12 @@ class CostModelDoublePendulum(crocoddyl.CostModelAbstract):
 
 
 class CostDataDoublePendulum(crocoddyl.CostDataAbstract):
-
     def __init__(self, model, collector):
         crocoddyl.CostDataAbstract.__init__(self, model, collector)
         self.Rxx = np.zeros((6, 4))
 
 
 class ActuationModelDoublePendulum(crocoddyl.ActuationModelAbstract):
-
     def __init__(self, state, actLink):
         crocoddyl.ActuationModelAbstract.__init__(self, state, 1)
         self.nv = state.nv
@@ -62,7 +59,6 @@ class ActuationModelDoublePendulum(crocoddyl.ActuationModelAbstract):
 
 
 class ActuationDataDoublePendulum(crocoddyl.ActuationDataAbstract):
-
     def __init__(self, model):
         crocoddyl.ActuationDataAbstract.__init__(self, model)
         if model.nu == 1:

--- a/bindings/python/crocoddyl/utils/quadruped.py
+++ b/bindings/python/crocoddyl/utils/quadruped.py
@@ -13,7 +13,6 @@ class SimpleQuadrupedalGaitProblem:
     through a strict process of deprecation.
     Thus, we advice any user to DO NOT develop their application based on this class.
     """
-
     def __init__(self, rmodel, lfFoot, rfFoot, lhFoot, rhFoot, integrator='euler', control='zero'):
         """ Construct quadrupedal-gait problem.
 

--- a/examples/notebooks/cartpole_swing_up.py
+++ b/examples/notebooks/cartpole_swing_up.py
@@ -5,7 +5,6 @@ import crocoddyl
 
 
 class DifferentialActionModelCartpole(crocoddyl.DifferentialActionModelAbstract):
-
     def __init__(self):
         crocoddyl.DifferentialActionModelAbstract.__init__(self, crocoddyl.StateVector(4), 1, 6)  # nu = 1; nr = 6
         self.unone = np.zeros(self.nu)

--- a/include/crocoddyl/multibody/contacts/contact-1d.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-1d.hpp
@@ -37,6 +37,7 @@ class ContactModel1DTpl : public ContactModelAbstractTpl<_Scalar> {
   typedef typename MathBase::Vector3s Vector3s;
   typedef typename MathBase::VectorXs VectorXs;
   typedef typename MathBase::Matrix3s Matrix3s;
+  typedef typename MathBase::Vector6s Vector6s;
 
   /**
    * @brief Initialize the 1d contact model
@@ -48,7 +49,8 @@ class ContactModel1DTpl : public ContactModelAbstractTpl<_Scalar> {
    * @param[in] gains  Baumgarte stabilization gains
    */
   ContactModel1DTpl(boost::shared_ptr<StateMultibody> state, const pinocchio::FrameIndex id, const Scalar xref,
-                    const std::size_t nu, const Vector2s& gains = Vector2s::Zero());
+                    const std::size_t nu, const Vector2s& gains = Vector2s::Zero(), const std::size_t& type = 2, 
+                    const pinocchio::ReferenceFrame = pinocchio::LOCAL);
 
   /**
    * @brief Initialize the 1d contact model
@@ -61,7 +63,8 @@ class ContactModel1DTpl : public ContactModelAbstractTpl<_Scalar> {
    * @param[in] gains  Baumgarte stabilization gains
    */
   ContactModel1DTpl(boost::shared_ptr<StateMultibody> state, const pinocchio::FrameIndex id, const Scalar xref,
-                    const Vector2s& gains = Vector2s::Zero());
+                    const Vector2s& gains = Vector2s::Zero(),
+                    const pinocchio::ReferenceFrame = pinocchio::LOCAL);
 
   virtual ~ContactModel1DTpl();
 
@@ -111,6 +114,18 @@ class ContactModel1DTpl : public ContactModelAbstractTpl<_Scalar> {
    */
   void set_reference(const Scalar reference);
 
+
+  /**
+   * @brief Modify pinocchio::ReferenceFrame
+   */
+  void set_pinReferenceFrame(const pinocchio::ReferenceFrame);
+
+  /**
+   * @brief Get pinocchio::ReferenceFrame
+   */
+  const pinocchio::ReferenceFrame get_pinReferenceFrame() const;
+
+
   /**
    * @brief Print relevant information of the 1d contact model
    *
@@ -125,8 +140,11 @@ class ContactModel1DTpl : public ContactModelAbstractTpl<_Scalar> {
   using Base::state_;
 
  private:
-  Scalar xref_;     //!< Contact position used for the Baumgarte stabilization
-  Vector2s gains_;  //!< Baumgarte stabilization gains
+  Scalar xref_;                                    //!< Contact position used for the Baumgarte stabilization
+  Vector2s gains_;                                 //!< Baumgarte stabilization gains
+  Vector3s mask_;                     //!< Projection matrix selecting contact constraint direction in LOCAL frame
+  std::size_t type_;                               //!< Type of the 1D contact in {0,1,2} for {'x','y','z'} 
+  pinocchio::ReferenceFrame pinReferenceFrame_;    //!< Pinocchio reference frame   
 };
 
 template <typename _Scalar>

--- a/include/crocoddyl/multibody/contacts/contact-1d.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-1d.hpp
@@ -22,6 +22,8 @@
 
 namespace crocoddyl {
 
+enum Contact1DMaskType { X_MASK = 0, Y_MASK = 1, Z_MASK = 2 };
+
 template <typename _Scalar>
 class ContactModel1DTpl : public ContactModelAbstractTpl<_Scalar> {
  public:
@@ -37,7 +39,6 @@ class ContactModel1DTpl : public ContactModelAbstractTpl<_Scalar> {
   typedef typename MathBase::Vector3s Vector3s;
   typedef typename MathBase::VectorXs VectorXs;
   typedef typename MathBase::Matrix3s Matrix3s;
-  typedef typename MathBase::Vector6s Vector6s;
 
   /**
    * @brief Initialize the 1d contact model
@@ -47,10 +48,12 @@ class ContactModel1DTpl : public ContactModelAbstractTpl<_Scalar> {
    * @param[in] xref   Contact position used for the Baumgarte stabilization
    * @param[in] nu     Dimension of the control vector
    * @param[in] gains  Baumgarte stabilization gains
+   * @param[in] mask   Constraint 1D axis
+   * @param[in] ref    Reference type of contact
    */
   ContactModel1DTpl(boost::shared_ptr<StateMultibody> state, const pinocchio::FrameIndex id, const Scalar xref,
-                    const std::size_t nu, const Vector2s& gains = Vector2s::Zero(), const std::size_t& type = 2, 
-                    const pinocchio::ReferenceFrame = pinocchio::LOCAL);
+                    const std::size_t nu, const Vector2s& gains = Vector2s::Zero(),
+                    const Contact1DMaskType& mask = Z_MASK, const pinocchio::ReferenceFrame ref = pinocchio::LOCAL);
 
   /**
    * @brief Initialize the 1d contact model
@@ -61,10 +64,10 @@ class ContactModel1DTpl : public ContactModelAbstractTpl<_Scalar> {
    * @param[in] id     Reference frame id of the contact
    * @param[in] xref   Contact position used for the Baumgarte stabilization
    * @param[in] gains  Baumgarte stabilization gains
+   * @param[in] ref    Reference type of contact
    */
   ContactModel1DTpl(boost::shared_ptr<StateMultibody> state, const pinocchio::FrameIndex id, const Scalar xref,
-                    const Vector2s& gains = Vector2s::Zero(),
-                    const pinocchio::ReferenceFrame = pinocchio::LOCAL);
+                    const Vector2s& gains = Vector2s::Zero(), const pinocchio::ReferenceFrame ref = pinocchio::LOCAL);
 
   virtual ~ContactModel1DTpl();
 
@@ -114,17 +117,25 @@ class ContactModel1DTpl : public ContactModelAbstractTpl<_Scalar> {
    */
   void set_reference(const Scalar reference);
 
-
   /**
    * @brief Modify pinocchio::ReferenceFrame
    */
-  void set_pinReferenceFrame(const pinocchio::ReferenceFrame);
+  void set_type(const pinocchio::ReferenceFrame type);
 
   /**
    * @brief Get pinocchio::ReferenceFrame
    */
-  const pinocchio::ReferenceFrame get_pinReferenceFrame() const;
+  const pinocchio::ReferenceFrame get_type() const;
 
+  /**
+   * @brief Modify contact 1D mask
+   */
+  void set_mask(const Contact1DMaskType mask);
+
+  /**
+   * @brief Get contact 1D mask
+   */
+  const Contact1DMaskType get_mask() const;
 
   /**
    * @brief Print relevant information of the 1d contact model
@@ -140,11 +151,10 @@ class ContactModel1DTpl : public ContactModelAbstractTpl<_Scalar> {
   using Base::state_;
 
  private:
-  Scalar xref_;                                    //!< Contact position used for the Baumgarte stabilization
-  Vector2s gains_;                                 //!< Baumgarte stabilization gains
-  Vector3s mask_;                     //!< Projection matrix selecting contact constraint direction in LOCAL frame
-  std::size_t type_;                               //!< Type of the 1D contact in {0,1,2} for {'x','y','z'} 
-  pinocchio::ReferenceFrame pinReferenceFrame_;    //!< Pinocchio reference frame   
+  Scalar xref_;                     //!< Contact position used for the Baumgarte stabilization
+  Vector2s gains_;                  //!< Baumgarte stabilization gains
+  Contact1DMaskType mask_;          //!< Axis of the 1D contact in (x,y,z)
+  pinocchio::ReferenceFrame type_;  //!< Reference type of contact
 };
 
 template <typename _Scalar>

--- a/include/crocoddyl/multibody/contacts/contact-1d.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-1d.hpp
@@ -53,7 +53,8 @@ class ContactModel1DTpl : public ContactModelAbstractTpl<_Scalar> {
    */
   ContactModel1DTpl(boost::shared_ptr<StateMultibody> state, const pinocchio::FrameIndex id, const Scalar xref,
                     const std::size_t nu, const Vector2s& gains = Vector2s::Zero(),
-                    const Vector3MaskType& mask = Vector3MaskType::z, const pinocchio::ReferenceFrame ref = pinocchio::LOCAL);
+                    const Vector3MaskType& mask = Vector3MaskType::z,
+                    const pinocchio::ReferenceFrame ref = pinocchio::LOCAL);
 
   /**
    * @brief Initialize the 1d contact model
@@ -153,7 +154,7 @@ class ContactModel1DTpl : public ContactModelAbstractTpl<_Scalar> {
  private:
   Scalar xref_;                     //!< Contact position used for the Baumgarte stabilization
   Vector2s gains_;                  //!< Baumgarte stabilization gains
-  Vector3MaskType mask_;          //!< Axis of the 1D contact in (x,y,z)
+  Vector3MaskType mask_;            //!< Axis of the 1D contact in (x,y,z)
   pinocchio::ReferenceFrame type_;  //!< Reference type of contact
 };
 
@@ -182,7 +183,7 @@ struct ContactData1DTpl : public ContactDataAbstractTpl<_Scalar> {
         fXjda_dv(6, model->get_state()->get_nv()) {
     frame = model->get_id();
     jMf = model->get_state()->get_pinocchio()->frames[frame].placement;
-    fXj = pinocchio::SE3::Identity().toActionMatrix(); //jMf.inverse().toActionMatrix(); 
+    fXj = pinocchio::SE3::Identity().toActionMatrix();  // jMf.inverse().toActionMatrix();
     fJf.setZero();
     v_partial_dq.setZero();
     a_partial_dq.setZero();
@@ -200,7 +201,7 @@ struct ContactData1DTpl : public ContactDataAbstractTpl<_Scalar> {
     mask = model->get_mask();
     jMc_ = pinocchio::SE3::Identity();
     wMlwa_ = pinocchio::SE3::Identity();
-    lwaMj_ = pinocchio::SE3::Identity(); 
+    lwaMj_ = pinocchio::SE3::Identity();
   }
 
   using Base::a0;

--- a/include/crocoddyl/multibody/contacts/contact-1d.hxx
+++ b/include/crocoddyl/multibody/contacts/contact-1d.hxx
@@ -64,13 +64,11 @@ void ContactModel1DTpl<Scalar>::calcDiff(const boost::shared_ptr<ContactDataAbst
   pinocchio::skew(d->vv, d->vv_skew);
   pinocchio::skew(d->vw, d->vw_skew);
   // Matrix6s fXj;
-  if (type_ == pinocchio::LOCAL){
+  if (type_ == pinocchio::LOCAL) {
     d->fXj = d->jMf.inverse().toActionMatrix();
-  } 
-  else if (type_ == pinocchio::WORLD) {
+  } else if (type_ == pinocchio::WORLD) {
     d->fXj = d->fXj;
-  } 
-  else if (type_ == pinocchio::LOCAL_WORLD_ALIGNED) {
+  } else if (type_ == pinocchio::LOCAL_WORLD_ALIGNED) {
     d->lwaMj_.translation(d->jMf.inverse().translation());
     d->fXj = d->lwaMj_.toActionMatrix();
   }

--- a/include/crocoddyl/multibody/contacts/contact-1d.hxx
+++ b/include/crocoddyl/multibody/contacts/contact-1d.hxx
@@ -9,17 +9,36 @@
 namespace crocoddyl {
 
 template <typename Scalar>
-ContactModel1DTpl<Scalar>::ContactModel1DTpl(boost::shared_ptr<StateMultibody> state, const pinocchio::FrameIndex id,
-                                             const Scalar xref, const std::size_t nu, const Vector2s& gains)
-    : Base(state, 1, nu), xref_(xref), gains_(gains) {
+ContactModel1DTpl<Scalar>::ContactModel1DTpl(boost::shared_ptr<StateMultibody> state, 
+                                             const pinocchio::FrameIndex id,
+                                             const Scalar xref, 
+                                             const std::size_t nu, 
+                                             const Vector2s& gains, 
+                                             const std::size_t& type, 
+                                             const pinocchio::ReferenceFrame pinRefFrame)
+    : Base(state, 1, nu), xref_(xref), gains_(gains), type_(type), pinReferenceFrame_(pinRefFrame) {
   id_ = id;
+  if(type_ < 0 || type_ > 2){
+    throw_pretty("Invalid argument: " 
+      << "Contact1D type must be in {0,1,2} for {x,y,z}");
+  }
+  mask_ = Vector3s::Zero();
+  mask_[type] = 1;
 }
 
 template <typename Scalar>
-ContactModel1DTpl<Scalar>::ContactModel1DTpl(boost::shared_ptr<StateMultibody> state, const pinocchio::FrameIndex id,
-                                             const Scalar xref, const Vector2s& gains)
-    : Base(state, 1), xref_(xref), gains_(gains) {
+ContactModel1DTpl<Scalar>::ContactModel1DTpl(boost::shared_ptr<StateMultibody> state, 
+                                             const pinocchio::FrameIndex id,
+                                             const Scalar xref, 
+                                             const Vector2s& gains,
+                                             const pinocchio::ReferenceFrame pinRefFrame)
+    : Base(state, 1), xref_(xref), gains_(gains), pinReferenceFrame_(pinRefFrame){
   id_ = id;
+  // Default type is 2
+  type_ = 2;
+  mask_ = Vector3s::Zero();
+  mask_[type_] = 1;
+  
 }
 
 template <typename Scalar>
@@ -30,22 +49,25 @@ void ContactModel1DTpl<Scalar>::calc(const boost::shared_ptr<ContactDataAbstract
                                      const Eigen::Ref<const VectorXs>&) {
   Data* d = static_cast<Data*>(data.get());
   pinocchio::updateFramePlacement(*state_->get_pinocchio().get(), *d->pinocchio, id_);
-  pinocchio::getFrameJacobian(*state_->get_pinocchio().get(), *d->pinocchio, id_, pinocchio::LOCAL, d->fJf);
-  d->v = pinocchio::getFrameVelocity(*state_->get_pinocchio().get(), *d->pinocchio, id_);
-  d->a = pinocchio::getFrameAcceleration(*state_->get_pinocchio().get(), *d->pinocchio, id_);
+  pinocchio::getFrameJacobian(*state_->get_pinocchio().get(), *d->pinocchio, id_, pinReferenceFrame_, d->fJf);
+  d->v = pinocchio::getFrameVelocity(*state_->get_pinocchio().get(), *d->pinocchio, id_, pinReferenceFrame_);
+  d->a = pinocchio::getFrameAcceleration(*state_->get_pinocchio().get(), *d->pinocchio, id_, pinReferenceFrame_);
 
-  d->Jc.row(0) = d->fJf.row(2);
-
+  d->Jc.row(0) = d->fJf.row(type_);
   d->vw = d->v.angular();
   d->vv = d->v.linear();
-
-  d->a0[0] = d->a.linear()[2] + d->vw[0] * d->vv[1] - d->vw[1] * d->vv[0];
+  d->a0[0] = mask_.dot( d->a.linear() + d->vw.cross(d->vv) );
 
   if (gains_[0] != 0.) {
-    d->a0[0] += gains_[0] * (d->pinocchio->oMf[id_].translation()[2] - xref_);
+    if(pinReferenceFrame_ == pinocchio::WORLD){
+      d->a0[0] += gains_[0] * (d->pinocchio->oMf[id_].translation()[type_] - xref_);
+    }
+    else if (pinReferenceFrame_ == pinocchio::LOCAL || pinReferenceFrame_ == pinocchio::LOCAL_WORLD_ALIGNED){
+      d->a0[0] += - gains_[0] * xref_;
+    }
   }
   if (gains_[1] != 0.) {
-    d->a0[0] += gains_[1] * d->vv[2];
+    d->a0[0] += gains_[1] * d->vv[type_];
   }
 }
 
@@ -54,7 +76,7 @@ void ContactModel1DTpl<Scalar>::calcDiff(const boost::shared_ptr<ContactDataAbst
                                          const Eigen::Ref<const VectorXs>&) {
   Data* d = static_cast<Data*>(data.get());
   const pinocchio::JointIndex joint = state_->get_pinocchio()->frames[d->frame].parent;
-  pinocchio::getJointAccelerationDerivatives(*state_->get_pinocchio().get(), *d->pinocchio, joint, pinocchio::LOCAL,
+  pinocchio::getJointAccelerationDerivatives(*state_->get_pinocchio().get(), *d->pinocchio, joint, pinReferenceFrame_,
                                              d->v_partial_dq, d->a_partial_dq, d->a_partial_dv, d->a_partial_da);
   const std::size_t nv = state_->get_nv();
   pinocchio::skew(d->vv, d->vv_skew);
@@ -63,22 +85,22 @@ void ContactModel1DTpl<Scalar>::calcDiff(const boost::shared_ptr<ContactDataAbst
   d->fXjda_dq.noalias() = d->fXj * d->a_partial_dq;
   d->fXjda_dv.noalias() = d->fXj * d->a_partial_dv;
 
-  d->da0_dx.leftCols(nv).row(0).noalias() = d->fXjda_dq.row(2);
-  d->da0_dx.leftCols(nv).row(0).noalias() += d->vw_skew.row(2) * d->fXjdv_dq.template topRows<3>();
-  d->da0_dx.leftCols(nv).row(0).noalias() -= d->vv_skew.row(2) * d->fXjdv_dq.template bottomRows<3>();
+  d->da0_dx.leftCols(nv).row(0) = d->fXjda_dq.row(type_);
+  d->da0_dx.leftCols(nv).row(0).noalias() += d->vw_skew.row(type_) * d->fXjdv_dq.template topRows<3>();
+  d->da0_dx.leftCols(nv).row(0).noalias() -= d->vv_skew.row(type_) * d->fXjdv_dq.template bottomRows<3>();
 
-  d->da0_dx.rightCols(nv).row(0).noalias() = d->fXjda_dv.row(2);
-  d->da0_dx.rightCols(nv).row(0).noalias() += d->vw_skew.row(2) * d->fJf.template topRows<3>();
-  d->da0_dx.rightCols(nv).row(0).noalias() -= d->vv_skew.row(2) * d->fJf.template bottomRows<3>();
+  d->da0_dx.rightCols(nv).row(0) = d->fXjda_dv.row(type_);
+  d->da0_dx.rightCols(nv).row(0).noalias() += d->vw_skew.row(type_) * d->fJf.template topRows<3>();
+  d->da0_dx.rightCols(nv).row(0).noalias() -= d->vv_skew.row(type_) * d->fJf.template bottomRows<3>();
 
   if (gains_[0] != 0.) {
     const Eigen::Ref<const Matrix3s> oRf = d->pinocchio->oMf[id_].rotation();
-    d->oRf(0, 0) = oRf(2, 2);
+    d->oRf(0, 0) = oRf(type_, type_);
     d->da0_dx.leftCols(nv).noalias() += gains_[0] * d->oRf * d->Jc;
   }
   if (gains_[1] != 0.) {
-    d->da0_dx.leftCols(nv).row(0).noalias() += gains_[1] * d->fXj.row(2) * d->v_partial_dq;
-    d->da0_dx.rightCols(nv).row(0).noalias() += gains_[1] * d->fXj.row(2) * d->a_partial_da;
+    d->da0_dx.leftCols(nv).row(0).noalias() += gains_[1] * d->fXj.row(type_) * d->v_partial_dq;
+    d->da0_dx.rightCols(nv).row(0).noalias() += gains_[1] * d->fXj.row(type_) * d->a_partial_da;
   }
 }
 
@@ -90,8 +112,21 @@ void ContactModel1DTpl<Scalar>::updateForce(const boost::shared_ptr<ContactDataA
                  << "lambda has wrong dimension (it should be 1)");
   }
   Data* d = static_cast<Data*>(data.get());
-  const Eigen::Ref<const Matrix3s> R = d->jMf.rotation();
-  data->f.linear() = R.col(2) * force[0];
+  switch( pinReferenceFrame_ ){
+    case pinocchio::LOCAL: {
+      const pinocchio::SE3 jMc = d->jMf;
+      break;  
+    }
+    case pinocchio::WORLD: {
+      const pinocchio::SE3 jMc = d->jMf.act(d->pinocchio->oMf[id_].inverse());
+      break;
+    }
+    case pinocchio::LOCAL_WORLD_ALIGNED: {
+      const pinocchio::SE3 jMc = pinocchio::SE3(Matrix3s::Identity(), jMc.translation());
+      break;
+    }
+  }
+  data->f.linear() = d->jMf.rotation().col(type_) * force[0];
   data->f.angular() = d->jMf.translation().cross(data->f.linear());
 }
 
@@ -120,5 +155,17 @@ template <typename Scalar>
 void ContactModel1DTpl<Scalar>::set_reference(const Scalar reference) {
   xref_ = reference;
 }
+
+
+template <typename Scalar>
+void ContactModel1DTpl<Scalar>::set_pinReferenceFrame(const pinocchio::ReferenceFrame reference) {
+  pinReferenceFrame_ = reference;
+}
+
+template <typename Scalar>
+const pinocchio::ReferenceFrame ContactModel1DTpl<Scalar>::get_pinReferenceFrame() const {
+  return pinReferenceFrame_;
+}
+
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/multibody/contacts/contact-1d.hxx
+++ b/include/crocoddyl/multibody/contacts/contact-1d.hxx
@@ -112,22 +112,23 @@ void ContactModel1DTpl<Scalar>::updateForce(const boost::shared_ptr<ContactDataA
                  << "lambda has wrong dimension (it should be 1)");
   }
   Data* d = static_cast<Data*>(data.get());
+  pinocchio::SE3 jMc;
   switch( pinReferenceFrame_ ){
     case pinocchio::LOCAL: {
-      const pinocchio::SE3 jMc = d->jMf;
+      jMc = d->jMf;
       break;  
     }
     case pinocchio::WORLD: {
-      const pinocchio::SE3 jMc = d->jMf.act(d->pinocchio->oMf[id_].inverse());
+      jMc = d->jMf.act(d->pinocchio->oMf[id_].inverse());
       break;
     }
     case pinocchio::LOCAL_WORLD_ALIGNED: {
-      const pinocchio::SE3 jMc = pinocchio::SE3(Matrix3s::Identity(), jMc.translation());
+      jMc = pinocchio::SE3(Matrix3s::Identity(), d->jMf.translation());
       break;
     }
   }
-  data->f.linear() = d->jMf.rotation().col(type_) * force[0];
-  data->f.angular() = d->jMf.translation().cross(data->f.linear());
+  data->f.linear() = jMc.rotation().col(type_) * force[0];
+  data->f.angular() = jMc.translation().cross(data->f.linear());
 }
 
 template <typename Scalar>

--- a/include/crocoddyl/multibody/residuals/contact-force.hxx
+++ b/include/crocoddyl/multibody/residuals/contact-force.hxx
@@ -40,17 +40,20 @@ void ResidualModelContactForceTpl<Scalar>::calc(const boost::shared_ptr<Residual
 
   // We transform the force to the contact frame
   switch (d->contact_type) {
-    case Contact1D:{
+    case Contact1D: {
       ContactData1DTpl<Scalar>* d1d = static_cast<ContactData1DTpl<Scalar>*>(d->contact.get());
-      if(d1d->type == pinocchio::LOCAL){
+      if (d1d->type == pinocchio::LOCAL) {
         data->r = ((d->contact->jMf.actInv(d->contact->f) - fref_).linear()).row(d1d->mask);
-      } 
-      else if(d1d->type == pinocchio::WORLD) {
-        data->r = ((d->contact->pinocchio->oMf[id_].act(d->contact->jMf.actInv(d->contact->f)) - fref_).linear()).row(d1d->mask);
-      }  
-      else if(d1d->type == pinocchio::LOCAL_WORLD_ALIGNED) {
+      } else if (d1d->type == pinocchio::WORLD) {
+        data->r = ((d->contact->pinocchio->oMf[id_].act(d->contact->jMf.actInv(d->contact->f)) - fref_).linear())
+                      .row(d1d->mask);
+      } else if (d1d->type == pinocchio::LOCAL_WORLD_ALIGNED) {
         d1d->wMlwa_.translation_impl(d->contact->pinocchio->oMf[id_].translation());
-        data->r = (( d1d->wMlwa_.actInv( d->contact->pinocchio->oMf[id_].act(d->contact->jMf.inverse()) ).act(d->contact->f) - fref_).linear()).row(d1d->mask);
+        data->r =
+            ((d1d->wMlwa_.actInv(d->contact->pinocchio->oMf[id_].act(d->contact->jMf.inverse())).act(d->contact->f) -
+              fref_)
+                 .linear())
+                .row(d1d->mask);
       }
       break;
     }

--- a/include/crocoddyl/multibody/residuals/contact-force.hxx
+++ b/include/crocoddyl/multibody/residuals/contact-force.hxx
@@ -40,9 +40,20 @@ void ResidualModelContactForceTpl<Scalar>::calc(const boost::shared_ptr<Residual
 
   // We transform the force to the contact frame
   switch (d->contact_type) {
-    case Contact1D:
-      data->r = ((d->contact->jMf.actInv(d->contact->f) - fref_).linear()).row(2);
+    case Contact1D:{
+      ContactData1DTpl<Scalar>* d1d = static_cast<ContactData1DTpl<Scalar>*>(d->contact.get());
+      if(d1d->type == pinocchio::LOCAL){
+        data->r = ((d->contact->jMf.actInv(d->contact->f) - fref_).linear()).row(d1d->mask);
+      } 
+      else if(d1d->type == pinocchio::WORLD) {
+        data->r = ((d->contact->pinocchio->oMf[id_].act(d->contact->jMf.actInv(d->contact->f)) - fref_).linear()).row(d1d->mask);
+      }  
+      else if(d1d->type == pinocchio::LOCAL_WORLD_ALIGNED) {
+        d1d->wMlwa_.translation_impl(d->contact->pinocchio->oMf[id_].translation());
+        data->r = (( d1d->wMlwa_.actInv( d->contact->pinocchio->oMf[id_].act(d->contact->jMf.inverse()) ).act(d->contact->f) - fref_).linear()).row(d1d->mask);
+      }
       break;
+    }
     case Contact3D:
       data->r = (d->contact->jMf.actInv(d->contact->f) - fref_).linear();
       break;

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -28,6 +28,7 @@ SET(${PROJECT_NAME}_CPP_TESTS
   test_costs_collision
   test_cost_sum
   test_contacts
+  test_contact1d
   test_controls
   test_impulses
   test_multiple_contacts

--- a/unittest/factory/contact1d.cpp
+++ b/unittest/factory/contact1d.cpp
@@ -1,0 +1,141 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2019-2021, University of Edinburgh
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#include "contact1d.hpp"
+#include "crocoddyl/multibody/contacts/contact-1d.hpp"
+#include "crocoddyl/core/utils/exception.hpp"
+
+namespace crocoddyl {
+namespace unittest {
+
+const std::vector<ContactModelMaskTypes::Type> ContactModelMaskTypes::all(ContactModelMaskTypes::init_all());
+
+const std::vector<PinocchioReferenceTypes::Type> PinocchioReferenceTypes::all(PinocchioReferenceTypes::init_all());
+
+std::ostream& operator<<(std::ostream& os, const ContactModelMaskTypes::Type& type) {
+  switch (type) {
+    case ContactModelMaskTypes::X:
+      os << "X";
+      break;
+    case ContactModelMaskTypes::Y:
+      os << "Y";
+      break;
+    case ContactModelMaskTypes::Z:
+      os << "Z";
+      break;
+    case ContactModelMaskTypes::NbMaskTypes:
+      os << "NbMaskTypes";
+      break;
+    default:
+      os << "Unknown type";
+      break;
+  }
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const PinocchioReferenceTypes::Type& type) {
+  switch (type) {
+    case PinocchioReferenceTypes::LOCAL:
+      os << "LOCAL";
+      break;
+    case PinocchioReferenceTypes::WORLD:
+      os << "WORLD";
+      break;
+    case PinocchioReferenceTypes::LOCAL_WORLD_ALIGNED:
+      os << "LOCAL_WORLD_ALIGNED";
+      break;
+    case PinocchioReferenceTypes::NbPinRefTypes:
+      os << "NbPinRefTypes";
+      break;
+    default:
+      os << "Unknown type";
+      break;
+  }
+  return os;
+}
+
+ContactModel1DFactory::ContactModel1DFactory() {}
+ContactModel1DFactory::~ContactModel1DFactory() {}
+
+boost::shared_ptr<crocoddyl::ContactModelAbstract> ContactModel1DFactory::create(ContactModelMaskTypes::Type mask_type,
+                                                                               PinocchioModelTypes::Type model_type,
+                                                                               PinocchioReferenceTypes::Type reference_type,
+                                                                               const std::string frame_name,
+                                                                               std::size_t nu) const {
+  PinocchioModelFactory model_factory(model_type);
+  boost::shared_ptr<crocoddyl::StateMultibody> state =
+      boost::make_shared<crocoddyl::StateMultibody>(model_factory.create());
+  boost::shared_ptr<crocoddyl::ContactModelAbstract> contact;
+  std::size_t frame_id = 0;
+  if (frame_name == "") {
+    frame_id = model_factory.get_frame_id();
+  } else {
+    frame_id = state->get_pinocchio()->getFrameId(frame_name);
+  }
+  if (nu == std::numeric_limits<std::size_t>::max()) {
+    nu = state->get_nv();
+  }
+
+  Eigen::Vector2d gains = Eigen::Vector2d::Zero();
+  switch (mask_type) {
+    case ContactModelMaskTypes::X: {
+      if(reference_type == PinocchioReferenceTypes::LOCAL){
+        contact = boost::make_shared<crocoddyl::ContactModel1D>(state, frame_id, 0., nu, gains, Vector3MaskType::x, pinocchio::LOCAL);
+      } else if(reference_type == PinocchioReferenceTypes::WORLD){
+        contact = boost::make_shared<crocoddyl::ContactModel1D>(state, frame_id, 0., nu, gains, Vector3MaskType::x, pinocchio::WORLD);
+      } else if(reference_type == PinocchioReferenceTypes::LOCAL_WORLD_ALIGNED){
+        contact = boost::make_shared<crocoddyl::ContactModel1D>(state, frame_id, 0., nu, gains, Vector3MaskType::x, pinocchio::LOCAL_WORLD_ALIGNED);
+      }
+      break;
+    }
+    case ContactModelMaskTypes::Y: {
+      if(reference_type == PinocchioReferenceTypes::LOCAL){
+        contact = boost::make_shared<crocoddyl::ContactModel1D>(state, frame_id, 0., nu, gains, Vector3MaskType::y, pinocchio::LOCAL);
+      } else if(reference_type == PinocchioReferenceTypes::WORLD){
+        contact = boost::make_shared<crocoddyl::ContactModel1D>(state, frame_id, 0., nu, gains, Vector3MaskType::y, pinocchio::WORLD);
+      } else if(reference_type == PinocchioReferenceTypes::LOCAL_WORLD_ALIGNED){
+        contact = boost::make_shared<crocoddyl::ContactModel1D>(state, frame_id, 0., nu, gains, Vector3MaskType::y, pinocchio::LOCAL_WORLD_ALIGNED);
+      }
+      break;
+    }
+    case ContactModelMaskTypes::Z:
+      if(reference_type == PinocchioReferenceTypes::LOCAL){
+        contact = boost::make_shared<crocoddyl::ContactModel1D>(state, frame_id, 0., nu, gains, Vector3MaskType::z, pinocchio::LOCAL);
+      } else if(reference_type == PinocchioReferenceTypes::WORLD){
+        contact = boost::make_shared<crocoddyl::ContactModel1D>(state, frame_id, 0., nu, gains, Vector3MaskType::z, pinocchio::WORLD);
+      } else if(reference_type == PinocchioReferenceTypes::LOCAL_WORLD_ALIGNED){
+        contact = boost::make_shared<crocoddyl::ContactModel1D>(state, frame_id, 0., nu, gains, Vector3MaskType::z, pinocchio::LOCAL_WORLD_ALIGNED);
+      }      
+      break;
+    default:
+      throw_pretty(__FILE__ ": Wrong ContactModelMaskTypes::Type given");
+      break;
+  }
+  return contact;
+}
+
+boost::shared_ptr<crocoddyl::ContactModelAbstract> create_random_contact1d() {
+  static bool once = true;
+  if (once) {
+    srand((unsigned)time(NULL));
+    once = false;
+  }
+  boost::shared_ptr<crocoddyl::ContactModelAbstract> contact;
+  ContactModel1DFactory factory;
+  if (rand() % 3 == 0) {
+    contact = factory.create(ContactModelMaskTypes::X, PinocchioModelTypes::RandomHumanoid, PinocchioReferenceTypes::LOCAL);
+  } else if (rand() % 3 == 1) {
+    contact = factory.create(ContactModelMaskTypes::Y, PinocchioModelTypes::RandomHumanoid, PinocchioReferenceTypes::LOCAL);
+  } else {
+    contact = factory.create(ContactModelMaskTypes::Z, PinocchioModelTypes::RandomHumanoid, PinocchioReferenceTypes::LOCAL);
+  }
+  return contact;
+}
+
+}  // namespace unittest
+}  // namespace crocoddyl

--- a/unittest/factory/contact1d.cpp
+++ b/unittest/factory/contact1d.cpp
@@ -62,11 +62,9 @@ std::ostream& operator<<(std::ostream& os, const PinocchioReferenceTypes::Type& 
 ContactModel1DFactory::ContactModel1DFactory() {}
 ContactModel1DFactory::~ContactModel1DFactory() {}
 
-boost::shared_ptr<crocoddyl::ContactModelAbstract> ContactModel1DFactory::create(ContactModelMaskTypes::Type mask_type,
-                                                                               PinocchioModelTypes::Type model_type,
-                                                                               PinocchioReferenceTypes::Type reference_type,
-                                                                               const std::string frame_name,
-                                                                               std::size_t nu) const {
+boost::shared_ptr<crocoddyl::ContactModelAbstract> ContactModel1DFactory::create(
+    ContactModelMaskTypes::Type mask_type, PinocchioModelTypes::Type model_type,
+    PinocchioReferenceTypes::Type reference_type, const std::string frame_name, std::size_t nu) const {
   PinocchioModelFactory model_factory(model_type);
   boost::shared_ptr<crocoddyl::StateMultibody> state =
       boost::make_shared<crocoddyl::StateMultibody>(model_factory.create());
@@ -84,33 +82,42 @@ boost::shared_ptr<crocoddyl::ContactModelAbstract> ContactModel1DFactory::create
   Eigen::Vector2d gains = Eigen::Vector2d::Zero();
   switch (mask_type) {
     case ContactModelMaskTypes::X: {
-      if(reference_type == PinocchioReferenceTypes::LOCAL){
-        contact = boost::make_shared<crocoddyl::ContactModel1D>(state, frame_id, 0., nu, gains, Vector3MaskType::x, pinocchio::LOCAL);
-      } else if(reference_type == PinocchioReferenceTypes::WORLD){
-        contact = boost::make_shared<crocoddyl::ContactModel1D>(state, frame_id, 0., nu, gains, Vector3MaskType::x, pinocchio::WORLD);
-      } else if(reference_type == PinocchioReferenceTypes::LOCAL_WORLD_ALIGNED){
-        contact = boost::make_shared<crocoddyl::ContactModel1D>(state, frame_id, 0., nu, gains, Vector3MaskType::x, pinocchio::LOCAL_WORLD_ALIGNED);
+      if (reference_type == PinocchioReferenceTypes::LOCAL) {
+        contact = boost::make_shared<crocoddyl::ContactModel1D>(state, frame_id, 0., nu, gains, Vector3MaskType::x,
+                                                                pinocchio::LOCAL);
+      } else if (reference_type == PinocchioReferenceTypes::WORLD) {
+        contact = boost::make_shared<crocoddyl::ContactModel1D>(state, frame_id, 0., nu, gains, Vector3MaskType::x,
+                                                                pinocchio::WORLD);
+      } else if (reference_type == PinocchioReferenceTypes::LOCAL_WORLD_ALIGNED) {
+        contact = boost::make_shared<crocoddyl::ContactModel1D>(state, frame_id, 0., nu, gains, Vector3MaskType::x,
+                                                                pinocchio::LOCAL_WORLD_ALIGNED);
       }
       break;
     }
     case ContactModelMaskTypes::Y: {
-      if(reference_type == PinocchioReferenceTypes::LOCAL){
-        contact = boost::make_shared<crocoddyl::ContactModel1D>(state, frame_id, 0., nu, gains, Vector3MaskType::y, pinocchio::LOCAL);
-      } else if(reference_type == PinocchioReferenceTypes::WORLD){
-        contact = boost::make_shared<crocoddyl::ContactModel1D>(state, frame_id, 0., nu, gains, Vector3MaskType::y, pinocchio::WORLD);
-      } else if(reference_type == PinocchioReferenceTypes::LOCAL_WORLD_ALIGNED){
-        contact = boost::make_shared<crocoddyl::ContactModel1D>(state, frame_id, 0., nu, gains, Vector3MaskType::y, pinocchio::LOCAL_WORLD_ALIGNED);
+      if (reference_type == PinocchioReferenceTypes::LOCAL) {
+        contact = boost::make_shared<crocoddyl::ContactModel1D>(state, frame_id, 0., nu, gains, Vector3MaskType::y,
+                                                                pinocchio::LOCAL);
+      } else if (reference_type == PinocchioReferenceTypes::WORLD) {
+        contact = boost::make_shared<crocoddyl::ContactModel1D>(state, frame_id, 0., nu, gains, Vector3MaskType::y,
+                                                                pinocchio::WORLD);
+      } else if (reference_type == PinocchioReferenceTypes::LOCAL_WORLD_ALIGNED) {
+        contact = boost::make_shared<crocoddyl::ContactModel1D>(state, frame_id, 0., nu, gains, Vector3MaskType::y,
+                                                                pinocchio::LOCAL_WORLD_ALIGNED);
       }
       break;
     }
     case ContactModelMaskTypes::Z:
-      if(reference_type == PinocchioReferenceTypes::LOCAL){
-        contact = boost::make_shared<crocoddyl::ContactModel1D>(state, frame_id, 0., nu, gains, Vector3MaskType::z, pinocchio::LOCAL);
-      } else if(reference_type == PinocchioReferenceTypes::WORLD){
-        contact = boost::make_shared<crocoddyl::ContactModel1D>(state, frame_id, 0., nu, gains, Vector3MaskType::z, pinocchio::WORLD);
-      } else if(reference_type == PinocchioReferenceTypes::LOCAL_WORLD_ALIGNED){
-        contact = boost::make_shared<crocoddyl::ContactModel1D>(state, frame_id, 0., nu, gains, Vector3MaskType::z, pinocchio::LOCAL_WORLD_ALIGNED);
-      }      
+      if (reference_type == PinocchioReferenceTypes::LOCAL) {
+        contact = boost::make_shared<crocoddyl::ContactModel1D>(state, frame_id, 0., nu, gains, Vector3MaskType::z,
+                                                                pinocchio::LOCAL);
+      } else if (reference_type == PinocchioReferenceTypes::WORLD) {
+        contact = boost::make_shared<crocoddyl::ContactModel1D>(state, frame_id, 0., nu, gains, Vector3MaskType::z,
+                                                                pinocchio::WORLD);
+      } else if (reference_type == PinocchioReferenceTypes::LOCAL_WORLD_ALIGNED) {
+        contact = boost::make_shared<crocoddyl::ContactModel1D>(state, frame_id, 0., nu, gains, Vector3MaskType::z,
+                                                                pinocchio::LOCAL_WORLD_ALIGNED);
+      }
       break;
     default:
       throw_pretty(__FILE__ ": Wrong ContactModelMaskTypes::Type given");
@@ -128,11 +135,14 @@ boost::shared_ptr<crocoddyl::ContactModelAbstract> create_random_contact1d() {
   boost::shared_ptr<crocoddyl::ContactModelAbstract> contact;
   ContactModel1DFactory factory;
   if (rand() % 3 == 0) {
-    contact = factory.create(ContactModelMaskTypes::X, PinocchioModelTypes::RandomHumanoid, PinocchioReferenceTypes::LOCAL);
+    contact =
+        factory.create(ContactModelMaskTypes::X, PinocchioModelTypes::RandomHumanoid, PinocchioReferenceTypes::LOCAL);
   } else if (rand() % 3 == 1) {
-    contact = factory.create(ContactModelMaskTypes::Y, PinocchioModelTypes::RandomHumanoid, PinocchioReferenceTypes::LOCAL);
+    contact =
+        factory.create(ContactModelMaskTypes::Y, PinocchioModelTypes::RandomHumanoid, PinocchioReferenceTypes::LOCAL);
   } else {
-    contact = factory.create(ContactModelMaskTypes::Z, PinocchioModelTypes::RandomHumanoid, PinocchioReferenceTypes::LOCAL);
+    contact =
+        factory.create(ContactModelMaskTypes::Z, PinocchioModelTypes::RandomHumanoid, PinocchioReferenceTypes::LOCAL);
   }
   return contact;
 }

--- a/unittest/factory/contact1d.hpp
+++ b/unittest/factory/contact1d.hpp
@@ -1,0 +1,75 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2019-2021, University of Edinburgh
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef CROCODDYL_CONTACT_1D_FACTORY_HPP_
+#define CROCODDYL_CONTACT_1D_FACTORY_HPP_
+
+#include <iostream>
+#include <limits>
+
+#include "state.hpp"
+#include "crocoddyl/multibody/contact-base.hpp"
+#include "crocoddyl/multibody/numdiff/contact.hpp"
+#include "crocoddyl/multibody/contacts/multiple-contacts.hpp"
+
+namespace crocoddyl {
+namespace unittest {
+
+
+struct ContactModelMaskTypes {
+  enum Type {X, Y, Z, NbMaskTypes};
+  static std::vector<Type> init_all() {
+    std::vector<Type> v;
+    v.clear();
+    for (int i = 0; i < NbMaskTypes; ++i) {
+      v.push_back((Type)i);
+    }
+    return v;
+  }
+  static const std::vector<Type> all;
+};
+
+struct PinocchioReferenceTypes {
+  enum Type { LOCAL, WORLD, LOCAL_WORLD_ALIGNED, NbPinRefTypes};
+  static std::vector<Type> init_all() {
+    std::vector<Type> v;
+    v.clear();
+    for (int i = 0; i < NbPinRefTypes; ++i) {
+      v.push_back((Type)i);
+    }
+    return v;
+  }
+  static const std::vector<Type> all;
+};
+
+
+std::ostream& operator<<(std::ostream& os, const ContactModelMaskTypes::Type& type);
+
+std::ostream& operator<<(std::ostream& os, const PinocchioReferenceTypes::Type& type);
+
+
+class ContactModel1DFactory {
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  explicit ContactModel1DFactory();
+  ~ContactModel1DFactory();
+
+  boost::shared_ptr<crocoddyl::ContactModelAbstract> create(
+      ContactModelMaskTypes::Type mask_type, PinocchioModelTypes::Type model_type,
+      PinocchioReferenceTypes::Type reference_type,
+      const std::string frame_name = std::string(""),
+      const std::size_t nu = std::numeric_limits<std::size_t>::max()) const;
+};
+
+boost::shared_ptr<crocoddyl::ContactModelAbstract> create_random_contact1d();
+
+}  // namespace unittest
+}  // namespace crocoddyl
+
+#endif  // CROCODDYL_CONTACT_1D_FACTORY_HPP_

--- a/unittest/factory/contact1d.hpp
+++ b/unittest/factory/contact1d.hpp
@@ -20,9 +20,8 @@
 namespace crocoddyl {
 namespace unittest {
 
-
 struct ContactModelMaskTypes {
-  enum Type {X, Y, Z, NbMaskTypes};
+  enum Type { X, Y, Z, NbMaskTypes };
   static std::vector<Type> init_all() {
     std::vector<Type> v;
     v.clear();
@@ -35,7 +34,7 @@ struct ContactModelMaskTypes {
 };
 
 struct PinocchioReferenceTypes {
-  enum Type { LOCAL, WORLD, LOCAL_WORLD_ALIGNED, NbPinRefTypes};
+  enum Type { LOCAL, WORLD, LOCAL_WORLD_ALIGNED, NbPinRefTypes };
   static std::vector<Type> init_all() {
     std::vector<Type> v;
     v.clear();
@@ -47,11 +46,9 @@ struct PinocchioReferenceTypes {
   static const std::vector<Type> all;
 };
 
-
 std::ostream& operator<<(std::ostream& os, const ContactModelMaskTypes::Type& type);
 
 std::ostream& operator<<(std::ostream& os, const PinocchioReferenceTypes::Type& type);
-
 
 class ContactModel1DFactory {
  public:
@@ -62,8 +59,7 @@ class ContactModel1DFactory {
 
   boost::shared_ptr<crocoddyl::ContactModelAbstract> create(
       ContactModelMaskTypes::Type mask_type, PinocchioModelTypes::Type model_type,
-      PinocchioReferenceTypes::Type reference_type,
-      const std::string frame_name = std::string(""),
+      PinocchioReferenceTypes::Type reference_type, const std::string frame_name = std::string(""),
       const std::size_t nu = std::numeric_limits<std::size_t>::max()) const;
 };
 

--- a/unittest/test_contact1d.cpp
+++ b/unittest/test_contact1d.cpp
@@ -1,0 +1,228 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2019-2021, University of Edinburgh
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#define BOOST_TEST_NO_MAIN
+#define BOOST_TEST_ALTERNATIVE_INIT_API
+
+#include <boost/shared_ptr.hpp>
+#include <boost/make_shared.hpp>
+
+#include <pinocchio/algorithm/kinematics-derivatives.hpp>
+#include <pinocchio/algorithm/frames.hpp>
+
+#include "crocoddyl/multibody/contacts/contact-1d.hpp"
+
+#include "factory/contact1d.hpp"
+#include "unittest_common.hpp"
+
+using namespace crocoddyl::unittest;
+using namespace boost::unit_test;
+
+//----------------------------------------------------------------------------//
+
+void test_construct_data(ContactModelMaskTypes::Type mask_type, 
+                         PinocchioModelTypes::Type model_type, 
+                         PinocchioReferenceTypes::Type reference_type) {
+  // create the model
+  ContactModel1DFactory factory;
+  boost::shared_ptr<crocoddyl::ContactModelAbstract> model = factory.create(mask_type, model_type, reference_type);
+
+  // Run the print function
+  std::ostringstream tmp;
+  tmp << *model;
+
+  // create the corresponding data object
+  const boost::shared_ptr<pinocchio::Model>& pinocchio_model = model->get_state()->get_pinocchio();
+  pinocchio::Data pinocchio_data(*pinocchio_model.get());
+  boost::shared_ptr<crocoddyl::ContactDataAbstract> data = model->createData(&pinocchio_data);
+}
+
+void test_calc_fetch_jacobians(ContactModelMaskTypes::Type mask_type, 
+                                PinocchioModelTypes::Type model_type, 
+                                PinocchioReferenceTypes::Type reference_type) {
+  // create the model
+  ContactModel1DFactory factory;
+  boost::shared_ptr<crocoddyl::ContactModelAbstract> model = factory.create(mask_type, model_type, reference_type);
+
+  // create the corresponding data object
+  const boost::shared_ptr<pinocchio::Model>& pinocchio_model = model->get_state()->get_pinocchio();
+  pinocchio::Data pinocchio_data(*pinocchio_model.get());
+  boost::shared_ptr<crocoddyl::ContactDataAbstract> data = model->createData(&pinocchio_data);
+
+  // Compute the jacobian and check that the impulse model fetch it.
+  Eigen::VectorXd x = model->get_state()->rand();
+  crocoddyl::unittest::updateAllPinocchio(pinocchio_model.get(), &pinocchio_data, x);
+
+  // Getting the jacobian from the model
+  model->calc(data, x);
+
+  // Check that only the Jacobian has been filled
+  BOOST_CHECK(!data->Jc.isZero());
+  BOOST_CHECK(!data->a0.isZero());
+  BOOST_CHECK(data->da0_dx.isZero());
+  BOOST_CHECK(data->f.toVector().isZero());
+  BOOST_CHECK(data->df_dx.isZero());
+  BOOST_CHECK(data->df_du.isZero());
+}
+
+void test_calc_diff_fetch_derivatives(ContactModelMaskTypes::Type mask_type, 
+                                        PinocchioModelTypes::Type model_type, 
+                                        PinocchioReferenceTypes::Type reference_type) {
+  // create the model
+  ContactModel1DFactory factory;
+  boost::shared_ptr<crocoddyl::ContactModelAbstract> model = factory.create(mask_type, model_type, reference_type);
+
+  // create the corresponding data object
+  const boost::shared_ptr<pinocchio::Model>& pinocchio_model = model->get_state()->get_pinocchio();
+  pinocchio::Data pinocchio_data(*pinocchio_model.get());
+  boost::shared_ptr<crocoddyl::ContactDataAbstract> data = model->createData(&pinocchio_data);
+
+  // Compute the jacobian and check that the impulse model fetch it.
+  Eigen::VectorXd x = model->get_state()->rand();
+  crocoddyl::unittest::updateAllPinocchio(pinocchio_model.get(), &pinocchio_data, x);
+
+  // Getting the jacobian from the model
+  model->calc(data, x);
+  model->calcDiff(data, x);
+
+  // Check that nothing has been computed and that all value are initialized to 0
+  BOOST_CHECK(!data->Jc.isZero());
+  BOOST_CHECK(!data->a0.isZero());
+  BOOST_CHECK(!data->da0_dx.isZero());
+  BOOST_CHECK(data->f.toVector().isZero());
+  BOOST_CHECK(data->df_dx.isZero());
+  BOOST_CHECK(data->df_du.isZero());
+}
+
+void test_update_force(ContactModelMaskTypes::Type mask_type, 
+                    PinocchioModelTypes::Type model_type, 
+                    PinocchioReferenceTypes::Type reference_type) {
+  // create the model
+  ContactModel1DFactory factory;
+  boost::shared_ptr<crocoddyl::ContactModelAbstract> model = factory.create(mask_type, model_type, reference_type);
+
+  // create the corresponding data object
+  const boost::shared_ptr<pinocchio::Model>& pinocchio_model = model->get_state()->get_pinocchio();
+  pinocchio::Data pinocchio_data(*pinocchio_model.get());
+  boost::shared_ptr<crocoddyl::ContactDataAbstract> data = model->createData(&pinocchio_data);
+
+  // Create a random force and update it
+  Eigen::VectorXd f = Eigen::VectorXd::Random(data->Jc.rows());
+  model->updateForce(data, f);
+//   boost::shared_ptr<crocoddyl::ContactModel3D> m = boost::static_pointer_cast<crocoddyl::ContactModel3D>(model);
+
+  // Check that nothing has been computed and that all value are initialized to 0
+  BOOST_CHECK(data->Jc.isZero());
+  BOOST_CHECK(data->a0.isZero());
+  BOOST_CHECK(data->da0_dx.isZero());
+  BOOST_CHECK(!data->f.toVector().isZero());
+  BOOST_CHECK(data->df_dx.isZero());
+  BOOST_CHECK(data->df_du.isZero());
+}
+
+void test_update_force_diff(ContactModelMaskTypes::Type mask_type, 
+                            PinocchioModelTypes::Type model_type, 
+                            PinocchioReferenceTypes::Type reference_type) {
+  // create the model
+  ContactModel1DFactory factory;
+  boost::shared_ptr<crocoddyl::ContactModelAbstract> model = factory.create(mask_type, model_type, reference_type);
+
+  // create the corresponding data object
+  const boost::shared_ptr<pinocchio::Model>& pinocchio_model = model->get_state()->get_pinocchio();
+  pinocchio::Data pinocchio_data(*pinocchio_model.get());
+  boost::shared_ptr<crocoddyl::ContactDataAbstract> data = model->createData(&pinocchio_data);
+
+  // Create a random force and update it
+  Eigen::MatrixXd df_dx = Eigen::MatrixXd::Random(data->df_dx.rows(), data->df_dx.cols());
+  Eigen::MatrixXd df_du = Eigen::MatrixXd::Random(data->df_du.rows(), data->df_du.cols());
+  model->updateForceDiff(data, df_dx, df_du);
+
+  // Check that nothing has been computed and that all value are initialized to 0
+  BOOST_CHECK(data->Jc.isZero());
+  BOOST_CHECK(data->a0.isZero());
+  BOOST_CHECK(data->da0_dx.isZero());
+  BOOST_CHECK(data->f.toVector().isZero());
+  BOOST_CHECK(!data->df_dx.isZero());
+  BOOST_CHECK(!data->df_du.isZero());
+}
+
+void test_partial_derivatives_against_numdiff(ContactModelMaskTypes::Type mask_type, 
+                                              PinocchioModelTypes::Type model_type, 
+                                              PinocchioReferenceTypes::Type reference_type) {
+#if BOOST_VERSION / 100 % 1000 >= 60
+  using namespace boost::placeholders;
+#endif
+  // create the model
+  ContactModel1DFactory factory;
+  boost::shared_ptr<crocoddyl::ContactModelAbstract> model = factory.create(mask_type, model_type, reference_type);
+
+  // create the corresponding data object
+  pinocchio::Model& pinocchio_model = *model->get_state()->get_pinocchio().get();
+  pinocchio::Data pinocchio_data(pinocchio_model);
+  boost::shared_ptr<crocoddyl::ContactDataAbstract> data = model->createData(&pinocchio_data);
+
+  // Create the equivalent num diff model and data.
+  crocoddyl::ContactModelNumDiff model_num_diff(model);
+  const boost::shared_ptr<crocoddyl::ContactDataAbstract>& data_num_diff = model_num_diff.createData(&pinocchio_data);
+
+  // Generating random values for the state
+  const Eigen::VectorXd& x = model->get_state()->rand();
+
+  // Compute all the pinocchio function needed for the models.
+  crocoddyl::unittest::updateAllPinocchio(&pinocchio_model, &pinocchio_data, x);
+
+  // set the function that needs to be called at every step of the numdiff
+  std::vector<crocoddyl::ContactModelNumDiff::ReevaluationFunction> reevals;
+  reevals.push_back(boost::bind(&crocoddyl::unittest::updateAllPinocchio, &pinocchio_model, &pinocchio_data, _1, _2));
+  model_num_diff.set_reevals(reevals);
+  // model_num_diff.set_disturbance(1e-3);
+  // Computing the contact derivatives
+  model->calc(data, x);
+  model->calcDiff(data, x);
+
+  // Computing the contact derivatives via numerical differentiation
+  model_num_diff.calc(data_num_diff, x);
+  model_num_diff.calcDiff(data_num_diff, x);
+
+  // Checking the partial derivatives against NumDiff
+  double tol = sqrt(model_num_diff.get_disturbance());
+  BOOST_CHECK((data->da0_dx - data_num_diff->da0_dx).isZero(tol));
+}
+
+//----------------------------------------------------------------------------//
+
+void register_contact_model_unit_tests(ContactModelMaskTypes::Type mask_type, 
+                                        PinocchioModelTypes::Type model_type, 
+                                        PinocchioReferenceTypes::Type reference_type) {
+  boost::test_tools::output_test_stream test_name;
+  test_name << "test_" << mask_type << "_" << model_type << "_" << reference_type;
+  std::cout << "Running " << test_name.str() << std::endl;
+  test_suite* ts = BOOST_TEST_SUITE(test_name.str());
+  ts->add(BOOST_TEST_CASE(boost::bind(&test_construct_data, mask_type, model_type, reference_type)));
+  ts->add(BOOST_TEST_CASE(boost::bind(&test_calc_fetch_jacobians, mask_type, model_type, reference_type)));
+  ts->add(BOOST_TEST_CASE(boost::bind(&test_calc_diff_fetch_derivatives, mask_type, model_type, reference_type)));
+  ts->add(BOOST_TEST_CASE(boost::bind(&test_update_force, mask_type, model_type, reference_type)));
+  ts->add(BOOST_TEST_CASE(boost::bind(&test_update_force_diff, mask_type, model_type, reference_type)));
+  ts->add(BOOST_TEST_CASE(boost::bind(&test_partial_derivatives_against_numdiff, mask_type, model_type, reference_type)));
+  framework::master_test_suite().add(ts);
+}
+
+bool init_function() {
+  for (size_t mask_type = 0; mask_type < ContactModelMaskTypes::all.size(); ++mask_type) {
+    for (size_t model_type = 0; model_type < PinocchioModelTypes::all.size(); ++model_type) {
+      for (size_t reference_type = 0; reference_type < PinocchioReferenceTypes::all.size(); ++reference_type) {
+      register_contact_model_unit_tests(ContactModelMaskTypes::all[mask_type], 
+                                        PinocchioModelTypes::all[model_type], 
+                                        PinocchioReferenceTypes::all[reference_type]);
+      }
+    }
+  }
+  return true;
+}
+
+int main(int argc, char** argv) { return ::boost::unit_test::unit_test_main(&init_function, argc, argv); }

--- a/unittest/test_contact1d.cpp
+++ b/unittest/test_contact1d.cpp
@@ -25,8 +25,7 @@ using namespace boost::unit_test;
 
 //----------------------------------------------------------------------------//
 
-void test_construct_data(ContactModelMaskTypes::Type mask_type, 
-                         PinocchioModelTypes::Type model_type, 
+void test_construct_data(ContactModelMaskTypes::Type mask_type, PinocchioModelTypes::Type model_type,
                          PinocchioReferenceTypes::Type reference_type) {
   // create the model
   ContactModel1DFactory factory;
@@ -42,9 +41,8 @@ void test_construct_data(ContactModelMaskTypes::Type mask_type,
   boost::shared_ptr<crocoddyl::ContactDataAbstract> data = model->createData(&pinocchio_data);
 }
 
-void test_calc_fetch_jacobians(ContactModelMaskTypes::Type mask_type, 
-                                PinocchioModelTypes::Type model_type, 
-                                PinocchioReferenceTypes::Type reference_type) {
+void test_calc_fetch_jacobians(ContactModelMaskTypes::Type mask_type, PinocchioModelTypes::Type model_type,
+                               PinocchioReferenceTypes::Type reference_type) {
   // create the model
   ContactModel1DFactory factory;
   boost::shared_ptr<crocoddyl::ContactModelAbstract> model = factory.create(mask_type, model_type, reference_type);
@@ -70,9 +68,8 @@ void test_calc_fetch_jacobians(ContactModelMaskTypes::Type mask_type,
   BOOST_CHECK(data->df_du.isZero());
 }
 
-void test_calc_diff_fetch_derivatives(ContactModelMaskTypes::Type mask_type, 
-                                        PinocchioModelTypes::Type model_type, 
-                                        PinocchioReferenceTypes::Type reference_type) {
+void test_calc_diff_fetch_derivatives(ContactModelMaskTypes::Type mask_type, PinocchioModelTypes::Type model_type,
+                                      PinocchioReferenceTypes::Type reference_type) {
   // create the model
   ContactModel1DFactory factory;
   boost::shared_ptr<crocoddyl::ContactModelAbstract> model = factory.create(mask_type, model_type, reference_type);
@@ -99,9 +96,8 @@ void test_calc_diff_fetch_derivatives(ContactModelMaskTypes::Type mask_type,
   BOOST_CHECK(data->df_du.isZero());
 }
 
-void test_update_force(ContactModelMaskTypes::Type mask_type, 
-                    PinocchioModelTypes::Type model_type, 
-                    PinocchioReferenceTypes::Type reference_type) {
+void test_update_force(ContactModelMaskTypes::Type mask_type, PinocchioModelTypes::Type model_type,
+                       PinocchioReferenceTypes::Type reference_type) {
   // create the model
   ContactModel1DFactory factory;
   boost::shared_ptr<crocoddyl::ContactModelAbstract> model = factory.create(mask_type, model_type, reference_type);
@@ -114,7 +110,7 @@ void test_update_force(ContactModelMaskTypes::Type mask_type,
   // Create a random force and update it
   Eigen::VectorXd f = Eigen::VectorXd::Random(data->Jc.rows());
   model->updateForce(data, f);
-//   boost::shared_ptr<crocoddyl::ContactModel3D> m = boost::static_pointer_cast<crocoddyl::ContactModel3D>(model);
+  //   boost::shared_ptr<crocoddyl::ContactModel3D> m = boost::static_pointer_cast<crocoddyl::ContactModel3D>(model);
 
   // Check that nothing has been computed and that all value are initialized to 0
   BOOST_CHECK(data->Jc.isZero());
@@ -125,8 +121,7 @@ void test_update_force(ContactModelMaskTypes::Type mask_type,
   BOOST_CHECK(data->df_du.isZero());
 }
 
-void test_update_force_diff(ContactModelMaskTypes::Type mask_type, 
-                            PinocchioModelTypes::Type model_type, 
+void test_update_force_diff(ContactModelMaskTypes::Type mask_type, PinocchioModelTypes::Type model_type,
                             PinocchioReferenceTypes::Type reference_type) {
   // create the model
   ContactModel1DFactory factory;
@@ -151,8 +146,8 @@ void test_update_force_diff(ContactModelMaskTypes::Type mask_type,
   BOOST_CHECK(!data->df_du.isZero());
 }
 
-void test_partial_derivatives_against_numdiff(ContactModelMaskTypes::Type mask_type, 
-                                              PinocchioModelTypes::Type model_type, 
+void test_partial_derivatives_against_numdiff(ContactModelMaskTypes::Type mask_type,
+                                              PinocchioModelTypes::Type model_type,
                                               PinocchioReferenceTypes::Type reference_type) {
 #if BOOST_VERSION / 100 % 1000 >= 60
   using namespace boost::placeholders;
@@ -196,9 +191,8 @@ void test_partial_derivatives_against_numdiff(ContactModelMaskTypes::Type mask_t
 
 //----------------------------------------------------------------------------//
 
-void register_contact_model_unit_tests(ContactModelMaskTypes::Type mask_type, 
-                                        PinocchioModelTypes::Type model_type, 
-                                        PinocchioReferenceTypes::Type reference_type) {
+void register_contact_model_unit_tests(ContactModelMaskTypes::Type mask_type, PinocchioModelTypes::Type model_type,
+                                       PinocchioReferenceTypes::Type reference_type) {
   boost::test_tools::output_test_stream test_name;
   test_name << "test_" << mask_type << "_" << model_type << "_" << reference_type;
   std::cout << "Running " << test_name.str() << std::endl;
@@ -208,7 +202,8 @@ void register_contact_model_unit_tests(ContactModelMaskTypes::Type mask_type,
   ts->add(BOOST_TEST_CASE(boost::bind(&test_calc_diff_fetch_derivatives, mask_type, model_type, reference_type)));
   ts->add(BOOST_TEST_CASE(boost::bind(&test_update_force, mask_type, model_type, reference_type)));
   ts->add(BOOST_TEST_CASE(boost::bind(&test_update_force_diff, mask_type, model_type, reference_type)));
-  ts->add(BOOST_TEST_CASE(boost::bind(&test_partial_derivatives_against_numdiff, mask_type, model_type, reference_type)));
+  ts->add(
+      BOOST_TEST_CASE(boost::bind(&test_partial_derivatives_against_numdiff, mask_type, model_type, reference_type)));
   framework::master_test_suite().add(ts);
 }
 
@@ -216,9 +211,8 @@ bool init_function() {
   for (size_t mask_type = 0; mask_type < ContactModelMaskTypes::all.size(); ++mask_type) {
     for (size_t model_type = 0; model_type < PinocchioModelTypes::all.size(); ++model_type) {
       for (size_t reference_type = 0; reference_type < PinocchioReferenceTypes::all.size(); ++reference_type) {
-      register_contact_model_unit_tests(ContactModelMaskTypes::all[mask_type], 
-                                        PinocchioModelTypes::all[model_type], 
-                                        PinocchioReferenceTypes::all[reference_type]);
+        register_contact_model_unit_tests(ContactModelMaskTypes::all[mask_type], PinocchioModelTypes::all[model_type],
+                                          PinocchioReferenceTypes::all[reference_type]);
       }
     }
   }


### PR DESCRIPTION
Minor enhancements for the 1D contact model . Related to #812 

- Add a mask for constraint dimension selection . The user selects optionally `type` in `{0,1,2}` for `{x,y,z}` the z-axis being the default one
- Add optional argument of pinocchio reference frame in {`LOCAL`, `WORLD` , `LOCAL_WORLD_ALIGNED`}, `LOCAL` being the default one

The mask could be extended to 2D contact , and the pinocchio reference frame option could be propagated to other contact models , if deemed useful . But I think all of this will be handled in Pinocchio in the future...