### PR TITLE
Included Python bindings for Crocoddyl exceptions

### DIFF
--- a/bindings/python/crocoddyl/core/core.cpp
+++ b/bindings/python/crocoddyl/core/core.cpp
@@ -72,6 +72,7 @@ void exposeCore() {
   exposeSolverIpopt();
 #endif
   exposeCallbacks();
+  exposeException();
   exposeStopWatch();
 }
 

--- a/bindings/python/crocoddyl/core/core.hpp
+++ b/bindings/python/crocoddyl/core/core.hpp
@@ -74,6 +74,7 @@ void exposeSolverIntro();
 void exposeSolverIpopt();
 #endif
 void exposeCallbacks();
+void exposeException();
 void exposeStopWatch();
 
 void exposeCore();

--- a/bindings/python/crocoddyl/core/utils/exception.hpp
+++ b/bindings/python/crocoddyl/core/utils/exception.hpp
@@ -1,0 +1,45 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2023-2023, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef BINDINGS_PYTHON_CROCODDYL_CORE_EXCEPTION_HPP_
+#define BINDINGS_PYTHON_CROCODDYL_CORE_EXCEPTION_HPP_
+
+#include "crocoddyl/core/utils/exception.hpp"
+#include "python/crocoddyl/core/core.hpp"
+
+namespace crocoddyl {
+namespace python {
+
+static PyObject* createExceptionClass(const char* name,
+                                      PyObject* base_type = PyExc_Exception) {
+  const std::string scope_name =
+      bp::extract<std::string>(bp::scope().attr("__name__"));
+  const std::string qualified_name = scope_name + "." + name;
+  PyObject* type = PyErr_NewException(qualified_name.c_str(), base_type, 0);
+  if (!type) {
+    bp::throw_error_already_set();
+  }
+  bp::scope().attr(name) = bp::handle<>(bp::borrowed(type));
+  return type;
+}
+
+PyObject* ExceptionType = NULL;
+void translateException(Exception const& e) {
+  bp::object exc_t(bp::handle<>(bp::borrowed(ExceptionType)));
+  exc_t.attr("cause") =
+      bp::object(e);  // add the wrapped exception to the Python exception
+  exc_t.attr("what") = bp::object(e.what());  // for convenience
+  PyErr_SetString(
+      ExceptionType,
+      e.what());  // the string is used by print(exception) in python
+}
+
+}  // namespace python
+}  // namespace crocoddyl
+
+#endif  // BINDINGS_PYTHON_CROCODDYL_CORE_EXCEPTION_HPP_

--- a/bindings/python/crocoddyl/core/utils/excepton.cpp
+++ b/bindings/python/crocoddyl/core/utils/excepton.cpp
@@ -1,0 +1,27 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2023-2023, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#include "python/crocoddyl/core/utils/exception.hpp"
+
+namespace crocoddyl {
+namespace python {
+
+void exposeException() {
+  bp::class_<Exception> ExceptionClass(
+      "Exception", bp::init<std::string, const char *, const char *, int>(
+                       bp::args("self", "msg", "file", "func", "line"),
+                       "Initialize the Crocoddyl's exception."));
+  ExceptionClass.add_property("message", &Exception::getMessage)
+      .add_property("extra_data", &Exception::getExtraData);
+
+  ExceptionType = createExceptionClass("Exception");
+  bp::register_exception_translator<Exception>(&translateException);
+}
+
+}  // namespace python
+}  // namespace crocoddyl

--- a/include/crocoddyl/core/utils/exception.hpp
+++ b/include/crocoddyl/core/utils/exception.hpp
@@ -1,7 +1,8 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, University of Edinburgh, LAAS-CNRS
+// Copyright (C) 2019-2023, University of Edinburgh, LAAS-CNRS,
+//                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -43,6 +44,12 @@ class Exception : public std::exception {
   virtual ~Exception() NOEXCEPT;
   virtual const char *what() const NOEXCEPT;
 
+  std::string getMessage() const;
+  std::string getExtraData() const;
+
+ private:
+  std::string exception_msg_;
+  std::string extra_data_;
   std::string msg_;
 };
 

--- a/src/core/utils/exception.cpp
+++ b/src/core/utils/exception.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, University of Edinburgh
+// Copyright (C) 2019-2023, University of Edinburgh, Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -18,10 +18,16 @@ Exception::Exception(const std::string &msg, const char *file, const char *func,
   ss << line << "\n";
   ss << msg;
   msg_ = ss.str();
+  exception_msg_ = msg;
+  extra_data_ = file;
 }
 
 Exception::~Exception() NOEXCEPT {}
 
 const char *Exception::what() const NOEXCEPT { return msg_.c_str(); }
+
+std::string Exception::getMessage() const { return exception_msg_; }
+
+std::string Exception::getExtraData() const { return extra_data_; }
 
 }  // namespace crocoddyl


### PR DESCRIPTION
This feature is needed when we wish to catch an exception in Python triggered by Crocoddyl.