### PR TITLE
Fixed terminal computation in model classes derivated in Python

### DIFF
--- a/bindings/python/crocoddyl/core/action-base.hpp
+++ b/bindings/python/crocoddyl/core/action-base.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2023, LAAS-CNRS, University of Edinburgh,
+// Copyright (C) 2019-2024, LAAS-CNRS, University of Edinburgh,
 //                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
@@ -24,12 +24,15 @@ class ActionModelAbstract_wrap : public ActionModelAbstract,
   using ActionModelAbstract::ng_;
   using ActionModelAbstract::nh_;
   using ActionModelAbstract::nu_;
+  using ActionModelAbstract::unone_;
 
   ActionModelAbstract_wrap(boost::shared_ptr<StateAbstract> state,
                            const std::size_t nu, const std::size_t nr = 1,
                            const std::size_t ng = 0, const std::size_t nh = 0)
       : ActionModelAbstract(state, nu, nr, ng, nh),
-        bp::wrapper<ActionModelAbstract>() {}
+        bp::wrapper<ActionModelAbstract>() {
+    unone_ = NAN * MathBase::VectorXs::Ones(nu);
+  }
 
   void calc(const boost::shared_ptr<ActionDataAbstract>& data,
             const Eigen::Ref<const Eigen::VectorXd>& x,
@@ -44,8 +47,13 @@ class ActionModelAbstract_wrap : public ActionModelAbstract,
                    << "u has wrong dimension (it should be " +
                           std::to_string(nu_) + ")");
     }
-    return bp::call<void>(this->get_override("calc").ptr(), data,
-                          (Eigen::VectorXd)x, (Eigen::VectorXd)u);
+    if (std::isnan(u.lpNorm<Eigen::Infinity>())) {
+      return bp::call<void>(this->get_override("calc").ptr(), data,
+                            (Eigen::VectorXd)x);
+    } else {
+      return bp::call<void>(this->get_override("calc").ptr(), data,
+                            (Eigen::VectorXd)x, (Eigen::VectorXd)u);
+    }
   }
 
   void calcDiff(const boost::shared_ptr<ActionDataAbstract>& data,
@@ -61,8 +69,13 @@ class ActionModelAbstract_wrap : public ActionModelAbstract,
                    << "u has wrong dimension (it should be " +
                           std::to_string(nu_) + ")");
     }
-    return bp::call<void>(this->get_override("calcDiff").ptr(), data,
-                          (Eigen::VectorXd)x, (Eigen::VectorXd)u);
+    if (std::isnan(u.lpNorm<Eigen::Infinity>())) {
+      return bp::call<void>(this->get_override("calcDiff").ptr(), data,
+                            (Eigen::VectorXd)x);
+    } else {
+      return bp::call<void>(this->get_override("calcDiff").ptr(), data,
+                            (Eigen::VectorXd)x, (Eigen::VectorXd)u);
+    }
   }
 
   boost::shared_ptr<ActionDataAbstract> createData() {

--- a/bindings/python/crocoddyl/utils/pendulum.py
+++ b/bindings/python/crocoddyl/utils/pendulum.py
@@ -12,14 +12,14 @@ class CostModelDoublePendulum(crocoddyl.CostModelAbstract):
         )
         crocoddyl.CostModelAbstract.__init__(self, state, activation, nu=nu)
 
-    def calc(self, data, x, u):
+    def calc(self, data, x, u=None):
         c1, c2 = np.cos(x[0]), np.cos(x[1])
         s1, s2 = np.sin(x[0]), np.sin(x[1])
         data.residual.r[:] = np.array([s1, s2, 1 - c1, 1 - c2, x[2], x[3]])
         self.activation.calc(data.activation, data.residual.r)
         data.cost = data.activation.a_value
 
-    def calcDiff(self, data, x, u):
+    def calcDiff(self, data, x, u=None):
         c1, c2 = np.cos(x[0]), np.cos(x[1])
         s1, s2 = np.sin(x[0]), np.sin(x[1])
 

--- a/include/crocoddyl/core/codegen/action-base.hpp
+++ b/include/crocoddyl/core/codegen/action-base.hpp
@@ -2,7 +2,8 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, LAAS-CNRS, INRIA, University of Edinburgh
+// Copyright (C) 2019-2024, LAAS-CNRS, INRIA, University of Edinburgh,
+//                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -243,7 +244,6 @@ class ActionModelCodeGenTpl : public ActionModelAbstractTpl<_Scalar> {
   using Base::state_;               //!< Model of the state
   using Base::u_lb_;                //!< Lower control limits
   using Base::u_ub_;                //!< Upper control limits
-  using Base::unone_;               //!< Neutral state
 
   boost::shared_ptr<Base> model;
   boost::shared_ptr<ADBase> ad_model;

--- a/include/crocoddyl/core/constraints/constraint-manager.hpp
+++ b/include/crocoddyl/core/constraints/constraint-manager.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2020-2022, University of Edinburgh, Heriot-Watt University
+// Copyright (C) 2020-2024, University of Edinburgh, Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -265,7 +265,6 @@ class ConstraintModelManagerTpl {
   std::set<std::string> active_set_;  //!< Names of the active constraint items
   std::set<std::string>
       inactive_set_;  //!< Names of the inactive constraint items
-  VectorXs unone_;    //!< No control vector
 };
 
 template <typename _Scalar>

--- a/include/crocoddyl/core/integ-action-base.hpp
+++ b/include/crocoddyl/core/integ-action-base.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2021-2022, LAAS-CNRS, University of Edinburgh,
+// Copyright (C) 2021-2024, LAAS-CNRS, University of Edinburgh,
 //                          University of Oxford, University of Trento,
 //                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
@@ -148,7 +148,6 @@ class IntegratedActionModelAbstractTpl
   using Base::state_;               //!< Model of the state
   using Base::u_lb_;                //!< Lower control limits
   using Base::u_ub_;                //!< Upper control limits
-  using Base::unone_;               //!< Neutral state
 
   void init();
 

--- a/include/crocoddyl/core/numdiff/action.hpp
+++ b/include/crocoddyl/core/numdiff/action.hpp
@@ -1,8 +1,9 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2023, LAAS-CNRS, New York University,
-//                          Max Planck Gesellschaft, University of Edinburgh
+// Copyright (C) 2019-2024, LAAS-CNRS, New York University,
+//                          Max Planck Gesellschaft, University of Edinburgh,
+//                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -145,7 +146,6 @@ class ActionModelNumDiffTpl : public ActionModelAbstractTpl<_Scalar> {
   using Base::state_;               //!< Model of the state
   using Base::u_lb_;                //!< Lower control limits
   using Base::u_ub_;                //!< Upper control limits
