### PR TITLE
update to example-robot-data 4.0.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,8 +90,8 @@ add_project_dependency(pinocchio 2.6.3 REQUIRED PKG_CONFIG_REQUIRES
 if(BUILD_EXAMPLES
    OR BUILD_TESTING
    OR BUILD_BENCHMARK)
-  add_project_dependency(example-robot-data 4.0.0 REQUIRED PKG_CONFIG_REQUIRES
-                         "example-robot-data >= 4.0.0")
+  add_project_dependency(example-robot-data 4.0.7 REQUIRED PKG_CONFIG_REQUIRES
+                         "example-robot-data >= 4.0.7")
 else()
   add_optional_dependency(example-robot-data)
 endif()

--- a/unittest/factory/pinocchio_model.cpp
+++ b/unittest/factory/pinocchio_model.cpp
@@ -8,7 +8,6 @@
 
 #include "pinocchio_model.hpp"
 
-#include <example-robot-data/path.hpp>
 #include <pinocchio/algorithm/center-of-mass.hpp>
 #include <pinocchio/algorithm/centroidal-derivatives.hpp>
 #include <pinocchio/algorithm/centroidal.hpp>

--- a/unittest/factory/pinocchio_model.hpp
+++ b/unittest/factory/pinocchio_model.hpp
@@ -9,7 +9,6 @@
 #ifndef CROCODDYL_PINOCCHIO_MODEL_FACTORY_HPP_
 #define CROCODDYL_PINOCCHIO_MODEL_FACTORY_HPP_
 
-#include <example-robot-data/path.hpp>
 #include <pinocchio/algorithm/center-of-mass.hpp>
 #include <pinocchio/algorithm/centroidal-derivatives.hpp>
 #include <pinocchio/algorithm/centroidal.hpp>

--- a/unittest/factory/state.cpp
+++ b/unittest/factory/state.cpp
@@ -8,7 +8,6 @@
 
 #include "state.hpp"
 
-#include <example-robot-data/path.hpp>
 #include <pinocchio/fwd.hpp>
 #include <pinocchio/parsers/sample-models.hpp>
 #include <pinocchio/parsers/urdf.hpp>

--- a/unittest/test_codegen.cpp
+++ b/unittest/test_codegen.cpp
@@ -10,7 +10,6 @@
 #define BOOST_TEST_NO_MAIN
 #define BOOST_TEST_ALTERNATIVE_INIT_API
 
-#include <example-robot-data/path.hpp>
 #include <pinocchio/algorithm/model.hpp>
 #include <pinocchio/container/aligned-vector.hpp>
 #include <pinocchio/parsers/srdf.hpp>


### PR DESCRIPTION
`EXAMPLE_ROBOT_DATA_MODEL_DIR` is now a compile definition

draft: gitlab-ci is expected to fail until the end of a robotpkg rebuild + CI images regenerations.

PS: I should have made 4.1.0 instead of 4.0.7, sorry for that.