### PR TITLE
Adding missing header for std::set

### DIFF
--- a/include/crocoddyl/core/constraints/constraint-manager.hpp
+++ b/include/crocoddyl/core/constraints/constraint-manager.hpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <map>
 #include <utility>
+#include <set>
 
 #include "crocoddyl/core/fwd.hpp"
 #include "crocoddyl/core/constraint-base.hpp"


### PR DESCRIPTION
This PR adds a missing header for the usage of std::set in the constraint manager. The lack of the header was responsible for compilation errors in some machines.