### PR TITLE
Fix use of 'template' when actually calling non-template member

### DIFF
--- a/include/crocoddyl/multibody/actuations/floating-base-thrusters.hpp
+++ b/include/crocoddyl/multibody/actuations/floating-base-thrusters.hpp
@@ -174,7 +174,7 @@ class ActuationModelFloatingBaseThrustersTpl
     W_thrust_.setZero();
     if (nu_ > n_thrusters_) {
       W_thrust_
-          .template bottomRightCorner(nu_ - n_thrusters_, nu_ - n_thrusters_)
+          .bottomRightCorner(nu_ - n_thrusters_, nu_ - n_thrusters_)
           .diagonal()
           .setOnes();
     }

--- a/include/crocoddyl/multibody/actuations/floating-base-thrusters.hpp
+++ b/include/crocoddyl/multibody/actuations/floating-base-thrusters.hpp
@@ -173,8 +173,7 @@ class ActuationModelFloatingBaseThrustersTpl
     // Update the joint actuation part
     W_thrust_.setZero();
     if (nu_ > n_thrusters_) {
-      W_thrust_
-          .bottomRightCorner(nu_ - n_thrusters_, nu_ - n_thrusters_)
+      W_thrust_.bottomRightCorner(nu_ - n_thrusters_, nu_ - n_thrusters_)
           .diagonal()
           .setOnes();
     }


### PR DESCRIPTION
The changed line of code tried to call a templated member for an [Eigen fixed-size block expression](https://eigen.tuxfamily.org/dox/group__TutorialBlockOperations.html) but instead calls the dynamic-sized overload.
This created a compile issue with Eigen 3.3.7 and clang 16.0.6.