### PR TITLE
Fix unittest factory for future compatibility

### DIFF
--- a/bindings/python/crocoddyl/fwd.hpp
+++ b/bindings/python/crocoddyl/fwd.hpp
@@ -10,9 +10,6 @@
 #define BINDINGS_PYTHON_CROCODDYL_CORE_FWD_HPP_
 
 #include <eigenpy/eigenpy.hpp>
-#include <boost/python.hpp>
-#include <boost/python/enum.hpp>
-#include <boost/python/scope.hpp>
 
 namespace crocoddyl {
 namespace python {

--- a/unittest/factory/cost.cpp
+++ b/unittest/factory/cost.cpp
@@ -213,12 +213,15 @@ boost::shared_ptr<crocoddyl::CostModelAbstract> CostModelFactory::create(CostMod
   boost::shared_ptr<pinocchio::GeometryModel> geometry =
       boost::make_shared<pinocchio::GeometryModel>(pinocchio::GeometryModel());
   pinocchio::GeomIndex ig_frame = geometry->addGeometryObject(pinocchio::GeometryObject(
-      "frame", frame_index, state->get_pinocchio()->frames[frame_index].parent,
-      boost::shared_ptr<hpp::fcl::CollisionGeometry>(new hpp::fcl::Capsule(0, alpha)), frame_SE3));
+      "frame", frame_index,
+      state->get_pinocchio()->frames[frame_index].parent,
+      frame_SE3,
+      CollisionGeometryPtr(new hpp::fcl::Capsule(0, alpha))));
   pinocchio::GeomIndex ig_obs = geometry->addGeometryObject(pinocchio::GeometryObject(
       "obs", state->get_pinocchio()->getFrameId("universe"),
       state->get_pinocchio()->frames[state->get_pinocchio()->getFrameId("universe")].parent,
-      boost::shared_ptr<hpp::fcl::CollisionGeometry>(new hpp::fcl::Capsule(0, beta)), frame_SE3_obstacle));
+      frame_SE3_obstacle,
+      CollisionGeometryPtr(new hpp::fcl::Capsule(0, beta))));
   geometry->addCollisionPair(pinocchio::CollisionPair(ig_frame, ig_obs));
 
   switch (cost_type) {

--- a/unittest/factory/cost.cpp
+++ b/unittest/factory/cost.cpp
@@ -212,16 +212,13 @@ boost::shared_ptr<crocoddyl::CostModelAbstract> CostModelFactory::create(CostMod
 
   boost::shared_ptr<pinocchio::GeometryModel> geometry =
       boost::make_shared<pinocchio::GeometryModel>(pinocchio::GeometryModel());
-  pinocchio::GeomIndex ig_frame = geometry->addGeometryObject(pinocchio::GeometryObject(
-      "frame", frame_index,
-      state->get_pinocchio()->frames[frame_index].parent,
-      frame_SE3,
-      CollisionGeometryPtr(new hpp::fcl::Capsule(0, alpha))));
-  pinocchio::GeomIndex ig_obs = geometry->addGeometryObject(pinocchio::GeometryObject(
-      "obs", state->get_pinocchio()->getFrameId("universe"),
-      state->get_pinocchio()->frames[state->get_pinocchio()->getFrameId("universe")].parent,
-      frame_SE3_obstacle,
-      CollisionGeometryPtr(new hpp::fcl::Capsule(0, beta))));
+  pinocchio::GeomIndex ig_frame = geometry->addGeometryObject(
+      pinocchio::GeometryObject("frame", frame_index, state->get_pinocchio()->frames[frame_index].parent,
+                                CollisionGeometryPtr(new hpp::fcl::Capsule(0, alpha)), frame_SE3));
+  pinocchio::GeomIndex ig_obs = geometry->addGeometryObject(
+      pinocchio::GeometryObject("obs", state->get_pinocchio()->getFrameId("universe"),
+                                state->get_pinocchio()->frames[state->get_pinocchio()->getFrameId("universe")].parent,
+                                CollisionGeometryPtr(new hpp::fcl::Capsule(0, beta)), frame_SE3_obstacle));
   geometry->addCollisionPair(pinocchio::CollisionPair(ig_frame, ig_obs));
 
   switch (cost_type) {

--- a/unittest/factory/cost.hpp
+++ b/unittest/factory/cost.hpp
@@ -82,6 +82,7 @@ class CostModelFactory {
 
   typedef crocoddyl::MathBaseTpl<double> MathBase;
   typedef typename MathBase::Vector6s Vector6d;
+  typedef pinocchio::GeometryObject::CollisionGeometryPtr CollisionGeometryPtr;
 
   explicit CostModelFactory();
   ~CostModelFactory();

--- a/unittest/factory/residual.cpp
+++ b/unittest/factory/residual.cpp
@@ -86,10 +86,10 @@ boost::shared_ptr<crocoddyl::ResidualModelAbstract> ResidualModelFactory::create
   pinocchio::GeomIndex ig_frame = geometry->addGeometryObject(
       pinocchio::GeometryObject("frame", frame_index, state->get_pinocchio()->frames[frame_index].parent,
                                 CollisionGeometryPtr(new hpp::fcl::Sphere(0)), frame_SE3));
-  pinocchio::GeomIndex ig_obs = geometry->addGeometryObject(pinocchio::GeometryObject(
-      "obs", state->get_pinocchio()->getFrameId("universe"),
-      state->get_pinocchio()->frames[state->get_pinocchio()->getFrameId("universe")].parent,
-      CollisionGeometryPtr(new hpp::fcl::Sphere(0)), frame_SE3_obstacle));
+  pinocchio::GeomIndex ig_obs = geometry->addGeometryObject(
+      pinocchio::GeometryObject("obs", state->get_pinocchio()->getFrameId("universe"),
+                                state->get_pinocchio()->frames[state->get_pinocchio()->getFrameId("universe")].parent,
+                                CollisionGeometryPtr(new hpp::fcl::Sphere(0)), frame_SE3_obstacle));
   geometry->addCollisionPair(pinocchio::CollisionPair(ig_frame, ig_obs));
 #endif  // PINOCCHIO_WITH_HPP_FCL
   if (nu == std::numeric_limits<std::size_t>::max()) {

--- a/unittest/factory/residual.cpp
+++ b/unittest/factory/residual.cpp
@@ -85,11 +85,11 @@ boost::shared_ptr<crocoddyl::ResidualModelAbstract> ResidualModelFactory::create
       boost::make_shared<pinocchio::GeometryModel>(pinocchio::GeometryModel());
   pinocchio::GeomIndex ig_frame = geometry->addGeometryObject(
       pinocchio::GeometryObject("frame", frame_index, state->get_pinocchio()->frames[frame_index].parent,
-                                boost::shared_ptr<hpp::fcl::CollisionGeometry>(new hpp::fcl::Sphere(0)), frame_SE3));
+                                CollisionGeometryPtr(new hpp::fcl::Sphere(0)), frame_SE3));
   pinocchio::GeomIndex ig_obs = geometry->addGeometryObject(pinocchio::GeometryObject(
       "obs", state->get_pinocchio()->getFrameId("universe"),
       state->get_pinocchio()->frames[state->get_pinocchio()->getFrameId("universe")].parent,
-      boost::shared_ptr<hpp::fcl::CollisionGeometry>(new hpp::fcl::Sphere(0)), frame_SE3_obstacle));
+      CollisionGeometryPtr(new hpp::fcl::Sphere(0)), frame_SE3_obstacle));
   geometry->addCollisionPair(pinocchio::CollisionPair(ig_frame, ig_obs));
 #endif  // PINOCCHIO_WITH_HPP_FCL
   if (nu == std::numeric_limits<std::size_t>::max()) {

--- a/unittest/factory/residual.hpp
+++ b/unittest/factory/residual.hpp
@@ -10,7 +10,6 @@
 #define CROCODDYL_RESIDUAL_FACTORY_HPP_
 
 #include "state.hpp"
-#include "residual.hpp"
 #include "crocoddyl/core/residual-base.hpp"
 #include "crocoddyl/core/numdiff/residual.hpp"
 #include "crocoddyl/multibody/states/multibody.hpp"
@@ -52,6 +51,7 @@ class ResidualModelFactory {
 
   typedef crocoddyl::MathBaseTpl<double> MathBase;
   typedef typename MathBase::Vector6s Vector6d;
+  typedef pinocchio::GeometryObject::CollisionGeometryPtr CollisionGeometryPtr;
 
   explicit ResidualModelFactory();
   ~ResidualModelFactory();


### PR DESCRIPTION
The main change is as follows:

*unittest : use GeometryObject's CollisionGeometryPtr typedef* (4f6f3e4aa42fd1c93a19ccd06100bac60cf62d12)

Which makes the factory code independent on whether installed release of Pinocchio (or hpp-fcl) uses std or boost shared_ptr.