### PR TITLE
Fixing the violation of bounds when one of the bounds is `inf` in `ActivationModelQuadraticBarrier`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+* Fixed handling of unbounded values for `ActivationBounds` in https://github.com/loco-3d/crocoddyl/pull/1191
+
 ## [2.0.2] - 2023-12-07
 
 * Added nu, ng, and nh setters for Python bindings in https://github.com/loco-3d/crocoddyl/pull/1192

--- a/include/crocoddyl/core/activations/quadratic-barrier.hpp
+++ b/include/crocoddyl/core/activations/quadratic-barrier.hpp
@@ -62,10 +62,16 @@ struct ActivationBoundsTpl {
     }
 
     if (beta >= Scalar(0) && beta <= Scalar(1.)) {
-      VectorXs m = Scalar(0.5) * (lb + ub);
-      VectorXs d = Scalar(0.5) * (ub - lb);
-      lb = m - beta * d;
-      ub = m + beta * d;
+      for (std::size_t i = 0; i < static_cast<std::size_t>(lb.size()); ++i) {
+        // do not use beta when one of the bounds is inf
+        if (lb(i) != (-std::numeric_limits<Scalar>::max()) &&
+            ub(i) != (std::numeric_limits<Scalar>::max())) {
+          Scalar m = Scalar(0.5) * (lb(i) + ub(i));
+          Scalar d = Scalar(0.5) * (ub(i) - lb(i));
+          lb(i) = m - beta * d;
+          ub(i) = m + beta * d;
+        }
+      }
     } else {
       beta = Scalar(1.);
     }


### PR DESCRIPTION
This PR fixes the issue mentioned in #1129.
Now when one of the `ub` or the `lb` are `nan` or `inf`, once they are converted to `std::numeric_limits<Scalar>::max()/min()`, such bounds are no longer modified even when a valid value for `beta` is specified. 

Thanks to @traversaro, an associated test function is added to the existing `test_activations.cpp` file, which fails when the bounds are not respected, as in the former code.