### PR TITLE
Bug Fix : pair-collision.hxx, changing the method to check the pair_id with collisionPair.size()

### DIFF
--- a/include/crocoddyl/multibody/residuals/pair-collision.hxx
+++ b/include/crocoddyl/multibody/residuals/pair-collision.hxx
@@ -26,7 +26,7 @@ ResidualModelPairCollisionTpl<Scalar>::ResidualModelPairCollisionTpl(
       geom_model_(geom_model),
       pair_id_(pair_id),
       joint_id_(joint_id) {
-  if (static_cast<pinocchio::FrameIndex>(geom_model->ngeoms) <= pair_id) {
+  if (static_cast<pinocchio::FrameIndex>(geom_model->collisionPairs.size()) <= pair_id) {
     throw_pretty(
         "Invalid argument: "
         << "the pair index is wrong (it does not exist in the geometry model)");

--- a/include/crocoddyl/multibody/residuals/pair-collision.hxx
+++ b/include/crocoddyl/multibody/residuals/pair-collision.hxx
@@ -26,7 +26,8 @@ ResidualModelPairCollisionTpl<Scalar>::ResidualModelPairCollisionTpl(
       geom_model_(geom_model),
       pair_id_(pair_id),
       joint_id_(joint_id) {
-  if (static_cast<pinocchio::FrameIndex>(geom_model->collisionPairs.size()) <= pair_id) {
+  if (static_cast<pinocchio::FrameIndex>(geom_model->collisionPairs.size()) <=
+      pair_id) {
     throw_pretty(
         "Invalid argument: "
         << "the pair index is wrong (it does not exist in the geometry model)");


### PR DESCRIPTION
Hello,  

First, I'd like to thank you for your work. Here's what I think a small mistake in pair-collision.hxx I corrected. 


# Pull Request: Update condition to use collisionPairs.size()

## Description
This pull request updates a conditional statement to use `collisionPairs.size()` instead of `ngeoms` because ngeoms is not the number of collision pairs but the number of geometry objects in geom_model. 
The number of pairs can be higher than the number of geometry objects, hence this pull request.

## Changes Made
- Replaced `static_cast<pinocchio::FrameIndex>(geom_model->ngeoms)` with `static_cast<pinocchio::FrameIndex>(geom_model->collisionPairs.size())` in the condition.

## Testing
After building it, I tried on a small example in python and it works. I did not run unit tests after this but it builds successfully. Please, do not hesitate to tell me if I did something wrong here.

## Related Issues
None

## Checklist
- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md).
- [X] My code follows the code style of this project.

Thank you, 
Arthur Haffemayer
PhD. Student, LAAS CNRS, Gepetto