### PR TITLE
Introduced floating base propeller actuation model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+* Introduced floating base propeller actuation model in https://github.com/loco-3d/crocoddyl/pull/1213
+* Fixed quadruped and biped examples in https://github.com/loco-3d/crocoddyl/pull/1208
+* Fixed terminal computation in Python models in https://github.com/loco-3d/crocoddyl/pull/1204
 * Fixed handling of unbounded values for `ActivationBounds` in https://github.com/loco-3d/crocoddyl/pull/1191
 
 ## [2.0.2] - 2023-12-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-* Introduced floating base propeller actuation model in https://github.com/loco-3d/crocoddyl/pull/1213
+* Introduced floating base thruster actuation model in https://github.com/loco-3d/crocoddyl/pull/1213
 * Fixed quadruped and biped examples in https://github.com/loco-3d/crocoddyl/pull/1208
 * Fixed terminal computation in Python models in https://github.com/loco-3d/crocoddyl/pull/1204
 * Fixed handling of unbounded values for `ActivationBounds` in https://github.com/loco-3d/crocoddyl/pull/1191

--- a/bindings/python/crocoddyl/multibody/actuations/floating-base-propellers.cpp
+++ b/bindings/python/crocoddyl/multibody/actuations/floating-base-propellers.cpp
@@ -6,8 +6,7 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "crocoddyl/multibody/actuations/floating-base-propellers.hpp"
-
+#include "crocoddyl/multibody/actuations/floating-base-thrusters.hpp"
 #include "python/crocoddyl/multibody/multibody.hpp"
 #include "python/crocoddyl/utils/copyable.hpp"
 #include "python/crocoddyl/utils/printable.hpp"
