### PR TITLE
Fix getters for constraint bounds

### DIFF
--- a/include/crocoddyl/core/action-base.hpp
+++ b/include/crocoddyl/core/action-base.hpp
@@ -245,12 +245,12 @@ class ActionModelAbstractTpl {
   /**
    * @brief Return the lower bound of the inequality constraints
    */
-  const VectorXs& get_g_lb() const;
+  virtual const VectorXs& get_g_lb() const;
 
   /**
    * @brief Return the upper bound of the inequality constraints
    */
-  const VectorXs& get_g_ub() const;
+  virtual const VectorXs& get_g_ub() const;
 
   /**
    * @brief Return the control lower bound

--- a/include/crocoddyl/core/diff-action-base.hpp
+++ b/include/crocoddyl/core/diff-action-base.hpp
@@ -278,12 +278,12 @@ class DifferentialActionModelAbstractTpl {
   /**
    * @brief Return the lower bound of the inequality constraints
    */
-  const VectorXs& get_g_lb() const;
+  virtual const VectorXs& get_g_lb() const;
 
   /**
    * @brief Return the upper bound of the inequality constraints
    */
-  const VectorXs& get_g_ub() const;
+  virtual const VectorXs& get_g_ub() const;
 
   /**
    * @brief Return the control lower bound


### PR DESCRIPTION
The current API does not set the action model bounds as emphasized in #1170 . This PR fixes this bug by making the corresponding getters virtual .