### PR TITLE
cmake: use find-external FindOpenMP.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,10 +70,13 @@ check_minimal_cxx_standard(14 ENFORCE)
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/find-external/CppAD/"
                       ${CMAKE_MODULE_PATH})
 if(APPLE) # Use the handmade approach
-  set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/find-external/OpenMP ${CMAKE_MODULE_PATH})
+  set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/find-external/OpenMP
+                        ${CMAKE_MODULE_PATH})
 elseif(UNIX)
-  if(${CMAKE_VERSION} VERSION_GREATER "3.20.0" OR ${CMAKE_VERSION} VERSION_EQUAL "3.20.0")
-    set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/find-external/OpenMP ${CMAKE_MODULE_PATH})
+  if(${CMAKE_VERSION} VERSION_GREATER "3.20.0" OR ${CMAKE_VERSION}
+                                                  VERSION_EQUAL "3.20.0")
+    set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/find-external/OpenMP
+                          ${CMAKE_MODULE_PATH})
   endif()
 endif(APPLE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,8 +69,13 @@ check_minimal_cxx_standard(14 ENFORCE)
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/find-external/CppAD/"
                       ${CMAKE_MODULE_PATH})
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/find-external/OpenMP/"
-                      ${CMAKE_MODULE_PATH})
+if(APPLE) # Use the handmade approach
+  set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/find-external/OpenMP ${CMAKE_MODULE_PATH})
+elseif(UNIX)
+  if(${CMAKE_VERSION} VERSION_GREATER "3.20.0" OR ${CMAKE_VERSION} VERSION_EQUAL "3.20.0")
+    set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/find-external/OpenMP ${CMAKE_MODULE_PATH})
+  endif()
+endif(APPLE)
 
 # Add the different required and optional dependencies
 if(BUILD_PYTHON_INTERFACE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,8 @@ check_minimal_cxx_standard(14 ENFORCE)
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/find-external/CppAD/"
                       ${CMAKE_MODULE_PATH})
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/find-external/OpenMP/"
+                      ${CMAKE_MODULE_PATH})
 
 # Add the different required and optional dependencies
 if(BUILD_PYTHON_INTERFACE)

--- a/bindings/python/crocoddyl/multibody/frames.cpp
+++ b/bindings/python/crocoddyl/multibody/frames.cpp
@@ -8,6 +8,7 @@
 
 #include <eigenpy/eigen-to-python.hpp>
 #include <eigenpy/memory.hpp>
+#include <pinocchio/fwd.hpp>
 #include <pinocchio/bindings/python/utils/std-aligned-vector.hpp>
 
 #include "crocoddyl/multibody/frames-deprecated.hpp"

--- a/bindings/python/crocoddyl/multibody/frames.cpp
+++ b/bindings/python/crocoddyl/multibody/frames.cpp
@@ -8,8 +8,8 @@
 
 #include <eigenpy/eigen-to-python.hpp>
 #include <eigenpy/memory.hpp>
-#include <pinocchio/fwd.hpp>
 #include <pinocchio/bindings/python/utils/std-aligned-vector.hpp>
+#include <pinocchio/fwd.hpp>
 
 #include "crocoddyl/multibody/frames-deprecated.hpp"
 #include "python/crocoddyl/multibody/multibody.hpp"


### PR DESCRIPTION
This PR changes a couple of CMake configuration options (I needed the changes to compile against a conda environment. We should wait for the CI to tell us if it breaks on non-conda setups).

* use find-external FindOpenMP.cmake
* include the pinocchio/fwd.hpp header in bindings multibody/frames.cpp (this might be required under pin3x or something)
* ~use `add_project_dependency` for OpenMP instead of `find_package`, for other CMake projects consuming crocoddyl (e.g. sobec)~