@@ -17,84 +16,83 @@ namespace crocoddyl {
 
 namespace python {
 
-void exposeActuationFloatingBasePropeller() {
-  bp::enum_<PropellerType>("PropellerType")
+void exposeActuationFloatingBaseThruster() {
+  bp::enum_<ThrusterType>("ThrusterType")
       .value("CW", CW)
       .value("CCW", CCW)
       .export_values();
 
-  bp::class_<Propeller>(
-      "Propeller", "Model for propellers",
-      bp::init<pinocchio::SE3, double, double, bp::optional<PropellerType>>(
-          bp::args("self", "M", "cthrust", "ctau", "type"),
-          "Initialize the propeller in a give pose from the root joint.\n\n"
+  bp::class_<Thruster>(
+      "Thruster", "Model for thrusters",
+      bp::init<pinocchio::SE3, double,
+               bp::optional<ThrusterType, double, double>>(
+          bp::args("self", "M", "ctorque", "type", "min_thrust", "max_thrust"),
+          "Initialize the thruster in a give pose from the root joint.\n\n"
           ":param M: pose from root joint\n"
-          ":param cthrust: coefficient of thrust (it relates propeller's "
-          "(square) velocity to its thrust)\n"
-          ":param ctau: coefficient of torque (it relates propeller's (square) "
-          "velocity to its torque)\n"
-          ":param type: type of propeller (clockwise or counterclockwise, "
-          "default clockwise)"))
-      .def(bp::init<double, double, bp::optional<PropellerType>>(
-          bp::args("self", "cthrust", "ctau", "type"),
-          "Initialize the propeller in a pose in the origin of the root "
-          "joint.\n\n"
-          ":param cthrust: coefficient of thrust (it relates propeller's "
-          "(square) velocity to its thrust)\n"
-          ":param ctau: coefficient of torque (it relates propeller's (square) "
-          "velocity to its torque)\n"
-          ":param type: type of propeller (clockwise or counterclockwise, "
-          "default clockwise)"))
-      .def_readwrite("pose", &Propeller::pose,
-                     "propeller pose (traslation, rotation)")
-      .def_readwrite("cthrust", &Propeller::cthrust, "coefficient of thrust")
-      .def_readwrite("ctorque", &Propeller::ctorque, "coefficient of torque")
-      .def_readwrite("type", &Propeller::type,
-                     "type of propeller (clockwise or counterclockwise)")
-      .def(PrintableVisitor<Propeller>())
-      .def(CopyableVisitor<Propeller>());
+          ":param ctorque: coefficient of generated torque per thrust\n"
+          ":param type: type of thruster (clockwise or counterclockwise, "
+          "default clockwise)\n"
+          ":param min_thrust: minimum thrust (default 0.)\n"
+          ":param max_thrust: maximum thrust (default np.inf)"))
+      .def(bp::init<double, bp::optional<ThrusterType, double, double>>(
+          bp::args("self", "ctorque", "type", "min_thrust", "max_thrust"),
+          "Initialize the thruster in a give pose from the root joint.\n\n"
+          ":param ctorque: coefficient of generated torque per thrust\n"
+          ":param type: type of thruster (clockwise or counterclockwise, "
+          "default clockwise)\n"
+          ":param min_thrust: minimum thrust (default 0.)\n"
+          ":param max_thrust: maximum thrust (default np.inf)"))
+      .def_readwrite("pose", &Thruster::pose,
+                     "thruster pose (traslation, rotation)")
+      .def_readwrite("ctorque", &Thruster::ctorque,
+                     "coefficient of generated torque per thrust")
+      .def_readwrite("type", &Thruster::type,
+                     "type of thruster (clockwise or counterclockwise)")
+      .def_readwrite("min_thrust", &Thruster::min_thrust, "minimum thrust")
+      .def_readwrite("max_thrust", &Thruster::min_thrust, "maximum thrust")
+      .def(PrintableVisitor<Thruster>())
+      .def(CopyableVisitor<Thruster>());
 
-  StdVectorPythonVisitor<std::vector<Propeller>, true>::expose(
-      "StdVec_Propeller");
+  StdVectorPythonVisitor<std::vector<Thruster>, true>::expose(
+      "StdVec_Thruster");
 
   bp::register_ptr_to_python<
-      boost::shared_ptr<crocoddyl::ActuationModelFloatingBasePropellers>>();
+      boost::shared_ptr<crocoddyl::ActuationModelFloatingBaseThrusters>>();
 
-  bp::class_<ActuationModelFloatingBasePropellers,
+  bp::class_<ActuationModelFloatingBaseThrusters,
              bp::bases<ActuationModelAbstract>>(
-      "ActuationModelFloatingBasePropellers",
-      "Actuation models for floating base systems actuated with propellers "
+      "ActuationModelFloatingBaseThrusters",
+      "Actuation models for floating base systems actuated with thrusters "
       "(e.g. aerial "
       "manipulators).",
-      bp::init<boost::shared_ptr<StateMultibody>, std::vector<Propeller>>(
-          bp::args("self", "state", "propellers"),
+      bp::init<boost::shared_ptr<StateMultibody>, std::vector<Thruster>>(
+          bp::args("self", "state", "thrusters"),
           "Initialize the floating base actuation model equipped with "
-          "propellers.\n\n"
+          "thrusters.\n\n"
           ":param state: state of multibody system\n"
-          ":param propellers: vector of propellers"))
-      .def<void (ActuationModelFloatingBasePropellers::*)(
+          ":param thrusters: vector of thrusters"))
+      .def<void (ActuationModelFloatingBaseThrusters::*)(
           const boost::shared_ptr<ActuationDataAbstract>&,
           const Eigen::Ref<const Eigen::VectorXd>&,
           const Eigen::Ref<const Eigen::VectorXd>&)>(
-          "calc", &ActuationModelFloatingBasePropellers::calc,
+          "calc", &ActuationModelFloatingBaseThrusters::calc,
           bp::args("self", "data", "x", "u"),
           "Compute the actuation signal and actuation set from the thrust\n"
           "forces and joint torque inputs u.\n\n"
-          ":param data: floating base propellers actuation data\n"
+          ":param data: floating base thrusters actuation data\n"
           ":param x: state point (dim. state.nx)\n"
           ":param u: joint torque input (dim. nu)")
-      .def(
-          "calcDiff", &ActuationModelFloatingBasePropellers::calcDiff,
-          bp::args("self", "data", "x", "u"),
-          "Compute the derivatives of the actuation model.\n\n"
-          "It computes the partial derivatives of the propeller actuation. It\n"
-          "assumes that calc has been run first. The reason is that the\n"
-          "derivatives are constant and defined in createData. The Hessian\n"
-          "is constant, so we don't write again this value.\n"
-          ":param data: floating base propellers actuation data\n"
-          ":param x: state point (dim. state.nx)\n"
-          ":param u: joint torque input (dim. nu)")
-      .def("commands", &ActuationModelFloatingBasePropellers::commands,
+      .def("calcDiff", &ActuationModelFloatingBaseThrusters::calcDiff,
+           bp::args("self", "data", "x", "u"),
+           "Compute the derivatives of the actuation model.\n\n"
+           "It computes the partial derivatives of the thruster actuation. It\n"
+           "assumes that calc has been run first. The reason is that the\n"
+           "derivatives are constant and defined in createData. The Hessian\n"
+           "is constant, so we don't write again this value.\n"
+           ":param data: floating base thrusters actuation data\n"
+           ":param x: state point (dim. state.nx)\n"
+           ":param u: joint torque input (dim. nu)")
+      .def("commands", &ActuationModelFloatingBaseThrusters::commands,
            bp::args("self", "data", "x", "tau"),
            "Compute the thrust and joint torque commands from the generalized "
            "torques.\n\n"
@@ -103,40 +101,40 @@ void exposeActuationFloatingBasePropeller() {
            ":param x: state point (dim. state.nx)\n"
            ":param tau: generalized torques (dim state.nv)")
       .def("torqueTransform",
-           &ActuationModelFloatingBasePropellers::torqueTransform,
+           &ActuationModelFloatingBaseThrusters::torqueTransform,
            bp::args("self", "data", "x", "tau"),
            "Compute the torque transform from generalized torques to thrust "
            "and joint torque inputs.\n\n"
            "It stores the results in data.Mtau.\n"
-           ":param data: floating base propellers actuation data\n"
+           ":param data: floating base thrusters actuation data\n"
            ":param x: state point (dim. state.nx)\n"
            ":param tau: generalized torques (dim state.nv)")
-      .def("createData", &ActuationModelFloatingBasePropellers::createData,
+      .def("createData", &ActuationModelFloatingBaseThrusters::createData,
            bp::args("self"),
-           "Create the floating base propellers actuation data.")
-      .add_property("propellers",
+           "Create the floating base thrusters actuation data.")
+      .add_property(
+          "thrusters",
+          bp::make_function(&ActuationModelFloatingBaseThrusters::get_thrusters,
+                            bp::return_value_policy<bp::return_by_value>()),
+          bp::make_function(
+              &ActuationModelFloatingBaseThrusters::set_thrusters),
+          "vector of thrusters")
+      .add_property("nthrusters",
                     bp::make_function(
-                        &ActuationModelFloatingBasePropellers::get_propellers,
-                        bp::return_value_policy<bp::return_by_value>()),
-                    bp::make_function(
-                        &ActuationModelFloatingBasePropellers::set_propellers),
-                    "vector of propellers")
-      .add_property("npropellers",
-                    bp::make_function(
-                        &ActuationModelFloatingBasePropellers::get_npropellers),
-                    "number of propellers")
+                        &ActuationModelFloatingBaseThrusters::get_nthrusters),
+                    "number of thrusters")
       .add_property(
           "Wthrust",
-          bp::make_function(&ActuationModelFloatingBasePropellers::get_Wthrust,
+          bp::make_function(&ActuationModelFloatingBaseThrusters::get_Wthrust,
                             bp::return_value_policy<bp::return_by_value>()),
-          "matrix mapping from thrusts to propeller wrenches")
+          "matrix mapping from thrusts to thruster wrenches")
       .add_property(
           "S",
-          bp::make_function(&ActuationModelFloatingBasePropellers::get_S,
+          bp::make_function(&ActuationModelFloatingBaseThrusters::get_S,
                             bp::return_value_policy<bp::return_by_value>()),
           "selection matrix for under-actuation part")
-      .def(PrintableVisitor<ActuationModelFloatingBasePropellers>())
-      .def(CopyableVisitor<ActuationModelFloatingBasePropellers>());
+      .def(PrintableVisitor<ActuationModelFloatingBaseThrusters>())
+      .def(CopyableVisitor<ActuationModelFloatingBaseThrusters>());
 }
 
 }  // namespace python

--- a/bindings/python/crocoddyl/multibody/actuations/floating-base-propellers.cpp
+++ b/bindings/python/crocoddyl/multibody/actuations/floating-base-propellers.cpp
@@ -1,0 +1,143 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2024-2024, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#include "crocoddyl/multibody/actuations/floating-base-propellers.hpp"
+
+#include "python/crocoddyl/multibody/multibody.hpp"
+#include "python/crocoddyl/utils/copyable.hpp"
+#include "python/crocoddyl/utils/printable.hpp"
+#include "python/crocoddyl/utils/vector-converter.hpp"
+
+namespace crocoddyl {
+
+namespace python {
+
+void exposeActuationFloatingBasePropeller() {
+  bp::enum_<PropellerType>("PropellerType")
+      .value("CW", CW)
+      .value("CCW", CCW)
+      .export_values();
+
+  bp::class_<Propeller>(
+      "Propeller", "Model for propellers",
+      bp::init<pinocchio::SE3, double, double, bp::optional<PropellerType>>(
+          bp::args("self", "M", "cthrust", "ctau", "type"),
+          "Initialize the propeller in a give pose from the root joint.\n\n"
+          ":param M: pose from root joint\n"
+          ":param cthrust: coefficient of thrust (it relates propeller's "
+          "(square) velocity to its thrust)\n"
+          ":param ctau: coefficient of torque (it relates propeller's (square) "
+          "velocity to its torque)\n"
+          ":param type: type of propeller (clockwise or counterclockwise, "
+          "default clockwise)"))
+      .def(bp::init<double, double, bp::optional<PropellerType>>(
+          bp::args("self", "cthrust", "ctau", "type"),
+          "Initialize the propeller in a pose in the origin of the root "
+          "joint.\n\n"
+          ":param cthrust: coefficient of thrust (it relates propeller's "
+          "(square) velocity to its thrust)\n"
+          ":param ctau: coefficient of torque (it relates propeller's (square) "
+          "velocity to its torque)\n"
+          ":param type: type of propeller (clockwise or counterclockwise, "
+          "default clockwise)"))
+      .def_readwrite("pose", &Propeller::pose,
+                     "propeller pose (traslation, rotation)")
+      .def_readwrite("cthrust", &Propeller::cthrust, "coefficient of thrust")
+      .def_readwrite("ctorque", &Propeller::ctorque, "coefficient of torque")
+      .def_readwrite("type", &Propeller::type,
+                     "type of propeller (clockwise or counterclockwise)")
+      .def(PrintableVisitor<Propeller>())
+      .def(CopyableVisitor<Propeller>());
+
+  StdVectorPythonVisitor<std::vector<Propeller>, true>::expose(
+      "StdVec_Propeller");
+
+  bp::register_ptr_to_python<
+      boost::shared_ptr<crocoddyl::ActuationModelFloatingBasePropellers>>();
+
+  bp::class_<ActuationModelFloatingBasePropellers,
+             bp::bases<ActuationModelAbstract>>(
+      "ActuationModelFloatingBasePropellers",
+      "Actuation models for floating base systems actuated with propellers "
+      "(e.g. aerial "
+      "manipulators).",
+      bp::init<boost::shared_ptr<StateMultibody>, std::vector<Propeller>>(
+          bp::args("self", "state", "propellers"),
+          "Initialize the floating base actuation model equipped with "
+          "propellers.\n\n"
+          ":param state: state of multibody system\n"
+          ":param propellers: vector of propellers"))
+      .def<void (ActuationModelFloatingBasePropellers::*)(
+          const boost::shared_ptr<ActuationDataAbstract>&,
+          const Eigen::Ref<const Eigen::VectorXd>&,
+          const Eigen::Ref<const Eigen::VectorXd>&)>(
+          "calc", &ActuationModelFloatingBasePropellers::calc,
+          bp::args("self", "data", "x", "u"),
+          "Compute the actuation signal and actuation set from the thrust\n"
+          "forces and joint torque inputs u.\n\n"
+          ":param data: floating base propellers actuation data\n"
+          ":param x: state point (dim. state.nx)\n"
+          ":param u: joint torque input (dim. nu)")
+      .def(
+          "calcDiff", &ActuationModelFloatingBasePropellers::calcDiff,
+          bp::args("self", "data", "x", "u"),
+          "Compute the derivatives of the actuation model.\n\n"
+          "It computes the partial derivatives of the propeller actuation. It\n"
+          "assumes that calc has been run first. The reason is that the\n"
+          "derivatives are constant and defined in createData. The Hessian\n"
+          "is constant, so we don't write again this value.\n"
+          ":param data: floating base propellers actuation data\n"
+          ":param x: state point (dim. state.nx)\n"
+          ":param u: joint torque input (dim. nu)")
+      .def("commands", &ActuationModelFloatingBasePropellers::commands,
+           bp::args("self", "data", "x", "tau"),
+           "Compute the thrust and joint torque commands from the generalized "
+           "torques.\n\n"
+           "It stores the results in data.u.\n"
+           ":param data: actuation data\n"
+           ":param x: state point (dim. state.nx)\n"
+           ":param tau: generalized torques (dim state.nv)")
+      .def("torqueTransform",
+           &ActuationModelFloatingBasePropellers::torqueTransform,
+           bp::args("self", "data", "x", "tau"),
+           "Compute the torque transform from generalized torques to thrust "
+           "and joint torque inputs.\n\n"
+           "It stores the results in data.Mtau.\n"
+           ":param data: floating base propellers actuation data\n"
+           ":param x: state point (dim. state.nx)\n"
+           ":param tau: generalized torques (dim state.nv)")
+      .def("createData", &ActuationModelFloatingBasePropellers::createData,
+           bp::args("self"),
+           "Create the floating base propellers actuation data.")
+      .add_property("propellers",
+                    bp::make_function(
+                        &ActuationModelFloatingBasePropellers::get_propellers,
+                        bp::return_value_policy<bp::return_by_value>()),
+                    bp::make_function(
+                        &ActuationModelFloatingBasePropellers::set_propellers),
+                    "vector of propellers")
+      .add_property("npropellers",
+                    bp::make_function(
+                        &ActuationModelFloatingBasePropellers::get_npropellers),
+                    "number of propellers")
+      .add_property(
+          "Wthrust",
+          bp::make_function(&ActuationModelFloatingBasePropellers::get_Wthrust,
+                            bp::return_value_policy<bp::return_by_value>()),
+          "matrix mapping from thrusts to propeller wrenches")
+      .add_property(
+          "S",
+          bp::make_function(&ActuationModelFloatingBasePropellers::get_S,
+                            bp::return_value_policy<bp::return_by_value>()),
+          "selection matrix for under-actuation part")
+      .def(PrintableVisitor<ActuationModelFloatingBasePropellers>())
+      .def(CopyableVisitor<ActuationModelFloatingBasePropellers>());
+}
+
+}  // namespace python
+}  // namespace crocoddyl

--- a/bindings/python/crocoddyl/multibody/multibody.cpp
+++ b/bindings/python/crocoddyl/multibody/multibody.cpp
@@ -18,7 +18,7 @@ void exposeMultibody() {
   exposeStateMultibody();
   exposeActuationFloatingBase();
   exposeActuationFull();
-  exposeActuationFloatingBasePropeller();
+  exposeActuationFloatingBaseThruster();
   exposeActuationModelMultiCopterBase();
   exposeForceAbstract();
   exposeContactAbstract();

--- a/bindings/python/crocoddyl/multibody/multibody.cpp
+++ b/bindings/python/crocoddyl/multibody/multibody.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2023, University of Edinburgh, Heriot-Watt University
+// Copyright (C) 2019-2024, University of Edinburgh, Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -18,6 +18,7 @@ void exposeMultibody() {
   exposeStateMultibody();
   exposeActuationFloatingBase();
   exposeActuationFull();
+  exposeActuationFloatingBasePropeller();
   exposeActuationModelMultiCopterBase();
   exposeForceAbstract();
   exposeContactAbstract();

--- a/bindings/python/crocoddyl/multibody/multibody.hpp
+++ b/bindings/python/crocoddyl/multibody/multibody.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2023, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2019-2024, LAAS-CNRS, University of Edinburgh
 //                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
@@ -23,6 +23,7 @@ void exposeCoPSupport();
 void exposeStateMultibody();
 void exposeActuationFloatingBase();
 void exposeActuationFull();
+void exposeActuationFloatingBasePropeller();
 void exposeActuationModelMultiCopterBase();
 void exposeForceAbstract();
 void exposeContactAbstract();
@@ -62,7 +63,6 @@ void exposeContact3D();
 void exposeContact6D();
 void exposeImpulse3D();
 void exposeImpulse6D();
-
 void exposeMultibody();
 
 }  // namespace python

--- a/bindings/python/crocoddyl/multibody/multibody.hpp
+++ b/bindings/python/crocoddyl/multibody/multibody.hpp
@@ -23,7 +23,7 @@ void exposeCoPSupport();
 void exposeStateMultibody();
 void exposeActuationFloatingBase();
 void exposeActuationFull();
-void exposeActuationFloatingBasePropeller();
+void exposeActuationFloatingBaseThruster();
 void exposeActuationModelMultiCopterBase();
 void exposeForceAbstract();
 void exposeContactAbstract();

--- a/examples/quadrotor_fwddyn.py
+++ b/examples/quadrotor_fwddyn.py
@@ -32,7 +32,35 @@ tau_f = np.array(
         [-cm / cf, cm / cf, -cm / cf, cm / cf],
     ]
 )
-actuation = crocoddyl.ActuationModelMultiCopterBase(state, tau_f)
+
+d_cog, cf, cm, u_lim, l_lim = 0.1525, 6.6e-5, 1e-6, 5.0, 0.1
+ps = [
+    crocoddyl.Propeller(
+        pinocchio.SE3(np.eye(3), np.array([d_cog, 0, 0])),
+        cf,
+        cm,
+        crocoddyl.PropellerType.CCW,
+    ),
+    crocoddyl.Propeller(
+        pinocchio.SE3(np.eye(3), np.array([0, d_cog, 0])),
+        cf,
+        cm,
+        crocoddyl.PropellerType.CW,
+    ),
+    crocoddyl.Propeller(
+        pinocchio.SE3(np.eye(3), np.array([-d_cog, 0, 0])),
+        cf,
+        cm,
+        crocoddyl.PropellerType.CCW,
+    ),
+    crocoddyl.Propeller(
+        pinocchio.SE3(np.eye(3), np.array([0, -d_cog, 0])),
+        cf,
+        cm,
+        crocoddyl.PropellerType.CW,
+    ),
+]
+actuation = crocoddyl.ActuationModelFloatingBasePropellers(state, ps)
 
 nu = actuation.nu
 runningCostModel = crocoddyl.CostModelSum(state, nu)

--- a/examples/quadrotor_fwddyn.py
+++ b/examples/quadrotor_fwddyn.py
@@ -22,45 +22,29 @@ target_quat = pinocchio.Quaternion(1.0, 0.0, 0.0, 0.0)
 state = crocoddyl.StateMultibody(robot_model)
 
 d_cog, cf, cm, u_lim, l_lim = 0.1525, 6.6e-5, 1e-6, 5.0, 0.1
-tau_f = np.array(
-    [
-        [0.0, 0.0, 0.0, 0.0],
-        [0.0, 0.0, 0.0, 0.0],
-        [1.0, 1.0, 1.0, 1.0],
-        [0.0, d_cog, 0.0, -d_cog],
-        [-d_cog, 0.0, d_cog, 0.0],
-        [-cm / cf, cm / cf, -cm / cf, cm / cf],
-    ]
-)
-
-d_cog, cf, cm, u_lim, l_lim = 0.1525, 6.6e-5, 1e-6, 5.0, 0.1
 ps = [
-    crocoddyl.Propeller(
+    crocoddyl.Thruster(
         pinocchio.SE3(np.eye(3), np.array([d_cog, 0, 0])),
-        cf,
-        cm,
-        crocoddyl.PropellerType.CCW,
+        cm / cf,
+        crocoddyl.ThrusterType.CCW,
     ),
-    crocoddyl.Propeller(
+    crocoddyl.Thruster(
         pinocchio.SE3(np.eye(3), np.array([0, d_cog, 0])),
-        cf,
-        cm,
-        crocoddyl.PropellerType.CW,
+        cm / cf,
+        crocoddyl.ThrusterType.CW,
     ),
-    crocoddyl.Propeller(
+    crocoddyl.Thruster(
         pinocchio.SE3(np.eye(3), np.array([-d_cog, 0, 0])),
-        cf,
-        cm,
-        crocoddyl.PropellerType.CCW,
+        cm / cf,
+        crocoddyl.ThrusterType.CCW,
     ),
-    crocoddyl.Propeller(
+    crocoddyl.Thruster(
         pinocchio.SE3(np.eye(3), np.array([0, -d_cog, 0])),
-        cf,
-        cm,
-        crocoddyl.PropellerType.CW,
+        cm / cf,
+        crocoddyl.ThrusterType.CW,
     ),
 ]
-actuation = crocoddyl.ActuationModelFloatingBasePropellers(state, ps)
+actuation = crocoddyl.ActuationModelFloatingBaseThrusters(state, ps)
 
 nu = actuation.nu
 runningCostModel = crocoddyl.CostModelSum(state, nu)

--- a/examples/quadrotor_invdyn.py
+++ b/examples/quadrotor_invdyn.py
@@ -22,17 +22,33 @@ target_quat = pinocchio.Quaternion(1.0, 0.0, 0.0, 0.0)
 state = crocoddyl.StateMultibody(robot_model)
 
 d_cog, cf, cm, u_lim, l_lim = 0.1525, 6.6e-5, 1e-6, 5.0, 0.1
-tau_f = np.array(
-    [
-        [0.0, 0.0, 0.0, 0.0],
-        [0.0, 0.0, 0.0, 0.0],
-        [1.0, 1.0, 1.0, 1.0],
-        [0.0, d_cog, 0.0, -d_cog],
-        [-d_cog, 0.0, d_cog, 0.0],
-        [-cm / cf, cm / cf, -cm / cf, cm / cf],
-    ]
-)
-actuation = crocoddyl.ActuationModelMultiCopterBase(state, tau_f)
+ps = [
+    crocoddyl.Propeller(
+        pinocchio.SE3(np.eye(3), np.array([d_cog, 0, 0])),
+        cf,
+        cm,
+        crocoddyl.PropellerType.CCW,
+    ),
+    crocoddyl.Propeller(
+        pinocchio.SE3(np.eye(3), np.array([0, d_cog, 0])),
+        cf,
+        cm,
+        crocoddyl.PropellerType.CW,
+    ),
+    crocoddyl.Propeller(
+        pinocchio.SE3(np.eye(3), np.array([-d_cog, 0, 0])),
+        cf,
+        cm,
+        crocoddyl.PropellerType.CCW,
+    ),
+    crocoddyl.Propeller(
+        pinocchio.SE3(np.eye(3), np.array([0, -d_cog, 0])),
+        cf,
+        cm,
+        crocoddyl.PropellerType.CW,
+    ),
+]
+actuation = crocoddyl.ActuationModelFloatingBasePropellers(state, ps)
 
 nu = state.nv
 runningCostModel = crocoddyl.CostModelSum(state, nu)

--- a/examples/quadrotor_invdyn.py
+++ b/examples/quadrotor_invdyn.py
@@ -23,32 +23,28 @@ state = crocoddyl.StateMultibody(robot_model)
 
 d_cog, cf, cm, u_lim, l_lim = 0.1525, 6.6e-5, 1e-6, 5.0, 0.1
 ps = [
-    crocoddyl.Propeller(
+    crocoddyl.Thruster(
         pinocchio.SE3(np.eye(3), np.array([d_cog, 0, 0])),
-        cf,
-        cm,
-        crocoddyl.PropellerType.CCW,
+        cm / cf,
+        crocoddyl.ThrusterType.CCW,
     ),
-    crocoddyl.Propeller(
+    crocoddyl.Thruster(
         pinocchio.SE3(np.eye(3), np.array([0, d_cog, 0])),
-        cf,
-        cm,
-        crocoddyl.PropellerType.CW,
+        cm / cf,
+        crocoddyl.ThrusterType.CW,
     ),
-    crocoddyl.Propeller(
+    crocoddyl.Thruster(
         pinocchio.SE3(np.eye(3), np.array([-d_cog, 0, 0])),
-        cf,
-        cm,
-        crocoddyl.PropellerType.CCW,
+        cm / cf,
+        crocoddyl.ThrusterType.CCW,
     ),
-    crocoddyl.Propeller(
+    crocoddyl.Thruster(
         pinocchio.SE3(np.eye(3), np.array([0, -d_cog, 0])),
-        cf,
-        cm,
-        crocoddyl.PropellerType.CW,
+        cm / cf,
+        crocoddyl.ThrusterType.CW,
     ),
 ]
-actuation = crocoddyl.ActuationModelFloatingBasePropellers(state, ps)
+actuation = crocoddyl.ActuationModelFloatingBaseThrusters(state, ps)
 
 nu = state.nv
 runningCostModel = crocoddyl.CostModelSum(state, nu)

--- a/examples/quadrotor_ubound.py
+++ b/examples/quadrotor_ubound.py
@@ -23,32 +23,28 @@ state = crocoddyl.StateMultibody(robot_model)
 
 d_cog, cf, cm, u_lim, l_lim = 0.1525, 6.6e-5, 1e-6, 5.0, 0.1
 ps = [
-    crocoddyl.Propeller(
+    crocoddyl.Thruster(
         pinocchio.SE3(np.eye(3), np.array([d_cog, 0, 0])),
-        cf,
-        cm,
-        crocoddyl.PropellerType.CCW,
+        cm / cf,
+        crocoddyl.ThrusterType.CCW,
     ),
-    crocoddyl.Propeller(
+    crocoddyl.Thruster(
         pinocchio.SE3(np.eye(3), np.array([0, d_cog, 0])),
-        cf,
-        cm,
-        crocoddyl.PropellerType.CW,
+        cm / cf,
+        crocoddyl.ThrusterType.CW,
     ),
-    crocoddyl.Propeller(
+    crocoddyl.Thruster(
         pinocchio.SE3(np.eye(3), np.array([-d_cog, 0, 0])),
-        cf,
-        cm,
-        crocoddyl.PropellerType.CCW,
+        cm / cf,
+        crocoddyl.ThrusterType.CCW,
     ),
-    crocoddyl.Propeller(
+    crocoddyl.Thruster(
         pinocchio.SE3(np.eye(3), np.array([0, -d_cog, 0])),
-        cf,
-        cm,
-        crocoddyl.PropellerType.CW,
+        cm / cf,
+        crocoddyl.ThrusterType.CW,
     ),
 ]
-actuation = crocoddyl.ActuationModelFloatingBasePropellers(state, ps)
+actuation = crocoddyl.ActuationModelFloatingBaseThrusters(state, ps)
 
 nu = actuation.nu
 runningCostModel = crocoddyl.CostModelSum(state, nu)

--- a/examples/quadrotor_ubound.py
+++ b/examples/quadrotor_ubound.py
@@ -22,17 +22,33 @@ target_quat = pinocchio.Quaternion(1.0, 0.0, 0.0, 0.0)
 state = crocoddyl.StateMultibody(robot_model)
 
 d_cog, cf, cm, u_lim, l_lim = 0.1525, 6.6e-5, 1e-6, 5.0, 0.1
-tau_f = np.array(
-    [
-        [0.0, 0.0, 0.0, 0.0],
-        [0.0, 0.0, 0.0, 0.0],
-        [1.0, 1.0, 1.0, 1.0],
-        [0.0, d_cog, 0.0, -d_cog],
-        [-d_cog, 0.0, d_cog, 0.0],
-        [-cm / cf, cm / cf, -cm / cf, cm / cf],
-    ]
-)
-actuation = crocoddyl.ActuationModelMultiCopterBase(state, tau_f)
+ps = [
+    crocoddyl.Propeller(
+        pinocchio.SE3(np.eye(3), np.array([d_cog, 0, 0])),
+        cf,
+        cm,
+        crocoddyl.PropellerType.CCW,
+    ),
+    crocoddyl.Propeller(
+        pinocchio.SE3(np.eye(3), np.array([0, d_cog, 0])),
+        cf,
+        cm,
+        crocoddyl.PropellerType.CW,
+    ),
+    crocoddyl.Propeller(
+        pinocchio.SE3(np.eye(3), np.array([-d_cog, 0, 0])),
+        cf,
+        cm,
+        crocoddyl.PropellerType.CCW,
+    ),
+    crocoddyl.Propeller(
+        pinocchio.SE3(np.eye(3), np.array([0, -d_cog, 0])),
+        cf,
+        cm,
+        crocoddyl.PropellerType.CW,
+    ),
+]
+actuation = crocoddyl.ActuationModelFloatingBasePropellers(state, ps)
 
 nu = actuation.nu
 runningCostModel = crocoddyl.CostModelSum(state, nu)

--- a/include/crocoddyl/core/numdiff/actuation.hpp
+++ b/include/crocoddyl/core/numdiff/actuation.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2023, University of Edinburgh, LAAS-CNRS
+// Copyright (C) 2019-2024, University of Edinburgh, LAAS-CNRS
 //                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
@@ -89,6 +89,13 @@ class ActuationModelNumDiffTpl : public ActuationModelAbstractTpl<_Scalar> {
   virtual void commands(const boost::shared_ptr<ActuationDataAbstract>& data,
                         const Eigen::Ref<const VectorXs>& x,
                         const Eigen::Ref<const VectorXs>& tau);
+
+  /**
+   * @brief @copydoc Base::torqueTransform()
+   */
+  virtual void torqueTransform(
+      const boost::shared_ptr<ActuationDataAbstract>& data,
+      const Eigen::Ref<const VectorXs>& x, const Eigen::Ref<const VectorXs>& u);
 
   /**
    * @brief @copydoc Base::createData()

--- a/include/crocoddyl/core/numdiff/actuation.hxx
+++ b/include/crocoddyl/core/numdiff/actuation.hxx
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2023, University of Edinburgh, LAAS-CNRS
+// Copyright (C) 2019-2024, University of Edinburgh, LAAS-CNRS
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -140,7 +140,8 @@ void ActuationModelNumDiffTpl<Scalar>::commands(
   Data* d = static_cast<Data*>(data.get());
 
   model_->torqueTransform(d->data_x[0], x, tau);
-  data->u.noalias() = d->data_x[0]->Mtau * tau;
+  d->Mtau = d->data_x[0]->Mtau;
+  data->u.noalias() = d->Mtau * tau;
 }
 
 template <typename Scalar>

--- a/include/crocoddyl/core/numdiff/actuation.hxx
+++ b/include/crocoddyl/core/numdiff/actuation.hxx
@@ -138,10 +138,27 @@ void ActuationModelNumDiffTpl<Scalar>::commands(
                         std::to_string(model_->get_state()->get_nv()) + ")");
   }
   Data* d = static_cast<Data*>(data.get());
+  model_->commands(d->data_0, x, tau);
+  data->u = d->data_0->u;
+}
 
-  model_->torqueTransform(d->data_x[0], x, tau);
-  d->Mtau = d->data_x[0]->Mtau;
-  data->u.noalias() = d->Mtau * tau;
+template <typename Scalar>
+void ActuationModelNumDiffTpl<Scalar>::torqueTransform(
+    const boost::shared_ptr<ActuationDataAbstract>& data,
+    const Eigen::Ref<const VectorXs>& x, const Eigen::Ref<const VectorXs>& u) {
+  if (static_cast<std::size_t>(x.size()) != model_->get_state()->get_nx()) {
+    throw_pretty("Invalid argument: "
+                 << "x has wrong dimension (it should be " +
+                        std::to_string(model_->get_state()->get_nx()) + ")");
+  }
+  if (static_cast<std::size_t>(u.size()) != nu_) {
+    throw_pretty("Invalid argument: "
+                 << "u has wrong dimension (it should be " +
+                        std::to_string(nu_) + ")");
+  }
+  Data* d = static_cast<Data*>(data.get());
+  model_->torqueTransform(d->data_0, x, u);
+  d->Mtau = d->data_0->Mtau;
 }
 
 template <typename Scalar>

--- a/include/crocoddyl/multibody/actuations/floating-base-propellers.hpp
+++ b/include/crocoddyl/multibody/actuations/floating-base-propellers.hpp
@@ -1,0 +1,341 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2014-2024, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef CROCODDYL_MULTIBODY_ACTUATIONS_PROPELLERS_HPP_
+#define CROCODDYL_MULTIBODY_ACTUATIONS_PROPELLERS_HPP_
+
+#include <pinocchio/multibody/fwd.hpp>
+#include <pinocchio/spatial/se3.hpp>
+#include <vector>
+
+#include "crocoddyl/core/actuation-base.hpp"
+#include "crocoddyl/core/utils/exception.hpp"
+#include "crocoddyl/multibody/states/multibody.hpp"
+
+namespace crocoddyl {
+
+enum PropellerType { CW = 0, CCW };
+
+template <typename _Scalar>
+struct PropellerTpl {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  typedef _Scalar Scalar;
+  typedef pinocchio::SE3Tpl<Scalar> SE3;
+  typedef PropellerTpl<Scalar> Propeller;
+
+  /**
+   * @brief Initialize the propeller in a give pose from the root joint.
+   *
+   * @param pose[in]     Pose from root joint
+   * @param cthrust[in]  Coefficient of thrust (it relates propeller's (square)
+   * velocity to its thrust)
+   * @param ctorque[in]  Coefficient of torque (it relates propeller's (square)
+   * velocity to its torque)
+   * @param type[in]     Type of propeller (clockwise or counterclockwise,
+   * default clockwise)
+   */
+  PropellerTpl(const SE3& pose, const Scalar cthrust, const Scalar ctorque,
+               const PropellerType type = CW)
+      : pose(pose), cthrust(cthrust), ctorque(ctorque), type(type) {}
+
+  /**
+   * @brief Initialize the propeller in a pose in the origin of the root joint.
+   *
+   * @param cthrust[in]  Coefficient of thrust (it relates propeller's (square)
+   * velocity to its thrust)
+   * @param ctorque[in]  Coefficient of torque (it relates propeller's (square)
+   * velocity to its torque)
+   * @param type[in]     Type of propeller (clockwise or counterclockwise,
+   * default clockwise)
+   */
+  PropellerTpl(const Scalar cthrust, const Scalar ctorque,
+               const PropellerType type = CW)
+      : pose(SE3::Identity()), cthrust(cthrust), ctorque(ctorque), type(type) {}
+  PropellerTpl(const PropellerTpl<Scalar>& clone)
+      : pose(clone.pose),
+        cthrust(clone.cthrust),
+        ctorque(clone.ctorque),
+        type(clone.type) {}
+
+  PropellerTpl& operator=(const PropellerTpl<Scalar>& other) {
+    if (this != &other) {
+      pose = other.pose;
+      cthrust = other.cthrust;
+      ctorque = other.ctorque;
+      type = other.type;
+    }
+    return *this;
+  }
+
+  template <typename OtherScalar>
+  bool operator==(const PropellerTpl<OtherScalar>& other) const {
+    return (pose == other.pose && cthrust == other.cthrust &&
+            ctorque == other.ctorque && type == other.type);
+  }
+
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const PropellerTpl<Scalar>& X) {
+    os << "   pose:" << std::endl
+       << X.pose << "cthrust: " << X.cthrust << std::endl
+       << "ctorque: " << X.ctorque << std::endl
+       << "   type: " << X.type << std::endl;
+    return os;
+  }
+
+  SE3 pose;            //!< Propeller pose
+  Scalar cthrust;      //!< Coefficient of thrust (it relates the square of the
+                       //!< propeller velocity with its thrust)
+  Scalar ctorque;      //!< Coefficient of torque (it relates the square of the
+                       //!< propeller velocity with its torque)
+  PropellerType type;  //!< Type of propeller (CW and CCW for clockwise and
+                       //!< counterclockwise, respectively)
+};
+
+/**
+ * @brief Actuation models for floating base systems actuated with propellers
+ *
+ * This actuation model models floating base robots equipped with propellers,
+ * e.g., multicopters or marine robots equipped with manipulators. It control
+ * inputs are the propellers' thrust (i.e., forces) and joint torques.
+ *
+ * Both actuation and Jacobians are computed analytically by `calc` and
+ * `calcDiff`, respectively.
+ *
+ * We assume the robot velocity to zero for easily related square propeller
+ * velocities with thrust and torque generated. This approach is similarly
+ * implemented in M. Geisert and N. Mansard, "Trajectory generation for
+ * quadrotor based systems using numerical optimal control", (ICRA). See Section
+ * III.C.
+ *
+ * \sa `ActuationModelAbstractTpl`, `calc()`, `calcDiff()`, `createData()`
+ */
+template <typename _Scalar>
+class ActuationModelFloatingBasePropellersTpl
+    : public ActuationModelAbstractTpl<_Scalar> {
+ public:
+  typedef _Scalar Scalar;
+  typedef MathBaseTpl<Scalar> MathBase;
+  typedef ActuationModelAbstractTpl<Scalar> Base;
+  typedef ActuationDataAbstractTpl<Scalar> Data;
+  typedef StateMultibodyTpl<Scalar> StateMultibody;
+  typedef PropellerTpl<Scalar> Propeller;
+  typedef typename MathBase::Vector3s Vector3s;
+  typedef typename MathBase::VectorXs VectorXs;
+  typedef typename MathBase::MatrixXs MatrixXs;
+
+  /**
+   * @brief Initialize the floating base actuation model equipped with
+   * propellers
+   *
+   * @param[in] state       State of the dynamical system
+   * @param[in] propellers  Vector of propellers
+   */
+  ActuationModelFloatingBasePropellersTpl(
+      boost::shared_ptr<StateMultibody> state,
+      const std::vector<Propeller>& propellers)
+      : Base(state,
+             state->get_nv() -
+                 state->get_pinocchio()
+                     ->joints[(
+                         state->get_pinocchio()->existJointName("root_joint")
+                             ? state->get_pinocchio()->getJointId("root_joint")
+                             : 0)]
+                     .nv() +
+                 propellers.size()),
+        propellers_(propellers),
+        n_propellers_(propellers.size()),
+        W_thrust_(state_->get_nv(), nu_),
+        update_data_(true) {
+    if (!state->get_pinocchio()->existJointName("root_joint")) {
+      throw_pretty(
+          "Invalid argument: "
+          << "the first joint has to be a root one (e.g., free-flyer joint)");
+    }
+    // Update the joint actuation part
+    W_thrust_.setZero();
+    if (nu_ > n_propellers_) {
+      W_thrust_
+          .template bottomRightCorner(nu_ - n_propellers_, nu_ - n_propellers_)
+          .diagonal()
+          .setOnes();
+    }
+    // Update the floating base actuation part
+    set_propellers(propellers_);
+  }
+  virtual ~ActuationModelFloatingBasePropellersTpl() {}
+
+  /**
+   * @brief Compute the actuation signal and actuation set from its thrust
+   * and joint torque inputs \f$\mathbf{u}\in\mathbb{R}^{nu}\f$
+   *
+   * @param[in] data  Floating base propellers actuation data
+   * @param[in] x     State point \f$\mathbf{x}\in\mathbb{R}^{ndx}\f$
+   * @param[in] u     Joint-torque input \f$\mathbf{u}\in\mathbb{R}^{nu}\f$
+   */
+  virtual void calc(const boost::shared_ptr<Data>& data,
+                    const Eigen::Ref<const VectorXs>&,
+                    const Eigen::Ref<const VectorXs>& u) {
+    if (static_cast<std::size_t>(u.size()) != nu_) {
+      throw_pretty("Invalid argument: "
+                   << "u has wrong dimension (it should be " +
+                          std::to_string(nu_) + ")");
+    }
+    if (update_data_) {
+      updateData(data);
+    }
+    data->tau.noalias() = data->dtau_du * u;
+  }
+
+  /**
+   * @brief Compute the Jacobians of the floating base propeller actuation
+   * function
+   *
+   * @param[in] data  Floating base propellers actuation data
+   * @param[in] x     State point \f$\mathbf{x}\in\mathbb{R}^{ndx}\f$
+   * @param[in] u     Joint-torque input \f$\mathbf{u}\in\mathbb{R}^{nu}\f$
+   */
+#ifndef NDEBUG
+  virtual void calcDiff(const boost::shared_ptr<Data>& data,
+                        const Eigen::Ref<const VectorXs>&,
+                        const Eigen::Ref<const VectorXs>&) {
+#else
+  virtual void calcDiff(const boost::shared_ptr<Data>&,
+                        const Eigen::Ref<const VectorXs>&,
+                        const Eigen::Ref<const VectorXs>&) {
+#endif
+    // The derivatives has constant values which were set in createData.
+    assert_pretty(MatrixXs(data->dtau_du).isApprox(W_thrust_),
+                  "dtau_du has wrong value");
+  }
+
+  virtual void commands(const boost::shared_ptr<Data>& data,
+                        const Eigen::Ref<const VectorXs>&,
+                        const Eigen::Ref<const VectorXs>& tau) {
+    data->u.noalias() = data->Mtau * tau;
+  }
+
+#ifndef NDEBUG
+  virtual void torqueTransform(const boost::shared_ptr<Data>& data,
+                               const Eigen::Ref<const VectorXs>&,
+                               const Eigen::Ref<const VectorXs>&) {
+#else
+  virtual void torqueTransform(const boost::shared_ptr<Data>&,
+                               const Eigen::Ref<const VectorXs>&,
+                               const Eigen::Ref<const VectorXs>&) {
+#endif
+    // The torque transform has constant values which were set in createData.
+    assert_pretty(MatrixXs(data->Mtau).isApprox(Mtau_), "Mtau has wrong value");
+  }
+
+  /**
+   * @brief Create the floating base propeller actuation data
+   *
+   * @return the actuation data
+   */
+  virtual boost::shared_ptr<Data> createData() {
+    boost::shared_ptr<Data> data =
+        boost::allocate_shared<Data>(Eigen::aligned_allocator<Data>(), this);
+    updateData(data);
+    return data;
+  }
+
+  /**
+   * @brief Return the vector of propellers
+   */
+  const std::vector<Propeller>& get_propellers() const { return propellers_; }
+
+  /**
+   * @brief Return the number of propellers
+   */
+  std::size_t get_npropellers() const { return n_propellers_; }
+
+  /**
+   * @brief Modify the vector of propellers
+   *
+   * Since we don't want to allocate data, we request to pass the same
+   * number of propellers.
+   *
+   * @param[in] propellers  Vector of propellers
+   */
+  void set_propellers(const std::vector<Propeller>& propellers) {
+    if (static_cast<std::size_t>(propellers.size()) != n_propellers_) {
+      throw_pretty("Invalid argument: "
+                   << "the number of propellers is wrong (it should be " +
+                          std::to_string(n_propellers_) + ")");
+    }
+    propellers_ = propellers;
+    // Update the mapping matrix from propellers thrust to body force/moments
+    for (std::size_t i = 0; i < n_propellers_; ++i) {
+      const Propeller& p = propellers_[i];
+      const Vector3s& f_z = p.pose.rotation() * Vector3s::UnitZ();
+      W_thrust_.template topRows<3>().col(i) += f_z;
+      W_thrust_.template middleRows<3>(3).col(i).noalias() +=
+          p.pose.translation().cross(Vector3s::UnitZ());
+      switch (p.type) {
+        case CW:
+          W_thrust_.template middleRows<3>(3).col(i) +=
+              (p.ctorque / p.cthrust) * f_z;
+          break;
+        case CCW:
+          W_thrust_.template middleRows<3>(3).col(i) -=
+              (p.ctorque / p.cthrust) * f_z;
+          break;
+      }
+    }
+    // Compute the torque transform matrix from generalized torques to joint
+    // torque inputs
+    Mtau_ = pseudoInverse(MatrixXs(W_thrust_));
+    S_.noalias() = W_thrust_ * Mtau_;
+    update_data_ = true;
+  }
+
+  const MatrixXs& get_Wthrust() const { return W_thrust_; }
+
+  const MatrixXs& get_S() const { return S_; }
+
+  void print(std::ostream& os) const {
+    os << "ActuationModelFloatingBasePropellers {nu=" << nu_
+       << ", npropellers=" << n_propellers_ << ", propellers=" << std::endl;
+    for (std::size_t i = 0; i < n_propellers_; ++i) {
+      os << std::to_string(i) << ": " << propellers_[i];
+    }
+    os << "}";
+  }
+
+ protected:
+  std::vector<Propeller> propellers_;  //!< Vector of propellers
+  std::size_t n_propellers_;           //!< Number of propellers
+  MatrixXs W_thrust_;  //!< Matrix from propellers thrusts to body wrench
+  MatrixXs Mtau_;  //!< Constaint torque transform from generalized torques to
+                   //!< joint torque inputs
+  MatrixXs S_;     //!< Selection matrix for under-actuation part
+
+  bool update_data_;
+  using Base::nu_;
+  using Base::state_;
+
+ private:
+  void updateData(const boost::shared_ptr<Data>& data) {
+    data->dtau_du = W_thrust_;
+    data->Mtau = Mtau_;
+    const std::size_t nv = state_->get_nv();
+    for (std::size_t k = 0; k < nv; ++k) {
+      if (fabs(S_(k, k)) < std::numeric_limits<Scalar>::epsilon()) {
+        data->tau_set[k] = false;
+      } else {
+        data->tau_set[k] = true;
+      }
+    }
+    update_data_ = false;
+  }
+};
+
+}  // namespace crocoddyl
+
+#endif  // CROCODDYL_MULTIBODY_ACTUATIONS_PROPELLERS_HPP_

--- a/include/crocoddyl/multibody/actuations/multicopter-base.hpp
+++ b/include/crocoddyl/multibody/actuations/multicopter-base.hpp
@@ -59,7 +59,7 @@ class ActuationModelMultiCopterBaseTpl
    * @param[in] tau_f  Matrix that maps the thrust of each propeller to the net
    * force and torque
    */
-  DEPRECATED("Use constructor ActuationModelFloatingBasePropellersTpl",
+  DEPRECATED("Use constructor ActuationModelFloatingBaseThrustersTpl",
              ActuationModelMultiCopterBaseTpl(
                  boost::shared_ptr<StateMultibody> state,
                  const Eigen::Ref<const Matrix6xs>& tau_f));
@@ -166,7 +166,7 @@ ActuationModelMultiCopterBaseTpl<Scalar>::ActuationModelMultiCopterBaseTpl(
   }
   Mtau_ = pseudoInverse(MatrixXs(tau_f));
   std::cerr << "Deprecated ActuationModelMultiCopterBase: Use "
-               "ActuationModelFloatingBasePropellers"
+               "ActuationModelFloatingBaseThrusters"
             << std::endl;
 }
 

--- a/include/crocoddyl/multibody/actuations/multicopter-base.hpp
+++ b/include/crocoddyl/multibody/actuations/multicopter-base.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2022, LAAS-CNRS, IRI: CSIC-UPC, University of Edinburgh
+// Copyright (C) 2019-2024, LAAS-CNRS, IRI: CSIC-UPC, University of Edinburgh
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -59,25 +59,10 @@ class ActuationModelMultiCopterBaseTpl
    * @param[in] tau_f  Matrix that maps the thrust of each propeller to the net
    * force and torque
    */
-  ActuationModelMultiCopterBaseTpl(boost::shared_ptr<StateMultibody> state,
-                                   const Eigen::Ref<const Matrix6xs>& tau_f)
-      : Base(state, state->get_nv() - 6 + tau_f.cols()),
-        n_rotors_(tau_f.cols()) {
-    pinocchio::JointModelFreeFlyerTpl<Scalar> ff_joint;
-    if (state->get_pinocchio()->joints[1].shortname() != ff_joint.shortname()) {
-      throw_pretty("Invalid argument: "
-                   << "the first joint has to be free-flyer");
-    }
-
-    tau_f_ = MatrixXs::Zero(state_->get_nv(), nu_);
-    tau_f_.block(0, 0, 6, n_rotors_) = tau_f;
-    if (nu_ > n_rotors_) {
-      tau_f_.bottomRightCorner(nu_ - n_rotors_, nu_ - n_rotors_)
-          .diagonal()
-          .setOnes();
-    }
-    Mtau_ = pseudoInverse(MatrixXs(tau_f));
-  }
+  DEPRECATED("Use constructor ActuationModelFloatingBasePropellersTpl",
+             ActuationModelMultiCopterBaseTpl(
+                 boost::shared_ptr<StateMultibody> state,
+                 const Eigen::Ref<const Matrix6xs>& tau_f));
 
   DEPRECATED("Use constructor without n_rotors",
              ActuationModelMultiCopterBaseTpl(
@@ -160,6 +145,30 @@ class ActuationModelMultiCopterBaseTpl
   MatrixXs S_;
 #endif
 };
+
+template <typename Scalar>
+ActuationModelMultiCopterBaseTpl<Scalar>::ActuationModelMultiCopterBaseTpl(
+    boost::shared_ptr<StateMultibody> state,
+    const Eigen::Ref<const Matrix6xs>& tau_f)
+    : Base(state, state->get_nv() - 6 + tau_f.cols()), n_rotors_(tau_f.cols()) {
+  pinocchio::JointModelFreeFlyerTpl<Scalar> ff_joint;
+  if (state->get_pinocchio()->joints[1].shortname() != ff_joint.shortname()) {
+    throw_pretty("Invalid argument: "
+                 << "the first joint has to be free-flyer");
+  }
+
+  tau_f_ = MatrixXs::Zero(state_->get_nv(), nu_);
+  tau_f_.block(0, 0, 6, n_rotors_) = tau_f;
+  if (nu_ > n_rotors_) {
+    tau_f_.bottomRightCorner(nu_ - n_rotors_, nu_ - n_rotors_)
+        .diagonal()
+        .setOnes();
+  }
+  Mtau_ = pseudoInverse(MatrixXs(tau_f));
+  std::cerr << "Deprecated ActuationModelMultiCopterBase: Use "
+               "ActuationModelFloatingBasePropellers"
+            << std::endl;
+}
 
 template <typename Scalar>
 ActuationModelMultiCopterBaseTpl<Scalar>::ActuationModelMultiCopterBaseTpl(

--- a/include/crocoddyl/multibody/fwd.hpp
+++ b/include/crocoddyl/multibody/fwd.hpp
@@ -1,7 +1,8 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2022, LAAS-CNRS, University of Edinburgh, INRIA
+// Copyright (C) 2019-2024, LAAS-CNRS, University of Edinburgh, INRIA
+//                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -20,6 +21,12 @@ class ActuationModelFloatingBaseTpl;
 
 template <typename Scalar>
 class ActuationModelFullTpl;
+
+template <typename Scalar>
+struct PropellerTpl;
+
+template <typename Scalar>
+class ActuationModelFloatingBasePropellersTpl;
 
 template <typename Scalar>
 class ActuationModelMultiCopterBaseTpl;
@@ -244,11 +251,13 @@ class ImpulseModelMultipleTpl;
 template <typename Scalar>
 struct ImpulseDataMultipleTpl;
 
-/*******************************Template
- * Instantiation**************************/
+/**** Template Instantiation ****/
 
 typedef ActuationModelFloatingBaseTpl<double> ActuationModelFloatingBase;
 typedef ActuationModelFullTpl<double> ActuationModelFull;
+typedef PropellerTpl<double> Propeller;
+typedef ActuationModelFloatingBasePropellersTpl<double>
+    ActuationModelFloatingBasePropellers;
 typedef ActuationModelMultiCopterBaseTpl<double> ActuationModelMultiCopterBase;
 
 typedef ForceDataAbstractTpl<double> ForceDataAbstract;

--- a/include/crocoddyl/multibody/fwd.hpp
+++ b/include/crocoddyl/multibody/fwd.hpp
@@ -23,10 +23,10 @@ template <typename Scalar>
 class ActuationModelFullTpl;
 
 template <typename Scalar>
-struct PropellerTpl;
+struct ThrusterTpl;
 
 template <typename Scalar>
-class ActuationModelFloatingBasePropellersTpl;
+class ActuationModelFloatingBaseThrustersTpl;
 
 template <typename Scalar>
 class ActuationModelMultiCopterBaseTpl;
@@ -255,10 +255,10 @@ struct ImpulseDataMultipleTpl;
 
 typedef ActuationModelFloatingBaseTpl<double> ActuationModelFloatingBase;
 typedef ActuationModelFullTpl<double> ActuationModelFull;
-typedef PropellerTpl<double> Propeller;
-typedef ActuationModelFloatingBasePropellersTpl<double>
-    ActuationModelFloatingBasePropellers;
-DEPRECATED("Use ActuationModelFloatingBasePropellersTpl",
+typedef ThrusterTpl<double> Thruster;
+typedef ActuationModelFloatingBaseThrustersTpl<double>
+    ActuationModelFloatingBaseThrusters;
+DEPRECATED("Use ActuationModelFloatingBaseThrustersTpl",
            typedef ActuationModelMultiCopterBaseTpl<double>
                ActuationModelMultiCopterBase;)
 

--- a/include/crocoddyl/multibody/fwd.hpp
+++ b/include/crocoddyl/multibody/fwd.hpp
@@ -258,7 +258,9 @@ typedef ActuationModelFullTpl<double> ActuationModelFull;
 typedef PropellerTpl<double> Propeller;
 typedef ActuationModelFloatingBasePropellersTpl<double>
     ActuationModelFloatingBasePropellers;
-typedef ActuationModelMultiCopterBaseTpl<double> ActuationModelMultiCopterBase;
+DEPRECATED("Use ActuationModelFloatingBasePropellersTpl",
+           typedef ActuationModelMultiCopterBaseTpl<double>
+               ActuationModelMultiCopterBase;)
 
 typedef ForceDataAbstractTpl<double> ForceDataAbstract;
 

--- a/unittest/bindings/test_copy.py
+++ b/unittest/bindings/test_copy.py
@@ -304,33 +304,29 @@ class ActuationsTest(CopyModelTestCase):
     MODEL.append(crocoddyl.ActuationModelFull(state))
     d_cog, cf, cm, u_lim, l_lim = 0.1525, 6.6e-5, 1e-6, 5.0, 0.1
     ps = [
-        crocoddyl.Propeller(
+        crocoddyl.Thruster(
             pinocchio.SE3(np.eye(3), np.array([d_cog, 0, 0])),
-            cf,
-            cm,
-            crocoddyl.PropellerType.CCW,
+            cm / cf,
+            crocoddyl.ThrusterType.CCW,
         ),
-        crocoddyl.Propeller(
+        crocoddyl.Thruster(
             pinocchio.SE3(np.eye(3), np.array([0, d_cog, 0])),
-            cf,
-            cm,
-            crocoddyl.PropellerType.CW,
+            cm / cf,
+            crocoddyl.ThrusterType.CW,
         ),
-        crocoddyl.Propeller(
+        crocoddyl.Thruster(
             pinocchio.SE3(np.eye(3), np.array([-d_cog, 0, 0])),
-            cf,
-            cm,
-            crocoddyl.PropellerType.CCW,
+            cm / cf,
+            crocoddyl.ThrusterType.CCW,
         ),
-        crocoddyl.Propeller(
+        crocoddyl.Thruster(
             pinocchio.SE3(np.eye(3), np.array([0, -d_cog, 0])),
-            cf,
-            cm,
-            crocoddyl.PropellerType.CW,
+            cm / cf,
+            crocoddyl.ThrusterType.CW,
         ),
     ]
-    actuation = crocoddyl.ActuationModelFloatingBasePropellers(state, ps)
-    MODEL.append(crocoddyl.ActuationModelFloatingBasePropellers(state, ps))
+    actuation = crocoddyl.ActuationModelFloatingBaseThrusters(state, ps)
+    MODEL.append(crocoddyl.ActuationModelFloatingBaseThrusters(state, ps))
 
 
 class ContactsTest(CopyModelTestCase):

--- a/unittest/bindings/test_copy.py
+++ b/unittest/bindings/test_copy.py
@@ -302,7 +302,35 @@ class ActuationsTest(CopyModelTestCase):
     # multibody actuations
     MODEL.append(crocoddyl.ActuationModelFloatingBase(state))
     MODEL.append(crocoddyl.ActuationModelFull(state))
-    MODEL.append(crocoddyl.ActuationModelMultiCopterBase(state, np.ones(6)))
+    d_cog, cf, cm, u_lim, l_lim = 0.1525, 6.6e-5, 1e-6, 5.0, 0.1
+    ps = [
+        crocoddyl.Propeller(
+            pinocchio.SE3(np.eye(3), np.array([d_cog, 0, 0])),
+            cf,
+            cm,
+            crocoddyl.PropellerType.CCW,
+        ),
+        crocoddyl.Propeller(
+            pinocchio.SE3(np.eye(3), np.array([0, d_cog, 0])),
+            cf,
+            cm,
+            crocoddyl.PropellerType.CW,
+        ),
+        crocoddyl.Propeller(
+            pinocchio.SE3(np.eye(3), np.array([-d_cog, 0, 0])),
+            cf,
+            cm,
+            crocoddyl.PropellerType.CCW,
+        ),
+        crocoddyl.Propeller(
+            pinocchio.SE3(np.eye(3), np.array([0, -d_cog, 0])),
+            cf,
+            cm,
+            crocoddyl.PropellerType.CW,
+        ),
+    ]
+    actuation = crocoddyl.ActuationModelFloatingBasePropellers(state, ps)
+    MODEL.append(crocoddyl.ActuationModelFloatingBasePropellers(state, ps))
 
 
 class ContactsTest(CopyModelTestCase):

--- a/unittest/factory/actuation.cpp
+++ b/unittest/factory/actuation.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2021, University of Edinburgh
+// Copyright (C) 2019-2024, University of Edinburgh, Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -12,9 +12,9 @@
 #include "crocoddyl/core/actuation/squashing-base.hpp"
 #include "crocoddyl/core/actuation/squashing/smooth-sat.hpp"
 #include "crocoddyl/core/utils/exception.hpp"
+#include "crocoddyl/multibody/actuations/floating-base-propellers.hpp"
 #include "crocoddyl/multibody/actuations/floating-base.hpp"
 #include "crocoddyl/multibody/actuations/full.hpp"
-#include "crocoddyl/multibody/actuations/multicopter-base.hpp"
 
 namespace crocoddyl {
 namespace unittest {
@@ -30,8 +30,8 @@ std::ostream& operator<<(std::ostream& os, ActuationModelTypes::Type type) {
     case ActuationModelTypes::ActuationModelFloatingBase:
       os << "ActuationModelFloatingBase";
       break;
-    case ActuationModelTypes::ActuationModelMultiCopterBase:
-      os << "ActuationModelMultiCopterBase";
+    case ActuationModelTypes::ActuationModelFloatingBasePropellers:
+      os << "ActuationModelFloatingBasePropellers";
       break;
     case ActuationModelTypes::ActuationModelSquashingFull:
       os << "ActuationModelSquashingFull";
@@ -56,8 +56,19 @@ ActuationModelFactory::create(ActuationModelTypes::Type actuation_type,
   boost::shared_ptr<crocoddyl::StateAbstract> state =
       factory.create(state_type);
   boost::shared_ptr<crocoddyl::StateMultibody> state_multibody;
-  // MultiCopter objects
-  Eigen::MatrixXd tau_f;
+  // Propeller objects
+  std::vector<crocoddyl::Propeller> ps;
+  const double d_cog = 0.1525;
+  const double cf = 6.6e-5;
+  const double cm = 1e-6;
+  pinocchio::SE3 p1(Eigen::Matrix3d::Identity(), Eigen::Vector3d(d_cog, 0, 0));
+  pinocchio::SE3 p2(Eigen::Matrix3d::Identity(), Eigen::Vector3d(0, d_cog, 0));
+  pinocchio::SE3 p3(Eigen::Matrix3d::Identity(), Eigen::Vector3d(-d_cog, 0, 0));
+  pinocchio::SE3 p4(Eigen::Matrix3d::Identity(), Eigen::Vector3d(0, -d_cog, 0));
+  ps.push_back(crocoddyl::Propeller(p1, cf, cm, crocoddyl::PropellerType::CCW));
+  ps.push_back(crocoddyl::Propeller(p2, cf, cm, crocoddyl::PropellerType::CW));
+  ps.push_back(crocoddyl::Propeller(p3, cf, cm, crocoddyl::PropellerType::CW));
+  ps.push_back(crocoddyl::Propeller(p4, cf, cm, crocoddyl::PropellerType::CCW));
   // Actuation Squashing objects
   boost::shared_ptr<crocoddyl::ActuationModelAbstract> act;
   boost::shared_ptr<crocoddyl::SquashingModelSmoothSat> squash;
@@ -76,16 +87,12 @@ ActuationModelFactory::create(ActuationModelTypes::Type actuation_type,
       actuation = boost::make_shared<crocoddyl::ActuationModelFloatingBase>(
           state_multibody);
       break;
-    case ActuationModelTypes::ActuationModelMultiCopterBase:
+    case ActuationModelTypes::ActuationModelFloatingBasePropellers:
       state_multibody =
           boost::static_pointer_cast<crocoddyl::StateMultibody>(state);
-      tau_f = Eigen::MatrixXd::Zero(6, 4);
-      tau_f.row(2).fill(1.0);
-      tau_f.row(3) << 0.0, 0.1525, 0.0, -0.1525;
-      tau_f.row(4) << -0.1525, 0.0, 0.1525, 0.0;
-      tau_f.row(5) << -0.01515, 0.01515, -0.01515, 0.01515;
-      actuation = boost::make_shared<crocoddyl::ActuationModelMultiCopterBase>(
-          state_multibody, tau_f);
+      actuation =
+          boost::make_shared<crocoddyl::ActuationModelFloatingBasePropellers>(
+              state_multibody, ps);
       break;
     case ActuationModelTypes::ActuationModelSquashingFull:
       state_multibody =

--- a/unittest/factory/actuation.cpp
+++ b/unittest/factory/actuation.cpp
@@ -12,7 +12,7 @@
 #include "crocoddyl/core/actuation/squashing-base.hpp"
 #include "crocoddyl/core/actuation/squashing/smooth-sat.hpp"
 #include "crocoddyl/core/utils/exception.hpp"
-#include "crocoddyl/multibody/actuations/floating-base-propellers.hpp"
+#include "crocoddyl/multibody/actuations/floating-base-thrusters.hpp"
 #include "crocoddyl/multibody/actuations/floating-base.hpp"
 #include "crocoddyl/multibody/actuations/full.hpp"
 
@@ -30,8 +30,8 @@ std::ostream& operator<<(std::ostream& os, ActuationModelTypes::Type type) {
     case ActuationModelTypes::ActuationModelFloatingBase:
       os << "ActuationModelFloatingBase";
       break;
-    case ActuationModelTypes::ActuationModelFloatingBasePropellers:
-      os << "ActuationModelFloatingBasePropellers";
+    case ActuationModelTypes::ActuationModelFloatingBaseThrusters:
+      os << "ActuationModelFloatingBaseThrusters";
       break;
     case ActuationModelTypes::ActuationModelSquashingFull:
       os << "ActuationModelSquashingFull";
@@ -56,8 +56,8 @@ ActuationModelFactory::create(ActuationModelTypes::Type actuation_type,
   boost::shared_ptr<crocoddyl::StateAbstract> state =
       factory.create(state_type);
   boost::shared_ptr<crocoddyl::StateMultibody> state_multibody;
-  // Propeller objects
-  std::vector<crocoddyl::Propeller> ps;
+  // Thruster objects
+  std::vector<crocoddyl::Thruster> ps;
   const double d_cog = 0.1525;
   const double cf = 6.6e-5;
   const double cm = 1e-6;
@@ -65,10 +65,10 @@ ActuationModelFactory::create(ActuationModelTypes::Type actuation_type,
   pinocchio::SE3 p2(Eigen::Matrix3d::Identity(), Eigen::Vector3d(0, d_cog, 0));
   pinocchio::SE3 p3(Eigen::Matrix3d::Identity(), Eigen::Vector3d(-d_cog, 0, 0));
   pinocchio::SE3 p4(Eigen::Matrix3d::Identity(), Eigen::Vector3d(0, -d_cog, 0));
-  ps.push_back(crocoddyl::Propeller(p1, cf, cm, crocoddyl::PropellerType::CCW));
-  ps.push_back(crocoddyl::Propeller(p2, cf, cm, crocoddyl::PropellerType::CW));
-  ps.push_back(crocoddyl::Propeller(p3, cf, cm, crocoddyl::PropellerType::CW));
-  ps.push_back(crocoddyl::Propeller(p4, cf, cm, crocoddyl::PropellerType::CCW));
+  ps.push_back(crocoddyl::Thruster(p1, cm / cf, crocoddyl::ThrusterType::CCW));
+  ps.push_back(crocoddyl::Thruster(p2, cm / cf, crocoddyl::ThrusterType::CW));
+  ps.push_back(crocoddyl::Thruster(p3, cm / cf, crocoddyl::ThrusterType::CW));
+  ps.push_back(crocoddyl::Thruster(p4, cm / cf, crocoddyl::ThrusterType::CCW));
   // Actuation Squashing objects
   boost::shared_ptr<crocoddyl::ActuationModelAbstract> act;
   boost::shared_ptr<crocoddyl::SquashingModelSmoothSat> squash;
@@ -87,11 +87,11 @@ ActuationModelFactory::create(ActuationModelTypes::Type actuation_type,
       actuation = boost::make_shared<crocoddyl::ActuationModelFloatingBase>(
           state_multibody);
       break;
-    case ActuationModelTypes::ActuationModelFloatingBasePropellers:
+    case ActuationModelTypes::ActuationModelFloatingBaseThrusters:
       state_multibody =
           boost::static_pointer_cast<crocoddyl::StateMultibody>(state);
       actuation =
-          boost::make_shared<crocoddyl::ActuationModelFloatingBasePropellers>(
+          boost::make_shared<crocoddyl::ActuationModelFloatingBaseThrusters>(
               state_multibody, ps);
       break;
     case ActuationModelTypes::ActuationModelSquashingFull:

--- a/unittest/factory/actuation.hpp
+++ b/unittest/factory/actuation.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2021, University of Edinburgh
+// Copyright (C) 2019-2024, University of Edinburgh, Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -20,7 +20,7 @@ struct ActuationModelTypes {
   enum Type {
     ActuationModelFull,
     ActuationModelFloatingBase,
-    ActuationModelMultiCopterBase,
+    ActuationModelFloatingBasePropellers,
     ActuationModelSquashingFull,
     NbActuationModelTypes
   };

--- a/unittest/factory/actuation.hpp
+++ b/unittest/factory/actuation.hpp
@@ -20,7 +20,7 @@ struct ActuationModelTypes {
   enum Type {
     ActuationModelFull,
     ActuationModelFloatingBase,
-    ActuationModelFloatingBasePropellers,
+    ActuationModelFloatingBaseThrusters,
     ActuationModelSquashingFull,
     NbActuationModelTypes
   };

--- a/unittest/factory/diff_action.cpp
+++ b/unittest/factory/diff_action.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2023, University of Edinburgh, CTU, INRIA,
+// Copyright (C) 2019-2024, University of Edinburgh, CTU, INRIA,
 //                          Heriot-Watt University, University of Pisa
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
@@ -151,7 +151,7 @@ DifferentialActionModelFactory::create(DifferentialActionModelTypes::Type type,
         DifferentialActionModelFreeFwdDynamics_Hector:
       action = create_freeFwdDynamics(
           StateModelTypes::StateMultibody_Hector,
-          ActuationModelTypes::ActuationModelMultiCopterBase, false);
+          ActuationModelTypes::ActuationModelFloatingBasePropellers, false);
       break;
     case DifferentialActionModelTypes::
         DifferentialActionModelFreeFwdDynamics_TalosArm:
@@ -168,7 +168,7 @@ DifferentialActionModelFactory::create(DifferentialActionModelTypes::Type type,
         DifferentialActionModelFreeInvDynamics_Hector:
       action = create_freeInvDynamics(
           StateModelTypes::StateMultibody_Hector,
-          ActuationModelTypes::ActuationModelMultiCopterBase);
+          ActuationModelTypes::ActuationModelFloatingBasePropellers);
       break;
     case DifferentialActionModelTypes::
         DifferentialActionModelFreeInvDynamics_TalosArm:

--- a/unittest/factory/diff_action.cpp
+++ b/unittest/factory/diff_action.cpp
@@ -151,7 +151,7 @@ DifferentialActionModelFactory::create(DifferentialActionModelTypes::Type type,
         DifferentialActionModelFreeFwdDynamics_Hector:
       action = create_freeFwdDynamics(
           StateModelTypes::StateMultibody_Hector,
-          ActuationModelTypes::ActuationModelFloatingBasePropellers, false);
+          ActuationModelTypes::ActuationModelFloatingBaseThrusters, false);
       break;
     case DifferentialActionModelTypes::
         DifferentialActionModelFreeFwdDynamics_TalosArm:
@@ -168,7 +168,7 @@ DifferentialActionModelFactory::create(DifferentialActionModelTypes::Type type,
         DifferentialActionModelFreeInvDynamics_Hector:
       action = create_freeInvDynamics(
           StateModelTypes::StateMultibody_Hector,
-          ActuationModelTypes::ActuationModelFloatingBasePropellers);
+          ActuationModelTypes::ActuationModelFloatingBaseThrusters);
       break;
     case DifferentialActionModelTypes::
         DifferentialActionModelFreeInvDynamics_TalosArm:

--- a/unittest/test_actuation.cpp
+++ b/unittest/test_actuation.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2023, University of Edinburgh, Heriot-Watt University
+// Copyright (C) 2019-2024, University of Edinburgh, Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -232,7 +232,7 @@ bool init_function() {
   }
 
   register_actuation_model_unit_tests(
-      ActuationModelTypes::ActuationModelMultiCopterBase,
+      ActuationModelTypes::ActuationModelFloatingBasePropellers,
       StateModelTypes::StateMultibody_Hector);
   return true;
 }

--- a/unittest/test_actuation.cpp
+++ b/unittest/test_actuation.cpp
@@ -232,7 +232,7 @@ bool init_function() {
   }
 
   register_actuation_model_unit_tests(
-      ActuationModelTypes::ActuationModelFloatingBasePropellers,
+      ActuationModelTypes::ActuationModelFloatingBaseThrusters,
       StateModelTypes::StateMultibody_Hector);
   return true;
 }

--- a/unittest/test_residuals.cpp
+++ b/unittest/test_residuals.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2021-2023, University of Edinburgh, Heriot-Watt University
+// Copyright (C) 2021-2024, University of Edinburgh, Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -300,7 +300,7 @@ bool init_function() {
       for (size_t actuation_type = 0;
            actuation_type < ActuationModelTypes::all.size(); ++actuation_type) {
         if (ActuationModelTypes::all[actuation_type] !=
-            ActuationModelTypes::ActuationModelMultiCopterBase) {
+            ActuationModelTypes::ActuationModelFloatingBasePropellers) {
           register_residual_model_unit_tests(
               ResidualModelTypes::all[residual_type],
               StateModelTypes::all[state_type],

--- a/unittest/test_residuals.cpp
+++ b/unittest/test_residuals.cpp
@@ -300,7 +300,7 @@ bool init_function() {
       for (size_t actuation_type = 0;
            actuation_type < ActuationModelTypes::all.size(); ++actuation_type) {
         if (ActuationModelTypes::all[actuation_type] !=
-            ActuationModelTypes::ActuationModelFloatingBasePropellers) {
+            ActuationModelTypes::ActuationModelFloatingBaseThrusters) {
           register_residual_model_unit_tests(
               ResidualModelTypes::all[residual_type],
               StateModelTypes::all[state_type],


### PR DESCRIPTION
This PR introduces a new actuation model that encapsulates floating base systems equipped with propellers in their base. This class replaces our previous actuation model for multi-copters, which was designed to pass a torque-mapping matrix. This old design is unintuitive and hard codes that propellers are oriented along the robot's z-axis in inverse dynamics formulations.

In a nutshell, we can model easily other types of systems such as marine robots.

Apart from this new model, the PR includes:
  - Deprecation of the multi-copter actuation model
  - Unit test for this new actuation model
  - Examples based on this new model

In future, I plan to extend this actuation to cases where the propellers are placed in the robot's limbs. For an efficient implementation, this will require changes in the actuation API which I prefer to avoid now.

@PepMS -- I am sure you want to know about this.