### PR TITLE
Fixed Armijo condition in BoxQP

### DIFF
--- a/bindings/python/crocoddyl/core/solvers/box-qp.cpp
+++ b/bindings/python/crocoddyl/core/solvers/box-qp.cpp
@@ -43,7 +43,7 @@ void exposeSolverBoxQP() {
                     "    x = argmin 0.5 x^T H x + q^T x\n"
                     "    subject to:   lb <= x <= ub"
                     "where nx is the number of decision variables.",
-                    bp::init<std::size_t, std::size_t, double, double, double>(
+                    bp::init<std::size_t, bp::optional<std::size_t, double, double, double> >(
                         bp::args("self", "nx", "maxiter", "th_acceptstep", "th_grad", "reg"),
                         "Initialize the Projected-Newton QP for bound constraints.\n\n"
                         ":param nx: dimension of the decision vector\n"

--- a/include/crocoddyl/core/solvers/box-qp.hpp
+++ b/include/crocoddyl/core/solvers/box-qp.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, University of Edinburgh
+// Copyright (C) 2019-2022, University of Edinburgh, Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////

--- a/include/crocoddyl/core/solvers/box-qp.hpp
+++ b/include/crocoddyl/core/solvers/box-qp.hpp
@@ -191,6 +191,7 @@ class BoxQP {
   Eigen::VectorXd g_;           //!< Current gradient
   Eigen::VectorXd dx_;          //!< Current search direction
 
+  Eigen::VectorXd gf_;                       //!< Gradient in the free subspace
   Eigen::VectorXd qf_;                       //!< Current problem gradient in the free subspace
   Eigen::VectorXd xf_;                       //!< Current decision variable in the free subspace
   Eigen::VectorXd xc_;                       //!< Current decision variable in the constrained subspace

--- a/src/core/solvers/box-qp.cpp
+++ b/src/core/solvers/box-qp.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, University of Edinburgh
+// Copyright (C) 2019-2022, University of Edinburgh, Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////

--- a/unittest/test_boxqp.cpp
+++ b/unittest/test_boxqp.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2021, University of Edinburgh
+// Copyright (C) 2019-2022, University of Edinburgh, Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////

--- a/unittest/test_boxqp.cpp
+++ b/unittest/test_boxqp.cpp
@@ -125,7 +125,7 @@ void test_box_qp_with_identity_hessian() {
   // Checking the solution against a regularized case
   boxqp.set_reg(reg);
   crocoddyl::BoxQPSolution sol_reg = boxqp.solve(hessian, gradient, lb, ub, xinit);
-  BOOST_CHECK((sol_reg.x - negbounded_gradient / (1 + reg)).isZero(1e-9));
+  BOOST_CHECK((sol_reg.x - negbounded_gradient_reg).isZero(1e-9));
 
   // Checking the all bounds are free and zero clamped
   BOOST_CHECK(sol.free_idx.size() == nf);


### PR DESCRIPTION
This error in the condition can be triggered with random initialisations.
In our Box-DDP/FDDP solvers, triggering this error is less likely to happen.
But, in that case, we could expect to run many useless iterations.

This should also improve the computation time of those solvers.