-  using Base::unone_;               //!< Neutral state
 
  private:
   /**

--- a/include/crocoddyl/core/numdiff/diff-action.hpp
+++ b/include/crocoddyl/core/numdiff/diff-action.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2023, LAAS-CNRS, University of Edinburgh,
+// Copyright (C) 2019-2024, LAAS-CNRS, University of Edinburgh,
 //                          New York University, Max Planck Gesellschaft
 //                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
@@ -153,7 +153,6 @@ class DifferentialActionModelNumDiffTpl
   using Base::state_;               //!< Model of the state
   using Base::u_lb_;                //!< Lower control limits
   using Base::u_ub_;                //!< Upper control limits
-  using Base::unone_;               //!< Neutral state
 
  private:
   void assertStableStateFD(const Eigen::Ref<const VectorXs>& x);

--- a/include/crocoddyl/core/residuals/control.hpp
+++ b/include/crocoddyl/core/residuals/control.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2023, LAAS-CNRS, University of Edinburgh,
+// Copyright (C) 2019-2024, LAAS-CNRS, University of Edinburgh,
 //                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
@@ -151,7 +151,6 @@ class ResidualModelControlTpl : public ResidualModelAbstractTpl<_Scalar> {
  protected:
   using Base::nu_;
   using Base::state_;
-  using Base::unone_;
 
  private:
   VectorXs uref_;  //!< Reference control input

--- a/include/crocoddyl/multibody/actions/contact-invdyn.hpp
+++ b/include/crocoddyl/multibody/actions/contact-invdyn.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2021-2022, Heriot-Watt University, University of Edinburgh
+// Copyright (C) 2021-2024, Heriot-Watt University, University of Edinburgh
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -512,7 +512,6 @@ class DifferentialActionModelContactInvDynamicsTpl
     using Base::nr_;
     using Base::nu_;
     using Base::state_;
-    using Base::unone_;
 
    private:
     pinocchio::FrameIndex id_;  //!< Reference frame id

--- a/include/crocoddyl/multibody/residuals/centroidal-momentum.hpp
+++ b/include/crocoddyl/multibody/residuals/centroidal-momentum.hpp
@@ -1,7 +1,8 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2021, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2021-2024, LAAS-CNRS, University of Edinburgh,
+//                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -121,7 +122,6 @@ class ResidualModelCentroidalMomentumTpl
   using Base::nu_;
   using Base::state_;
   using Base::u_dependent_;
-  using Base::unone_;
 
  private:
   Vector6s href_;  //!< Reference centroidal momentum

--- a/include/crocoddyl/multibody/residuals/com-position.hpp
+++ b/include/crocoddyl/multibody/residuals/com-position.hpp
@@ -1,7 +1,8 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2021, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2021-2024, LAAS-CNRS, University of Edinburgh,
+//                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -113,7 +114,6 @@ class ResidualModelCoMPositionTpl : public ResidualModelAbstractTpl<_Scalar> {
   using Base::nu_;
   using Base::state_;
   using Base::u_dependent_;
-  using Base::unone_;
   using Base::v_dependent_;
 
  private:

--- a/include/crocoddyl/multibody/residuals/contact-control-gravity.hpp
+++ b/include/crocoddyl/multibody/residuals/contact-control-gravity.hpp
@@ -1,7 +1,8 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2020-2021, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2020-2024, LAAS-CNRS, University of Edinburgh,
+//                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -138,7 +139,6 @@ class ResidualModelContactControlGravTpl
  protected:
   using Base::nu_;
   using Base::state_;
-  using Base::unone_;
   using Base::v_dependent_;
 
  private:

--- a/include/crocoddyl/multibody/residuals/contact-cop-position.hpp
+++ b/include/crocoddyl/multibody/residuals/contact-cop-position.hpp
@@ -1,9 +1,8 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2020-2022, University of Duisburg-Essen, University of
-// Edinburgh,
-//                          Heriot-Watt University
+// Copyright (C) 2020-2024, University of Duisburg-Essen,
+//                         University of Edinburgh, Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -232,7 +231,6 @@ class ResidualModelContactCoPPositionTpl
  protected:
   using Base::nu_;
   using Base::state_;
-  using Base::unone_;
 
  private:
   bool fwddyn_;  //!< Indicates if we are using this function for forward

--- a/include/crocoddyl/multibody/residuals/contact-force.hpp
+++ b/include/crocoddyl/multibody/residuals/contact-force.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2022, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2019-2024, LAAS-CNRS, University of Edinburgh
 //                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
@@ -221,7 +221,6 @@ class ResidualModelContactForceTpl : public ResidualModelAbstractTpl<_Scalar> {
   using Base::nr_;
   using Base::nu_;
   using Base::state_;
-  using Base::unone_;
 
  private:
   bool fwddyn_;  //!< Indicates if we are using this function for forward

--- a/include/crocoddyl/multibody/residuals/contact-friction-cone.hpp
+++ b/include/crocoddyl/multibody/residuals/contact-friction-cone.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2022, LAAS-CNRS, University of Edinburgh,
+// Copyright (C) 2019-2024, LAAS-CNRS, University of Edinburgh,
 //                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
@@ -207,7 +207,6 @@ class ResidualModelContactFrictionConeTpl
  protected:
   using Base::nu_;
   using Base::state_;
-  using Base::unone_;
 
  private:
   bool fwddyn_;  //!< Indicates if we are using this function for forward

--- a/include/crocoddyl/multibody/residuals/contact-wrench-cone.hpp
+++ b/include/crocoddyl/multibody/residuals/contact-wrench-cone.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2020-2022, University of Edinburgh, Heriot-Watt University
+// Copyright (C) 2020-2024, University of Edinburgh, Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -215,7 +215,6 @@ class ResidualModelContactWrenchConeTpl
  protected:
   using Base::nu_;
   using Base::state_;
-  using Base::unone_;
 
  private:
   bool fwddyn_;  //!< Indicates if we are using this function for forward

--- a/include/crocoddyl/multibody/residuals/control-gravity.hpp
+++ b/include/crocoddyl/multibody/residuals/control-gravity.hpp
@@ -116,7 +116,6 @@ class ResidualModelControlGravTpl : public ResidualModelAbstractTpl<_Scalar> {
  protected:
   using Base::nu_;
   using Base::state_;
-  using Base::unone_;
   using Base::v_dependent_;
 
  private:

--- a/include/crocoddyl/multibody/residuals/frame-placement.hpp
+++ b/include/crocoddyl/multibody/residuals/frame-placement.hpp
@@ -136,7 +136,6 @@ class ResidualModelFramePlacementTpl
   using Base::nu_;
   using Base::state_;
   using Base::u_dependent_;
-  using Base::unone_;
   using Base::v_dependent_;
 
  private:

--- a/include/crocoddyl/multibody/residuals/frame-rotation.hpp
+++ b/include/crocoddyl/multibody/residuals/frame-rotation.hpp
@@ -134,7 +134,6 @@ class ResidualModelFrameRotationTpl : public ResidualModelAbstractTpl<_Scalar> {
   using Base::nu_;
   using Base::state_;
   using Base::u_dependent_;
-  using Base::unone_;
   using Base::v_dependent_;
 
  private:

--- a/include/crocoddyl/multibody/residuals/frame-translation.hpp
+++ b/include/crocoddyl/multibody/residuals/frame-translation.hpp
@@ -136,7 +136,6 @@ class ResidualModelFrameTranslationTpl
   using Base::nu_;
   using Base::state_;
   using Base::u_dependent_;
-  using Base::unone_;
   using Base::v_dependent_;
 
  private:

--- a/include/crocoddyl/multibody/residuals/frame-velocity.hpp
+++ b/include/crocoddyl/multibody/residuals/frame-velocity.hpp
@@ -154,7 +154,6 @@ class ResidualModelFrameVelocityTpl : public ResidualModelAbstractTpl<_Scalar> {
   using Base::nu_;
   using Base::state_;
   using Base::u_dependent_;
-  using Base::unone_;
 
  private:
   pinocchio::FrameIndex id_;        //!< Reference frame id

--- a/include/crocoddyl/multibody/residuals/impulse-com.hpp
+++ b/include/crocoddyl/multibody/residuals/impulse-com.hpp
@@ -96,7 +96,6 @@ class ResidualModelImpulseCoMTpl : public ResidualModelAbstractTpl<_Scalar> {
   using Base::nu_;
   using Base::state_;
   using Base::u_dependent_;
-  using Base::unone_;
 
  private:
   boost::shared_ptr<typename StateMultibody::PinocchioModel> pin_model_;

--- a/include/crocoddyl/multibody/residuals/pair-collision.hpp
+++ b/include/crocoddyl/multibody/residuals/pair-collision.hpp
@@ -116,7 +116,6 @@ class ResidualModelPairCollisionTpl : public ResidualModelAbstractTpl<_Scalar> {
  protected:
   using Base::nu_;
   using Base::state_;
-  using Base::unone_;
   using Base::v_dependent_;
 
  private:

--- a/include/crocoddyl/multibody/residuals/state.hpp
+++ b/include/crocoddyl/multibody/residuals/state.hpp
@@ -158,7 +158,6 @@ class ResidualModelStateTpl : public ResidualModelAbstractTpl<_Scalar> {
   using Base::nu_;
   using Base::state_;
   using Base::u_dependent_;
-  using Base::unone_;
 
  private:
   VectorXs xref_;  //!< Reference state

--- a/unittest/bindings/factory.py
+++ b/unittest/bindings/factory.py
@@ -198,34 +198,34 @@ class UnicycleModelDerived(crocoddyl.ActionModelAbstract):
 
     def calc(self, data, x, u=None):
         if u is None:
-            u = self.unone
-        v, w = u
-        px, py, theta = x
-        c, s, dt = np.cos(theta), np.sin(theta), self.dt
-        # Rollout the dynamics
-        data.xnext[0] = px + c * v * dt
-        data.xnext[1] = py + s * v * dt
-        data.xnext[2] = theta + w * dt
-        # Compute the cost value
-        data.r[:3] = self.costWeights[0] * x
-        data.r[3:] = self.costWeights[1] * u
-        data.cost = 0.5 * sum(data.r**2)
+            data.xnext[:] = x
+            data.r[:3] = self.costWeights[0] * x
+            data.cost = 0.5 * sum(data.r**2)
+        else:
+            v, w = u
+            px, py, theta = x
+            c, s, dt = np.cos(theta), np.sin(theta), self.dt
+            data.xnext[0] = px + c * v * dt
+            data.xnext[1] = py + s * v * dt
+            data.xnext[2] = theta + w * dt
+            data.r[:3] = self.costWeights[0] * x
+            data.r[3:] = self.costWeights[1] * u
+            data.cost = 0.5 * sum(data.r**2)
 
     def calcDiff(self, data, x, u=None):
         if u is None:
-            u = self.unone
-        v = u[0]
-        theta = x[2]
-        # Cost derivatives
-        data.Lx[:] = x * ([self.costWeights[0] ** 2] * self.state.nx)
-        data.Lu[:] = u * ([self.costWeights[1] ** 2] * self.nu)
-        # Dynamic derivatives
-        c, s, dt = np.cos(theta), np.sin(theta), self.dt
-        data.Fx[0, 2] = -s * v * dt
-        data.Fx[1, 2] = c * v * dt
-        data.Fu[0, 0] = c * dt
-        data.Fu[1, 0] = s * dt
-        data.Fu[2, 1] = dt
+            data.Lx[:] = x * ([self.costWeights[0] ** 2] * self.state.nx)
+        else:
+            v = u[0]
+            theta = x[2]
+            data.Lx[:] = x * ([self.costWeights[0] ** 2] * self.state.nx)
+            c, s, dt = np.cos(theta), np.sin(theta), self.dt
+            data.Fx[0, 2] = -s * v * dt
+            data.Fx[1, 2] = c * v * dt
+            data.Fu[0, 0] = c * dt
+            data.Fu[1, 0] = s * dt
+            data.Fu[2, 1] = dt
+            data.Lu[:] = u * ([self.costWeights[1] ** 2] * self.nu)
 
     def createData(self):
         data = UnicycleDataDerived(self)
@@ -246,7 +246,6 @@ class UnicycleDataDerived(crocoddyl.ActionDataAbstract):
 class LQRModelDerived(crocoddyl.ActionModelAbstract):
     def __init__(self, nx, nu, driftFree=True):
         crocoddyl.ActionModelAbstract.__init__(self, crocoddyl.StateVector(nx), nu)
-
         self.Fx = np.eye(self.state.nx)
         self.Fu = np.eye(self.state.nx)[:, : self.nu]
         self.f0 = np.zeros(self.state.nx)
@@ -258,18 +257,22 @@ class LQRModelDerived(crocoddyl.ActionModelAbstract):
 
     def calc(self, data, x, u=None):
         if u is None:
-            u = self.unone
-        data.xnext[:] = np.dot(self.Fx, x) + np.dot(self.Fu, u) + self.f0
-        data.cost = 0.5 * np.dot(x.T, np.dot(self.Lxx, x))
-        data.cost += 0.5 * np.dot(u.T, np.dot(self.Luu, u))
-        data.cost += np.dot(x.T, np.dot(self.Lxu, u))
-        data.cost += np.dot(self.lx.T, x) + np.dot(self.lu.T, u)
+            data.xnext[:] = x
+            data.cost = 0.5 * np.dot(x.T, np.dot(self.Lxx, x))
+            data.cost += np.dot(self.lx.T, x)
+        else:
+            data.xnext[:] = np.dot(self.Fx, x) + np.dot(self.Fu, u) + self.f0
+            data.cost = 0.5 * np.dot(x.T, np.dot(self.Lxx, x))
+            data.cost += 0.5 * np.dot(u.T, np.dot(self.Luu, u))
+            data.cost += np.dot(x.T, np.dot(self.Lxu, u))
+            data.cost += np.dot(self.lx.T, x) + np.dot(self.lu.T, u)
 
     def calcDiff(self, data, x, u=None):
         if u is None:
-            u = self.unone
-        data.Lx[:] = self.lx + np.dot(self.Lxx, x) + np.dot(self.Lxu, u)
-        data.Lu[:] = self.lu + np.dot(self.Lxu.T, x) + np.dot(self.Luu, u)
+            data.Lx[:] = self.lx + np.dot(self.Lxx, x)
+        else:
+            data.Lx[:] = self.lx + np.dot(self.Lxx, x) + np.dot(self.Lxu, u)
+            data.Lu[:] = self.lu + np.dot(self.Lxu.T, x) + np.dot(self.Luu, u)
 
     def createData(self):
         data = LQRDataDerived(self)
@@ -291,7 +294,6 @@ class DifferentialLQRModelDerived(crocoddyl.DifferentialActionModelAbstract):
         crocoddyl.DifferentialActionModelAbstract.__init__(
             self, crocoddyl.StateVector(2 * nq), nu
         )
-
         self.Fq = np.eye(self.state.nq)
         self.Fv = np.eye(self.state.nv)
         self.Fu = np.eye(self.state.nq)[:, : self.nu]
@@ -304,21 +306,24 @@ class DifferentialLQRModelDerived(crocoddyl.DifferentialActionModelAbstract):
 
     def calc(self, data, x, u=None):
         if u is None:
-            u = self.unone
-        q, v = x[: self.state.nq], x[self.state.nq :]
-        data.xout[:] = (
-            np.dot(self.Fq, q) + np.dot(self.Fv, v) + np.dot(self.Fu, u) + self.f0
-        )
-        data.cost = 0.5 * np.dot(x.T, np.dot(self.Lxx, x))
-        data.cost += 0.5 * np.dot(u.T, np.dot(self.Luu, u))
-        data.cost += np.dot(x.T, np.dot(self.Lxu, u))
-        data.cost += np.dot(self.lx.T, x) + np.dot(self.lu.T, u)
+            data.cost = 0.5 * np.dot(x.T, np.dot(self.Lxx, x))
+            data.cost += np.dot(self.lx.T, x)
+        else:
+            q, v = x[: self.state.nq], x[self.state.nq :]
+            data.xout[:] = (
+                np.dot(self.Fq, q) + np.dot(self.Fv, v) + np.dot(self.Fu, u) + self.f0
+            )
+            data.cost = 0.5 * np.dot(x.T, np.dot(self.Lxx, x))
+            data.cost += 0.5 * np.dot(u.T, np.dot(self.Luu, u))
+            data.cost += np.dot(x.T, np.dot(self.Lxu, u))
+            data.cost += np.dot(self.lx.T, x) + np.dot(self.lu.T, u)
 
     def calcDiff(self, data, x, u=None):
         if u is None:
-            u = self.unone
-        data.Lx[:] = self.lx + np.dot(self.Lxx, x) + np.dot(self.Lxu, u)
-        data.Lu[:] = self.lu + np.dot(self.Lxu.T, x) + np.dot(self.Luu, u)
+            data.Lx[:] = self.lx + np.dot(self.Lxx, x)
+        else:
+            data.Lx[:] = self.lx + np.dot(self.Lxx, x) + np.dot(self.Lxu, u)
+            data.Lu[:] = self.lu + np.dot(self.Lxu.T, x) + np.dot(self.Luu, u)
 
     def createData(self):
         data = DifferentialLQRDataDerived(self)
@@ -349,61 +354,66 @@ class DifferentialFreeFwdDynamicsModelDerived(
 
     def calc(self, data, x, u=None):
         if u is None:
-            u = self.unone
-        q, v = x[: self.state.nq], x[-self.state.nv :]
-        self.actuation.calc(data.actuation, x, u)
-        tau = data.actuation.tau
-        # Computing the dynamics using ABA or manually for armature case
-        if self.enable_force:
-            data.xout[:] = pinocchio.aba(
-                self.state.pinocchio, data.pinocchio, q, v, tau
-            )
-        else:
+            q, v = x[: self.state.nq], x[-self.state.nv :]
             pinocchio.computeAllTerms(self.state.pinocchio, data.pinocchio, q, v)
-            data.M = data.pinocchio.M
-            if self.armature.size == self.state.nv:
-                data.M[range(self.state.nv), range(self.state.nv)] += self.armature
-            data.Minv = np.linalg.inv(data.M)
-            data.xout[:] = np.dot(data.Minv, (tau - data.pinocchio.nle))
-        # Computing the cost value and residuals
-        pinocchio.forwardKinematics(self.state.pinocchio, data.pinocchio, q, v)
-        pinocchio.updateFramePlacements(self.state.pinocchio, data.pinocchio)
-        self.costs.calc(data.costs, x, u)
-        data.cost = data.costs.cost
+            self.costs.calc(data.costs, x)
+            data.cost = data.costs.cost
+        else:
+            q, v = x[: self.state.nq], x[-self.state.nv :]
+            self.actuation.calc(data.actuation, x, u)
+            tau = data.actuation.tau
+            # Computing the dynamics using ABA or manually for armature case
+            if self.enable_force:
+                data.xout[:] = pinocchio.aba(
+                    self.state.pinocchio, data.pinocchio, q, v, tau
+                )
+            else:
+                pinocchio.computeAllTerms(self.state.pinocchio, data.pinocchio, q, v)
+                data.M = data.pinocchio.M
+                if self.armature.size == self.state.nv:
+                    data.M[range(self.state.nv), range(self.state.nv)] += self.armature
+                data.Minv = np.linalg.inv(data.M)
+                data.xout[:] = np.dot(data.Minv, (tau - data.pinocchio.nle))
+            # Computing the cost value and residuals
+            pinocchio.forwardKinematics(self.state.pinocchio, data.pinocchio, q, v)
+            pinocchio.updateFramePlacements(self.state.pinocchio, data.pinocchio)
+            self.costs.calc(data.costs, x, u)
+            data.cost = data.costs.cost
 
     def calcDiff(self, data, x, u=None):
         if u is None:
-            u = self.unone
-        nq, nv = self.state.nq, self.state.nv
-        q, v = x[:nq], x[-nv:]
-        # Computing the actuation derivatives
-        self.actuation.calcDiff(data.actuation, x, u)
-        tau = data.actuation.tau
-        # Computing the dynamics derivatives
-        if self.enable_force:
-            pinocchio.computeABADerivatives(
-                self.state.pinocchio, data.pinocchio, q, v, tau
-            )
-            ddq_dq = data.pinocchio.ddq_dq
-            ddq_dv = data.pinocchio.ddq_dv
-            data.Fx[:, :] = np.hstack([ddq_dq, ddq_dv]) + np.dot(
-                data.pinocchio.Minv, data.actuation.dtau_dx
-            )
-            data.Fu[:, :] = np.dot(data.pinocchio.Minv, data.actuation.dtau_du)
+            self.costs.calcDiff(data.costs, x)
         else:
-            pinocchio.computeRNEADerivatives(
-                self.state.pinocchio, data.pinocchio, q, v, data.xout
-            )
-            ddq_dq = np.dot(
-                data.Minv, (data.actuation.dtau_dx[:, :nv] - data.pinocchio.dtau_dq)
-            )
-            ddq_dv = np.dot(
-                data.Minv, (data.actuation.dtau_dx[:, nv:] - data.pinocchio.dtau_dv)
-            )
-            data.Fx[:, :] = np.hstack([ddq_dq, ddq_dv])
-            data.Fu[:, :] = np.dot(data.Minv, data.actuation.dtau_du)
-        # Computing the cost derivatives
-        self.costs.calcDiff(data.costs, x, u)
+            nq, nv = self.state.nq, self.state.nv
+            q, v = x[:nq], x[-nv:]
+            # Computing the actuation derivatives
+            self.actuation.calcDiff(data.actuation, x, u)
+            tau = data.actuation.tau
+            # Computing the dynamics derivatives
+            if self.enable_force:
+                pinocchio.computeABADerivatives(
+                    self.state.pinocchio, data.pinocchio, q, v, tau
+                )
+                ddq_dq = data.pinocchio.ddq_dq
+                ddq_dv = data.pinocchio.ddq_dv
+                data.Fx[:, :] = np.hstack([ddq_dq, ddq_dv]) + np.dot(
+                    data.pinocchio.Minv, data.actuation.dtau_dx
+                )
+                data.Fu[:, :] = np.dot(data.pinocchio.Minv, data.actuation.dtau_du)
+            else:
+                pinocchio.computeRNEADerivatives(
+                    self.state.pinocchio, data.pinocchio, q, v, data.xout
+                )
+                ddq_dq = np.dot(
+                    data.Minv, (data.actuation.dtau_dx[:, :nv] - data.pinocchio.dtau_dq)
+                )
+                ddq_dv = np.dot(
+                    data.Minv, (data.actuation.dtau_dx[:, nv:] - data.pinocchio.dtau_dv)
+                )
+                data.Fx[:, :] = np.hstack([ddq_dq, ddq_dv])
+                data.Fu[:, :] = np.dot(data.Minv, data.actuation.dtau_du)
+            # Computing the cost derivatives
+            self.costs.calcDiff(data.costs, x, u)
 
     def createData(self):
         data = DifferentialFreeFwdDynamicsDataDerived(self)
@@ -438,44 +448,41 @@ class IntegratedActionModelEulerDerived(crocoddyl.ActionModelAbstract):
         self.timeStep = timeStep
 
     def calc(self, data, x, u=None):
-        nq, dt = self.state.nq, self.timeStep
-        self.differential.calc(data.differential, x, u)
-        acc = data.differential.xout
-        if self.withCostResiduals:
-            data.r = data.differential.r
         if u is None:
+            self.differential.calc(data.differential, x)
+            data.dx[:] *= 0.0
+            data.xnext[:] = x
             data.cost = data.differential.cost
         else:
+            nq, dt = self.state.nq, self.timeStep
+            self.differential.calc(data.differential, x, u)
+            acc = data.differential.xout
+            if self.withCostResiduals:
+                data.r = data.differential.r
             data.cost = dt * data.differential.cost
-        # data.xnext[nq:] = x[nq:] + acc*dt
-        # data.xnext[:nq] = pinocchio.integrate(
-        # self.differential.pinocchio, a2m(x[:nq]), a2m(data.xnext[nq:] * dt)
-        # ).flat
-        data.dx = np.concatenate([x[nq:] * dt + acc * dt**2, acc * dt])
-        data.xnext[:] = self.differential.state.integrate(x, data.dx)
-
-        return data.xnext, data.cost
+            data.dx[:] = np.concatenate([x[nq:] * dt + acc * dt**2, acc * dt])
+            data.xnext[:] = self.differential.state.integrate(x, data.dx)
 
     def calcDiff(self, data, x, u=None):
-        nv, dt = self.state.nv, self.timeStep
-        self.differential.calcDiff(data.differential, x, u)
-        dxnext_dx, dxnext_ddx = self.state.Jintegrate(x, data.dx)
-        da_dx, da_du = data.differential.Fx, data.differential.Fu
-        ddx_dx = np.vstack([da_dx * dt, da_dx])
-        ddx_dx[range(nv), range(nv, 2 * nv)] += 1
-        data.Fx[:, :] = dxnext_dx + dt * np.dot(dxnext_ddx, ddx_dx)
-        ddx_du = np.vstack([da_du * dt, da_du])
-        if self.nu == 1:
-            data.Fu[:] = (dt * np.dot(dxnext_ddx, ddx_du)).reshape(self.state.nx)
-        else:
-            data.Fu[:, :] = dt * np.dot(dxnext_ddx, ddx_du)
         if u is None:
+            self.differential.calcDiff(data.differential, x)
+            dxnext_dx, _ = self.state.Jintegrate(x, data.dx)
+            data.Fx[:, :] = dxnext_dx
             data.Lx[:] = data.differential.Lx
             data.Lu[:] = data.differential.Lu
-            data.Lxx[:, :] = data.differential.Lxx
-            data.Lxu[:, :] = data.differential.Lxu
-            data.Luu[:, :] = data.differential.Luu
         else:
+            nv, dt = self.state.nv, self.timeStep
+            self.differential.calcDiff(data.differential, x, u)
+            dxnext_dx, dxnext_ddx = self.state.Jintegrate(x, data.dx)
+            da_dx, da_du = data.differential.Fx, data.differential.Fu
+            ddx_dx = np.vstack([da_dx * dt, da_dx])
+            ddx_dx[range(nv), range(nv, 2 * nv)] += 1
+            data.Fx[:, :] = dxnext_dx + dt * np.dot(dxnext_ddx, ddx_dx)
+            ddx_du = np.vstack([da_du * dt, da_du])
+            if self.nu == 1:
+                data.Fu[:] = (dt * np.dot(dxnext_ddx, ddx_du)).reshape(self.state.nx)
+            else:
+                data.Fu[:, :] = dt * np.dot(dxnext_ddx, ddx_du)
             data.Lx[:] = data.differential.Lx * dt
             data.Lu[:] = data.differential.Lu * dt
             data.Lxx[:, :] = data.differential.Lxx * dt
@@ -491,6 +498,7 @@ class IntegratedActionDataEulerDerived(crocoddyl.ActionDataAbstract):
     def __init__(self, model):
         crocoddyl.ActionDataAbstract.__init__(self, model)
         self.differential = model.differential.createData()
+        self.dx = np.zeros(model.state.ndx)
 
 
 class IntegratedActionModelRK4Derived(crocoddyl.ActionModelAbstract):
@@ -505,29 +513,32 @@ class IntegratedActionModelRK4Derived(crocoddyl.ActionModelAbstract):
         self.ndx = self.differential.state.ndx
         self.nq = self.differential.state.nq
         self.nv = self.differential.state.nv
-        self.enable_integration = self.timeStep > 0.0
 
     def createData(self):
         return IntegratedActionDataRK4Derived(self)
 
     def calc(self, data, x, u=None):
-        nq, dt = self.nq, self.timeStep
-
-        data.y[0] = x
-        for i in range(3):
-            self.differential.calc(data.differential[i], data.y[i], u)
-            data.acc[i] = data.differential[i].xout
-            data.int[i] = data.differential[i].cost
-            data.ki[i] = np.concatenate([data.y[i][nq:], data.acc[i]])
-            data.y[i + 1] = self.differential.state.integrate(
-                x, data.ki[i] * self.rk4_inc[i] * dt
-            )
-
-        self.differential.calc(data.differential[3], data.y[3], u)
-        data.acc[3] = data.differential[3].xout
-        data.int[3] = data.differential[3].cost
-        data.ki[3] = np.concatenate([data.y[3][nq:], data.acc[3]])
-        if self.enable_integration:
+        if u is None:
+            k0_data = data.differential[0]
+            self.differential.calc(k0_data, x)
+            self.dx[:] *= 0.0
+            self.xnext[:] = x
+            data.cost = k0_data.cost
+        else:
+            nq, dt = self.nq, self.timeStep
+            data.y[0] = x
+            for i in range(3):
+                self.differential.calc(data.differential[i], data.y[i], u)
+                data.acc[i] = data.differential[i].xout
+                data.int[i] = data.differential[i].cost
+                data.ki[i] = np.concatenate([data.y[i][nq:], data.acc[i]])
+                data.y[i + 1] = self.differential.state.integrate(
+                    x, data.ki[i] * self.rk4_inc[i] * dt
+                )
+            self.differential.calc(data.differential[3], data.y[3], u)
+            data.acc[3] = data.differential[3].xout
+            data.int[3] = data.differential[3].cost
+            data.ki[3] = np.concatenate([data.y[3][nq:], data.acc[3]])
             data.dx = (
                 (data.ki[0] + 2.0 * data.ki[1] + 2.0 * data.ki[2] + data.ki[3]) * dt / 6
             )
@@ -535,42 +546,33 @@ class IntegratedActionModelRK4Derived(crocoddyl.ActionModelAbstract):
             data.cost = (
                 (data.int[0] + 2 * data.int[1] + 2 * data.int[2] + data.int[3]) * dt / 6
             )
+
+    def calcDiff(self, data, x, u=None):
+        if u is None:
+            k0_data = data.differential[0]
+            self.differential.calcDiff(k0_data, x)
+            data.Lx[:] = k0_data.Lx
+            data.Lxx[:] = k0_data.Lxx
         else:
-            data.dx = np.zeros([self.ndx])
-            data.xnext = x
-            data.cost = data.differential[0].cost
-
-        return data.xnext, data.cost
-
-    def calcDiff(self, data, x, u):
-        ndx, nu, nv, dt = self.ndx, self.nu, self.nv, self.timeStep
-        for i in range(4):
-            self.differential.calcDiff(data.differential[i], data.y[i], u)
-            data.dki_dy[i] = np.bmat(
-                [[np.zeros([nv, nv]), np.identity(nv)], [data.differential[i].Fx]]
-            )
-
-        data.dki_du[0] = np.vstack([np.zeros([nv, nu]), data.differential[0].Fu])
-
-        data.Lx[:] = data.differential[0].Lx
-        data.Lu[:] = data.differential[0].Lu
-
-        data.dy_du[0] = np.zeros((ndx, nu))
-        data.dki_dx[0] = data.dki_dy[0]
-
-        data.dli_dx[0] = data.differential[0].Lx
-        data.dli_du[0] = data.differential[0].Lu
-
-        data.ddli_ddx[0] = data.differential[0].Lxx
-        data.ddli_ddu[0] = data.differential[0].Luu
-        data.ddli_dxdu[0] = data.differential[0].Lxu
-
-        if self.enable_integration:
+            ndx, nu, nv, dt = self.ndx, self.nu, self.nv, self.timeStep
+            for i in range(4):
+                self.differential.calcDiff(data.differential[i], data.y[i], u)
+                data.dki_dy[i] = np.bmat(
+                    [[np.zeros([nv, nv]), np.identity(nv)], [data.differential[i].Fx]]
+                )
+            data.dki_du[0] = np.vstack([np.zeros([nv, nu]), data.differential[0].Fu])
+            data.Lx[:] = data.differential[0].Lx
+            data.Lu[:] = data.differential[0].Lu
+            data.dy_du[0] = np.zeros((ndx, nu))
+            data.dki_dx[0] = data.dki_dy[0]
+            data.dli_dx[0] = data.differential[0].Lx
+            data.dli_du[0] = data.differential[0].Lu
+            data.ddli_ddx[0] = data.differential[0].Lxx
+            data.ddli_ddu[0] = data.differential[0].Luu
+            data.ddli_dxdu[0] = data.differential[0].Lxu
             for i in range(1, 4):
                 c = self.rk4_inc[i - 1] * dt
                 dyi_dx, dyi_ddx = self.state.Jintegrate(x, c * data.ki[i - 1])
-
-                # ---------Finding the derivative wrt u--------------
                 data.dy_du[i] = c * np.dot(dyi_ddx, data.dki_du[i - 1])
                 data.dki_du[i] = np.vstack(
                     [
@@ -579,11 +581,9 @@ class IntegratedActionModelRK4Derived(crocoddyl.ActionModelAbstract):
                         + np.dot(data.differential[i].Fx, data.dy_du[i]),
                     ]
                 )
-
                 data.dli_du[i] = data.differential[i].Lu + np.dot(
                     data.differential[i].Lx, data.dy_du[i]
                 )
-
                 data.Luu_partialx[i] = np.dot(data.differential[i].Lxu.T, data.dy_du[i])
                 data.ddli_ddu[i] = (
                     data.differential[i].Luu
@@ -593,8 +593,6 @@ class IntegratedActionModelRK4Derived(crocoddyl.ActionModelAbstract):
                         data.dy_du[i].T, np.dot(data.differential[i].Lxx, data.dy_du[i])
                     )
                 )
-
-                # ---------Finding the derivative wrt x--------------
                 data.dy_dx[i] = dyi_dx + c * np.dot(dyi_ddx, data.dki_dx[i - 1])
                 data.dki_dx[i] = np.dot(data.dki_dy[i], data.dy_dx[i])
 
@@ -607,7 +605,6 @@ class IntegratedActionModelRK4Derived(crocoddyl.ActionModelAbstract):
                 ) + np.dot(
                     data.dy_dx[i].T, np.dot(data.differential[i].Lxx, data.dy_du[i])
                 )
-
             dxnext_dx, dxnext_ddx = self.state.Jintegrate(x, data.dx)
             ddx_dx = (
                 (
@@ -631,7 +628,6 @@ class IntegratedActionModelRK4Derived(crocoddyl.ActionModelAbstract):
             )
             data.Fx[:] = dxnext_dx + np.dot(dxnext_ddx, ddx_dx)
             data.Fu[:] = np.dot(dxnext_ddx, data.ddx_du)
-
             data.Lx[:] = (
                 (
                     data.dli_dx[0]
@@ -652,7 +648,6 @@ class IntegratedActionModelRK4Derived(crocoddyl.ActionModelAbstract):
                 * dt
                 / 6
             )
-
             data.Lxx[:] = (
                 (
                     data.ddli_ddx[0]
@@ -684,14 +679,6 @@ class IntegratedActionModelRK4Derived(crocoddyl.ActionModelAbstract):
                 / 6
             )
             data.Lux = data.Lxu.T
-        else:
-            data.Fx, _ = self.state.Jintegrate(x, data.dx)
-            data.Fu = np.zeros([self.ndx, self.nu])
-            data.Lu = data.differential[0].Lx
-            data.Lu = data.differential[0].Lu
-            data.Lxx = data.differential[0].Lxx
-            data.Luu = data.differential[0].Luu
-            data.Lxu = data.differential[0].Lxu
 
 
 class IntegratedActionDataRK4Derived(crocoddyl.ActionDataAbstract):

--- a/unittest/bindings/factory.py
+++ b/unittest/bindings/factory.py
@@ -469,7 +469,7 @@ class IntegratedActionModelEulerDerived(crocoddyl.ActionModelAbstract):
             dxnext_dx, _ = self.state.Jintegrate(x, data.dx)
             data.Fx[:, :] = dxnext_dx
             data.Lx[:] = data.differential.Lx
-            data.Lu[:] = data.differential.Lu
+            data.Lxx[:] = data.differential.Lxx
         else:
             nv, dt = self.state.nv, self.timeStep
             self.differential.calcDiff(data.differential, x, u)
@@ -521,8 +521,8 @@ class IntegratedActionModelRK4Derived(crocoddyl.ActionModelAbstract):
         if u is None:
             k0_data = data.differential[0]
             self.differential.calc(k0_data, x)
-            self.dx[:] *= 0.0
-            self.xnext[:] = x
+            data.dx[:] *= 0.0
+            data.xnext[:] = x
             data.cost = k0_data.cost
         else:
             nq, dt = self.nq, self.timeStep
@@ -706,7 +706,7 @@ class IntegratedActionDataRK4Derived(crocoddyl.ActionDataAbstract):
         self.Fu = self.F[:, ndx:]
 
         # Quantities for derivatives
-        self.dx = [np.zeros([ndx])] * 4
+        self.dx = np.zeros([ndx])
         self.y = [np.zeros([nx])] * 4
         self.acc = [np.zeros([nu])] * 4
 

--- a/unittest/bindings/test_actions.py
+++ b/unittest/bindings/test_actions.py
@@ -66,6 +66,44 @@ class ActionModelAbstractTestCase(unittest.TestCase):
                 "Wrong next state.",
             )
 
+    def test_calc_x(self):
+        # Run calc for both action models
+        self.MODEL.calc(self.DATA, self.x)
+        self.MODEL_DER.calc(self.DATA_DER, self.x)
+        # Checking the cost value and its residual
+        self.assertAlmostEqual(
+            self.DATA.cost, self.DATA_DER.cost, 10, "Wrong cost value."
+        )
+        self.assertTrue(
+            np.allclose(self.DATA.r, self.DATA_DER.r, atol=1e-9),
+            "Wrong cost residuals.",
+        )
+
+        if isinstance(self.MODEL, crocoddyl.ActionModelAbstract):
+            # Checking the dimension of the next state
+            self.assertEqual(
+                self.DATA.xnext.shape,
+                self.DATA_DER.xnext.shape,
+                "Wrong next state dimension.",
+            )
+            # Checking the next state value
+            self.assertTrue(
+                np.allclose(self.DATA.xnext, self.DATA_DER.xnext, atol=1e-9),
+                "Wrong next state.",
+            )
+        elif isinstance(self.MODEL, crocoddyl.DifferentialActionModelAbstract):
+            # Checking the dimension of the next state
+            self.assertEqual(
+                self.DATA.xout.shape,
+                self.DATA_DER.xout.shape,
+                "Wrong next state dimension.",
+            )
+            # Checking the next state value
+            self.assertTrue(
+                np.allclose(self.DATA.xout, self.DATA_DER.xout, atol=1e-9),
+                "Wrong next state.",
+            )
+
     def test_calcDiff(self):
         # Run calcDiff for both action models
         self.MODEL.calc(self.DATA, self.x, self.u)
@@ -106,6 +144,27 @@ class ActionModelAbstractTestCase(unittest.TestCase):
         )
         self.assertTrue(
             np.allclose(self.DATA.Luu, self.DATA_DER.Luu, atol=1e-9), "Wrong Luu."
+        )
+
+    def test_calcDiff_x(self):
+        # Run calcDiff for both action models
+        self.MODEL.calc(self.DATA, self.x)
+        self.MODEL.calcDiff(self.DATA, self.x)
+
+        self.MODEL_DER.calc(self.DATA_DER, self.x)
+        self.MODEL_DER.calcDiff(self.DATA_DER, self.x)
+        # Checking the next state value
+        if isinstance(self.MODEL, crocoddyl.ActionModelAbstract):
+            self.assertTrue(
+                np.allclose(self.DATA.xnext, self.DATA_DER.xnext, atol=1e-9),
+                "Wrong next state.",
+            )
+        # Checking the Jacobians and Hessians of the cost
+        self.assertTrue(
+            np.allclose(self.DATA.Lx, self.DATA_DER.Lx, atol=1e-9), "Wrong Lx."
+        )
+        self.assertTrue(
+            np.allclose(self.DATA.Lxx, self.DATA_DER.Lxx, atol=1e-9), "Wrong Lxx."
         )
 
 

--- a/unittest/bindings/test_costs.py
+++ b/unittest/bindings/test_costs.py
@@ -72,6 +72,19 @@ class CostModelAbstractTestCase(unittest.TestCase):
             "Wrong cost residuals.",
         )
 
+    def test_calc_x(self):
+        # Run calc for both action models
+        self.COST.calc(self.data, self.x)
+        self.COST_DER.calc(self.data_der, self.x)
+        # Checking the cost value and its residual
+        self.assertAlmostEqual(
+            self.data.cost, self.data_der.cost, 10, "Wrong cost value."
+        )
+        self.assertTrue(
+            np.allclose(self.data.residual.r, self.data_der.residual.r, atol=1e-9),
+            "Wrong cost residuals.",
+        )
+
     def test_calcDiff(self):
         # Run calc for both action models
         self.COST.calc(self.data, self.x, self.u)
@@ -102,6 +115,29 @@ class CostModelAbstractTestCase(unittest.TestCase):
         )
         self.assertTrue(
             np.allclose(self.data.Luu, self.data_der.Luu, atol=1e-9), "Wrong Luu."
+        )
+
+    def test_calcDiff_x(self):
+        # Run calc for both action models
+        self.COST.calc(self.data, self.x)
+        self.COST.calcDiff(self.data, self.x)
+
+        self.COST_DER.calc(self.data_der, self.x)
+        self.COST_DER.calcDiff(self.data_der, self.x)
+        # Checking the cost value and its residual
+        self.assertAlmostEqual(
+            self.data.cost, self.data_der.cost, 10, "Wrong cost value."
+        )
+        self.assertTrue(
+            np.allclose(self.data.residual.r, self.data_der.residual.r, atol=1e-9),
+            "Wrong cost residuals.",
+        )
+        # Checking the Jacobians and Hessians of the cost
+        self.assertTrue(
+            np.allclose(self.data.Lx, self.data_der.Lx, atol=1e-9), "Wrong Lx."
+        )
+        self.assertTrue(
+            np.allclose(self.data.Lxx, self.data_der.Lxx, atol=1e-9), "Wrong Lxx."
         )
 
 

--- a/unittest/bindings/test_shooting.py
+++ b/unittest/bindings/test_shooting.py
@@ -29,10 +29,6 @@ class ShootingProblemTestCase(unittest.TestCase):
         self.PROBLEM_DER = crocoddyl.ShootingProblem(
             self.xs[0], [self.MODEL_DER] * self.T, self.MODEL_DER
         )
-        # TODO(cmastalli): Remove the following lines once Crocoddyl supports
-        # multithreading with Python-derived models.
-        self.PROBLEM.nthreads = 1
-        self.PROBLEM_DER.nthreads = 1
 
     def test_number_of_nodes(self):
         self.assertEqual(self.T, self.PROBLEM.T, "Wrong number of nodes")

--- a/unittest/bindings/test_shooting.py
+++ b/unittest/bindings/test_shooting.py
@@ -22,7 +22,7 @@ class ShootingProblemTestCase(unittest.TestCase):
         self.xs.append(state.rand())
         for _ in range(self.T):
             self.xs.append(state.rand())
-            self.us.append(np.matrix(np.random.rand(self.MODEL.nu)).T)
+            self.us.append(np.random.rand(self.MODEL.nu))
         self.PROBLEM = crocoddyl.ShootingProblem(
             self.xs[0], [self.MODEL] * self.T, self.MODEL
         )


### PR DESCRIPTION
When a C++ implementation performs a terminal computation in a Python-derivated code, we pass `u=0` instead of calling `calc(data, x)` or `calcDiff(data, x)`. This behaviour in Python doesn't replicate our C++ code. Moreover, this creates bug in Python developers that are hard to track.

This PR solves the issue above-mentioned by calling the right function. To do so, the trick is to define `unone_ = NAN` for Python code and call the expected virtual function implemented in Python. This problem is fixed in all the classes, i.e.,
 - action models
 - differential action models
 - constraint models
 - cost models
 - residual models

To be clear, when we wish to run a terminal computation in Python, then we pass `u=None`. This is how users are expected to implement their classes, e.g.,
```python
import crocoddyl

class MyActionModel(crocoddyl.ActionModelAbstract):
    def __init__(self, state, nu):
        crocoddyl.ActionModelAbstract.__init__(self, state, nu)

    def calc(self, data, x, u=None):
        if u is None:
            # We run terminal node computations. For action models, the terminal value of `xnext = x`
            data.xnext[:] = x
            data.cost = "my value"  
        else:
            # We run running node computations.
            data.xnext[:] = "my value"
            data.cost = "my value"

    def calcDiff(self, data, x, u=None):
        if u is None:
            # We run terminal node computations. For action models, we just need to update Lx and Lxx
            data.Lx[:] = "my value"
            data.Lxx[:, :] = "my value"
        else:
            # We run running node computations.
            data.Lx[:] =  "my value"
            data.Lu[:] =  "my value"
            data.Lxx[:, :] =  "my value"
            data.Luu[:, :] =  "my value"
            data.Lxu[:, :] =  "my value"
```

Additionally, the PR extends Python-derived classes used for examples and unit testing. Finally, the PR extends the Python bindings test for the action, differential action and cost models.