### PR TITLE
Fix build on aarch64-linux

### DIFF
--- a/src/core/solvers/ddp.cpp
+++ b/src/core/solvers/ddp.cpp
@@ -95,7 +95,7 @@ bool SolverDDP::solve(const std::vector<Eigen::VectorXd>& init_xs,
       dVexp_ = steplength_ * (d_[0] + 0.5 * steplength_ * d_[1]);
 
       if (dVexp_ >= 0) {  // descend direction
-        if (abs(d_[0]) < th_grad_ || !is_feasible_ ||
+        if (std::abs(d_[0]) < th_grad_ || !is_feasible_ ||
             dV_ > th_acceptstep_ * dVexp_) {
           was_feasible_ = is_feasible_;
           setCandidate(xs_try_, us_try_, true);
@@ -154,7 +154,7 @@ double SolverDDP::stoppingCriteria() {
   // function. If this reduction is less than a certain threshold, then the
   // algorithm reaches the local minimum. For more details, see C. Mastalli et
   // al. "Inverse-dynamics MPC via Nullspace Resolution".
-  stop_ = abs(d_[0] + 0.5 * d_[1]);
+  stop_ = std::abs(d_[0] + 0.5 * d_[1]);
   return stop_;
 }
 

--- a/src/core/solvers/fddp.cpp
+++ b/src/core/solvers/fddp.cpp
@@ -75,7 +75,7 @@ bool SolverFDDP::solve(const std::vector<Eigen::VectorXd>& init_xs,
       dVexp_ = steplength_ * (d_[0] + 0.5 * steplength_ * d_[1]);
 
       if (dVexp_ >= 0) {  // descend direction
-        if (abs(d_[0]) < th_grad_ || dV_ > th_acceptstep_ * dVexp_) {
+        if (std::abs(d_[0]) < th_grad_ || dV_ > th_acceptstep_ * dVexp_) {
           was_feasible_ = is_feasible_;
           setCandidate(xs_try_, us_try_, (was_feasible_) || (steplength_ == 1));
           cost_ = cost_try_;

--- a/src/core/solvers/intro.cpp
+++ b/src/core/solvers/intro.cpp
@@ -138,7 +138,7 @@ bool SolverIntro::solve(const std::vector<Eigen::VectorXd>& init_xs,
       dVexp_ = steplength_ * (d_[0] + 0.5 * steplength_ * d_[1]);
       dPhiexp_ = dVexp_ + steplength_ * upsilon_ * (hfeas_ - hfeas_try_);
       if (dPhiexp_ >= 0) {  // descend direction
-        if (abs(d_[0]) < th_grad_ || dPhi_ > th_acceptstep_ * dPhiexp_) {
+        if (std::abs(d_[0]) < th_grad_ || dPhi_ > th_acceptstep_ * dPhiexp_) {
           was_feasible_ = is_feasible_;
           setCandidate(xs_try_, us_try_, (was_feasible_) || (steplength_ == 1));
           cost_ = cost_try_;
@@ -169,7 +169,7 @@ bool SolverIntro::solve(const std::vector<Eigen::VectorXd>& init_xs,
     if (steplength_ > th_stepdec_ && dV_ >= 0.) {
       decreaseRegularization();
     }
-    if (steplength_ <= th_stepinc_ || abs(d_[1]) <= th_feas_) {
+    if (steplength_ <= th_stepinc_ || std::abs(d_[1]) <= th_feas_) {
       if (xreg_ == reg_max_) {
         STOP_PROFILER("SolverIntro::solve");
         return false;
@@ -193,7 +193,7 @@ double SolverIntro::tryStep(const double steplength) {
 }
 
 double SolverIntro::stoppingCriteria() {
-  stop_ = std::max(hfeas_, abs(d_[0] + 0.5 * d_[1]));
+  stop_ = std::max(hfeas_, std::abs(d_[0] + 0.5 * d_[1]));
   return stop_;
 }
 


### PR DESCRIPTION
In nixpkgs, we encountered [the following error](https://logs.ofborg.org/?key=nixos/nixpkgs.232585&attempt_id=a548c3a7-18fe-4568-a125-8c820509a67d) on aarch64-linux when bumping to 2.0.0:

```bash
/build/source/src/core/solvers/intro.cpp:196:19: error: no matching function for call to 'max(double&, int)'
  196 |   stop_ = std::max(hfeas_, abs(d_[0] + 0.5 * d_[1]));
```

The obvious fix is to replace `abs` with `std::abs`.