### PR TITLE
Extending LQR actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+* Extend LQR actions in https://github.com/loco-3d/crocoddyl/pull/1261
+* Print log with grad absolute + updated logs with Pinocchio 3 in https://github.com/loco-3d/crocoddyl/pull/1260
+
 ## [2.1.0] - 2024-05-31
 
-* Print log with grad absolute + updated logs with Pinocchio 3 in https://github.com/loco-3d/crocoddyl/pull/1260
 * Updated black + isort + flake8 to ruff in https://github.com/loco-3d/crocoddyl/pull/1256
 * Exported version for Python in https://github.com/loco-3d/crocoddyl/pull/1254
 * Added pinocchio 3 preliminary support in https://github.com/loco-3d/crocoddyl/pull/1253

--- a/bindings/python/crocoddyl/core/actions/diff-lqr.cpp
+++ b/bindings/python/crocoddyl/core/actions/diff-lqr.cpp
@@ -48,10 +48,7 @@ void exposeDifferentialActionLQR() {
       "  h(x,u) = H [x,u] + h<=0.",
       bp::init<Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd,
                Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd>(
-          bp::args("self", "Aq",
-                   "Av,"
-                   "B",
-                   "Q", "R", "N"),
+          bp::args("self", "Aq", "Av", "B", "Q", "R", "N"),
           "Initialize the differential LQR action model.\n\n"
           ":param Aq: position matrix\n"
           ":param Av: velocity matrix\n"

--- a/bindings/python/crocoddyl/core/actions/diff-lqr.cpp
+++ b/bindings/python/crocoddyl/core/actions/diff-lqr.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2023, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2019-2024, LAAS-CNRS, University of Edinburgh
 //                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
@@ -12,11 +12,17 @@
 #include "python/crocoddyl/core/core.hpp"
 #include "python/crocoddyl/core/diff-action-base.hpp"
 #include "python/crocoddyl/utils/copyable.hpp"
+#include "python/crocoddyl/utils/deprecate.hpp"
 
 namespace crocoddyl {
 namespace python {
 
 void exposeDifferentialActionLQR() {
+// TODO: Remove once the deprecated update call has been removed in a future
+// release
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
   boost::python::register_ptr_to_python<
       boost::shared_ptr<DifferentialActionModelLQR> >();
 
@@ -84,46 +90,112 @@ void exposeDifferentialActionLQR() {
           bp::args("self", "data", "x"))
       .def("createData", &DifferentialActionModelLQR::createData,
            bp::args("self"), "Create the differential LQR action data.")
-      .add_property("Fq",
-                    bp::make_function(&DifferentialActionModelLQR::get_Fq,
+      .add_property("Aq",
+                    bp::make_function(&DifferentialActionModelLQR::get_Aq,
                                       bp::return_internal_reference<>()),
-                    &DifferentialActionModelLQR::set_Fq,
-                    "Jacobian of the dynamics")
-      .add_property("Fv",
-                    bp::make_function(&DifferentialActionModelLQR::get_Fv,
+                    &DifferentialActionModelLQR::set_Aq, "position matrix")
+      .add_property("Av",
+                    bp::make_function(&DifferentialActionModelLQR::get_Av,
                                       bp::return_internal_reference<>()),
-                    &DifferentialActionModelLQR::set_Fv,
-                    "Jacobian of the dynamics")
-      .add_property("Fu",
-                    bp::make_function(&DifferentialActionModelLQR::get_Fu,
+                    &DifferentialActionModelLQR::set_Av, "velocity matrix")
+      .add_property("B",
+                    bp::make_function(&DifferentialActionModelLQR::get_B,
                                       bp::return_internal_reference<>()),
-                    &DifferentialActionModelLQR::set_Fu,
-                    "Jacobian of the dynamics")
-      .add_property("f0",
-                    bp::make_function(&DifferentialActionModelLQR::get_f0,
+                    &DifferentialActionModelLQR::set_B, "input matrix")
+      .add_property("f",
+                    bp::make_function(&DifferentialActionModelLQR::get_f,
                                       bp::return_internal_reference<>()),
-                    &DifferentialActionModelLQR::set_f0, "dynamics drift")
-      .add_property("lx",
-                    bp::make_function(&DifferentialActionModelLQR::get_lx,
+                    &DifferentialActionModelLQR::set_f, "dynamics drift")
+      .add_property("Q",
+                    bp::make_function(&DifferentialActionModelLQR::get_Q,
                                       bp::return_internal_reference<>()),
-                    &DifferentialActionModelLQR::set_lx, "Jacobian of the cost")
-      .add_property("lu",
-                    bp::make_function(&DifferentialActionModelLQR::get_lu,
+                    &DifferentialActionModelLQR::set_Q, "state weight matrix")
+      .add_property("R",
+                    bp::make_function(&DifferentialActionModelLQR::get_R,
                                       bp::return_internal_reference<>()),
-                    &DifferentialActionModelLQR::set_lu, "Jacobian of the cost")
-      .add_property("Lxx",
-                    bp::make_function(&DifferentialActionModelLQR::get_Lxx,
+                    &DifferentialActionModelLQR::set_R, "input weight matrix")
+      .add_property("N",
+                    bp::make_function(&DifferentialActionModelLQR::get_N,
                                       bp::return_internal_reference<>()),
-                    &DifferentialActionModelLQR::set_Lxx, "Hessian of the cost")
-      .add_property("Lxu",
-                    bp::make_function(&DifferentialActionModelLQR::get_Lxu,
+                    &DifferentialActionModelLQR::set_N,
+                    "state-input weight matrix")
+      .add_property("q",
+                    bp::make_function(&DifferentialActionModelLQR::get_q,
                                       bp::return_internal_reference<>()),
-                    &DifferentialActionModelLQR::set_Lxu, "Hessian of the cost")
+                    &DifferentialActionModelLQR::set_q, "state weight vector")
+      .add_property("r",
+                    bp::make_function(&DifferentialActionModelLQR::get_r,
+                                      bp::return_internal_reference<>()),
+                    &DifferentialActionModelLQR::set_r, "input weight vector")
+      // deprecated function
+      .add_property(
+          "Fq",
+          bp::make_function(&DifferentialActionModelLQR::get_Aq,
+                            deprecated<bp::return_internal_reference<> >(
+                                "Deprecated. Use Aq.")),
+          &DifferentialActionModelLQR::set_Aq, "position matrix")
+      .add_property(
+          "Fv",
+          bp::make_function(&DifferentialActionModelLQR::get_Av,
+                            deprecated<bp::return_internal_reference<> >(
+                                "Deprecated. Use Av.")),
+          &DifferentialActionModelLQR::set_Aq, "position matrix")
+      .add_property(
+          "Fu",
+          bp::make_function(&DifferentialActionModelLQR::get_B,
+                            deprecated<bp::return_internal_reference<> >(
+                                "Deprecated. Use B.")),
+          bp::make_function(&DifferentialActionModelLQR::set_B,
+                            deprecated<>("Deprecated. Use B.")),
+          "input matrix")
+      .add_property(
+          "f0",
+          bp::make_function(&DifferentialActionModelLQR::get_f,
+                            deprecated<bp::return_internal_reference<> >(
+                                "Deprecated. Use f.")),
+          bp::make_function(&DifferentialActionModelLQR::set_f,
+                            deprecated<>("Deprecated. Use f.")),
+          "dynamics drift")
+      .add_property(
+          "lx",
+          bp::make_function(&DifferentialActionModelLQR::get_q,
+                            deprecated<bp::return_internal_reference<> >(
+                                "Deprecated. Use q.")),
+          bp::make_function(&DifferentialActionModelLQR::set_q,
+                            deprecated<>("Deprecated. Use q.")),
+          "state weight vector")
+      .add_property(
+          "lu",
+          bp::make_function(&DifferentialActionModelLQR::get_r,
+                            deprecated<bp::return_internal_reference<> >(
+                                "Deprecated. Use r.")),
+          bp::make_function(&DifferentialActionModelLQR::set_r,
+                            deprecated<>("Deprecated. Use r.")),
+          "input weight vector")
+      .add_property(
+          "Lxx",
+          bp::make_function(&DifferentialActionModelLQR::get_Q,
+                            deprecated<bp::return_internal_reference<> >(
+                                "Deprecated. Use Q.")),
+          bp::make_function(&DifferentialActionModelLQR::set_Q,
+                            deprecated<>("Deprecated. Use Q.")),
+          "state weight matrix")
+      .add_property(
+          "Lxu",
+          bp::make_function(&DifferentialActionModelLQR::get_N,
+                            deprecated<bp::return_internal_reference<> >(
+                                "Deprecated. Use N.")),
+          bp::make_function(&DifferentialActionModelLQR::set_N,
+                            deprecated<>("Deprecated. Use N.")),
+          "state-input weight matrix")
       .add_property(
           "Luu",
-          bp::make_function(&DifferentialActionModelLQR::get_Luu,
-                            bp::return_value_policy<bp::return_by_value>()),
-          &DifferentialActionModelLQR::set_Luu, "Hessian of the cost")
+          bp::make_function(&DifferentialActionModelLQR::get_R,
+                            deprecated<bp::return_internal_reference<> >(
+                                "Deprecated. Use R.")),
+          bp::make_function(&DifferentialActionModelLQR::set_R,
+                            deprecated<>("Deprecated. Use R.")),
+          "input weight matrix")
       .def(CopyableVisitor<DifferentialActionModelLQR>());
 
   boost::python::register_ptr_to_python<
@@ -138,6 +210,8 @@ void exposeDifferentialActionLQR() {
           "Create differential LQR data.\n\n"
           ":param model: differential LQR action model"))
       .def(CopyableVisitor<DifferentialActionDataLQR>());
+
+#pragma GCC diagnostic pop
 }
 
 }  // namespace python

--- a/bindings/python/crocoddyl/core/actions/diff-lqr.cpp
+++ b/bindings/python/crocoddyl/core/actions/diff-lqr.cpp
@@ -37,11 +37,38 @@ void exposeDifferentialActionLQR() {
       "class implements a second order linear system given by\n"
       "  x = [q, v]\n"
       "  dv = Fq q + Fv v + Fu u + f0\n"
-      "where Fq, Fv, Fu and f0 are randomly chosen constant terms. On the "
+      "where Fq, Fv, Fu and f are randomly chosen constant terms. On the "
       "other\n"
       "hand the cost function is given by\n"
-      "  l(x,u) = 1/2 [x,u].T [Lxx Lxu; Lxu.T Luu] [x,u] + [lx,lu].T [x,u].",
-      bp::init<int, int, bp::optional<bool> >(
+      "  l(x,u) = 1/2 [x,u].T [Q N; N.T R] [x,u] + [q,r].T [x,u].",
+      bp::init<Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd,
+               Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd>(
+          bp::args("self", "Aq",
+                   "Av,"
+                   "B",
+                   "Q", "R", "N"),
+          "Initialize the differential LQR action model.\n\n"
+          ":param Aq: position matrix\n"
+          ":param Av: velocity matrix\n"
+          ":param B: input matrix\n"
+          ":param Q: state weight matrix\n"
+          ":param R: input weight matrix\n"
+          ":param N: state-input weight matrix"))
+      .def(bp::init<Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd,
+                    Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd,
+                    Eigen::VectorXd, Eigen::VectorXd, Eigen::VectorXd>(
+          bp::args("self", "Aq", "Av", "B", "Q", "R", "N", "f", "q", "r"),
+          "Initialize the differential LQR action model.\n\n"
+          ":param Aq: position matrix\n"
+          ":param Av: velocity matrix\n"
+          ":param B: input matrix\n"
+          ":param Q: state weight matrix\n"
+          ":param R: input weight matrix\n"
+          ":param N: state-input weight matrix\n"
+          ":param f: dynamics drift\n"
+          ":param q: state weight vector\n"
+          ":param r: input weight vector"))
+      .def(bp::init<int, int, bp::optional<bool> >(
           bp::args("self", "nq", "nu", "driftFree"),
           "Initialize the differential LQR action model.\n\n"
           ":param nx: dimension of the state vector\n"
@@ -90,6 +117,10 @@ void exposeDifferentialActionLQR() {
           bp::args("self", "data", "x"))
       .def("createData", &DifferentialActionModelLQR::createData,
            bp::args("self"), "Create the differential LQR action data.")
+      .def("Random", &DifferentialActionModelLQR::Random,
+           "Create a random LQR model.\n\n"
+           ":param: nq: position dimension\n"
+           ":param nu: control dimension")
       .def("setLQR", &DifferentialActionModelLQR::set_LQR,
            bp::args("self", "Aq", "Av", "B", "Q", "R", "N", "f", "q", "r"),
            "Modify the LQR action model.\n\n"

--- a/bindings/python/crocoddyl/core/actions/diff-lqr.cpp
+++ b/bindings/python/crocoddyl/core/actions/diff-lqr.cpp
@@ -17,6 +17,9 @@
 namespace crocoddyl {
 namespace python {
 
+BOOST_PYTHON_FUNCTION_OVERLOADS(DifferentialActionModelLQR_Random_wrap,
+                                DifferentialActionModelLQR::Random, 2, 4)
+
 void exposeDifferentialActionLQR() {
 // TODO: Remove once the deprecated update call has been removed in a future
 // release
@@ -30,17 +33,19 @@ void exposeDifferentialActionLQR() {
              bp::bases<DifferentialActionModelAbstract> >(
       "DifferentialActionModelLQR",
       "Differential action model for linear dynamics and quadratic cost.\n\n"
-      "This class implements a linear dynamics, and quadratic costs (i.e.\n"
-      "LQR action). Since the DAM is a second order system, and the "
-      "integrated\n"
-      "action models are implemented as being second order integrators. This\n"
-      "class implements a second order linear system given by\n"
+      "This class implements a linear dynamics, quadratic costs, and linear "
+      "constraints (i.e. LQR action). Since the DAM is a second order system, "
+      "and the integrated action models are implemented as being second order "
+      "integrators. This class implements a second order linear system given "
+      "by\n"
       "  x = [q, v]\n"
       "  dv = Fq q + Fv v + Fu u + f0\n"
-      "where Fq, Fv, Fu and f are randomly chosen constant terms. On the "
-      "other\n"
-      "hand the cost function is given by\n"
-      "  l(x,u) = 1/2 [x,u].T [Q N; N.T R] [x,u] + [q,r].T [x,u].",
+      "where Fq, Fv, Fu and f are randomly chosen constant terms. On the other "
+      "hand, the cost function is given by\n"
+      "  l(x,u) = 1/2 [x,u].T [Q N; N.T R] [x,u] + [q,r].T [x,u],\n"
+      "and the linear equality and inequality constraints has the form:\n"
+      "  g(x,u) = G [x,u] + g\n"
+      "  h(x,u) = H [x,u] + h<=0.",
       bp::init<Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd,
                Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd>(
           bp::args("self", "Aq",
@@ -118,9 +123,14 @@ void exposeDifferentialActionLQR() {
       .def("createData", &DifferentialActionModelLQR::createData,
            bp::args("self"), "Create the differential LQR action data.")
       .def("Random", &DifferentialActionModelLQR::Random,
-           "Create a random LQR model.\n\n"
-           ":param: nq: position dimension\n"
-           ":param nu: control dimension")
+           DifferentialActionModelLQR_Random_wrap(
+               bp::args("nq", "nu", "ng", "nh"),
+               "Create a random LQR model.\n\n"
+               ":param: nq: position dimension\n"
+               ":param nu: control dimension\n"
+               ":param ng: equality constraint dimension (default 0)\n"
+               ":param nh: inequality constraint dimension (default 0)"))
+      .staticmethod("Random")
       .def("setLQR", &DifferentialActionModelLQR::set_LQR,
            bp::args("self", "Aq", "Av", "B", "Q", "R", "N", "f", "q", "r"),
            "Modify the LQR action model.\n\n"
@@ -161,6 +171,14 @@ void exposeDifferentialActionLQR() {
                     bp::make_function(&DifferentialActionModelLQR::get_N,
                                       bp::return_internal_reference<>()),
                     "state-input weight matrix")
+      .add_property("G",
+                    bp::make_function(&DifferentialActionModelLQR::get_G,
+                                      bp::return_internal_reference<>()),
+                    "state-input equality constraint matrix")
+      .add_property("H",
+                    bp::make_function(&DifferentialActionModelLQR::get_H,
+                                      bp::return_internal_reference<>()),
+                    "state-input inequality constraint matrix")
       .add_property("q",
                     bp::make_function(&DifferentialActionModelLQR::get_q,
                                       bp::return_internal_reference<>()),
@@ -169,6 +187,14 @@ void exposeDifferentialActionLQR() {
                     bp::make_function(&DifferentialActionModelLQR::get_r,
                                       bp::return_internal_reference<>()),
                     "input weight vector")
+      .add_property("g",
+                    bp::make_function(&DifferentialActionModelLQR::get_g,
+                                      bp::return_internal_reference<>()),
+                    "state-input equality constraint bias")
+      .add_property("h",
+                    bp::make_function(&DifferentialActionModelLQR::get_h,
+                                      bp::return_internal_reference<>()),
+                    "state-input inequality constraint bias")
       // deprecated function
       .add_property(
           "Fq",

--- a/bindings/python/crocoddyl/core/actions/diff-lqr.cpp
+++ b/bindings/python/crocoddyl/core/actions/diff-lqr.cpp
@@ -90,111 +90,126 @@ void exposeDifferentialActionLQR() {
           bp::args("self", "data", "x"))
       .def("createData", &DifferentialActionModelLQR::createData,
            bp::args("self"), "Create the differential LQR action data.")
+      .def("setLQR", &DifferentialActionModelLQR::set_LQR,
+           bp::args("self", "Aq", "Av", "B", "Q", "R", "N", "f", "q", "r"),
+           "Modify the LQR action model.\n\n"
+           ":param Aq: position matrix\n"
+           ":param Av: velocity matrix\n"
+           ":param B: input matrix\n"
+           ":param Q: state weight matrix\n"
+           ":param R: input weight matrix\n"
+           ":param N: state-input weight matrix\n"
+           ":param f: dynamics drift\n"
+           ":param q: state weight vector\n"
+           ":param r: input weight vector")
       .add_property("Aq",
                     bp::make_function(&DifferentialActionModelLQR::get_Aq,
                                       bp::return_internal_reference<>()),
-                    &DifferentialActionModelLQR::set_Aq, "position matrix")
+                    "position matrix")
       .add_property("Av",
                     bp::make_function(&DifferentialActionModelLQR::get_Av,
                                       bp::return_internal_reference<>()),
-                    &DifferentialActionModelLQR::set_Av, "velocity matrix")
+                    "velocity matrix")
       .add_property("B",
                     bp::make_function(&DifferentialActionModelLQR::get_B,
                                       bp::return_internal_reference<>()),
-                    &DifferentialActionModelLQR::set_B, "input matrix")
+                    "input matrix")
       .add_property("f",
                     bp::make_function(&DifferentialActionModelLQR::get_f,
                                       bp::return_internal_reference<>()),
-                    &DifferentialActionModelLQR::set_f, "dynamics drift")
+                    "dynamics drift")
       .add_property("Q",
                     bp::make_function(&DifferentialActionModelLQR::get_Q,
                                       bp::return_internal_reference<>()),
-                    &DifferentialActionModelLQR::set_Q, "state weight matrix")
+                    "state weight matrix")
       .add_property("R",
                     bp::make_function(&DifferentialActionModelLQR::get_R,
                                       bp::return_internal_reference<>()),
-                    &DifferentialActionModelLQR::set_R, "input weight matrix")
+                    "input weight matrix")
       .add_property("N",
                     bp::make_function(&DifferentialActionModelLQR::get_N,
                                       bp::return_internal_reference<>()),
-                    &DifferentialActionModelLQR::set_N,
                     "state-input weight matrix")
       .add_property("q",
                     bp::make_function(&DifferentialActionModelLQR::get_q,
                                       bp::return_internal_reference<>()),
-                    &DifferentialActionModelLQR::set_q, "state weight vector")
+                    "state weight vector")
       .add_property("r",
                     bp::make_function(&DifferentialActionModelLQR::get_r,
                                       bp::return_internal_reference<>()),
-                    &DifferentialActionModelLQR::set_r, "input weight vector")
+                    "input weight vector")
       // deprecated function
       .add_property(
           "Fq",
           bp::make_function(&DifferentialActionModelLQR::get_Aq,
                             deprecated<bp::return_internal_reference<> >(
                                 "Deprecated. Use Aq.")),
-          &DifferentialActionModelLQR::set_Aq, "position matrix")
+          bp::make_function(&DifferentialActionModelLQR::set_Fq,
+                            deprecated<>("Deprecated. Use set_LQR.")),
+          "position matrix")
       .add_property(
           "Fv",
           bp::make_function(&DifferentialActionModelLQR::get_Av,
                             deprecated<bp::return_internal_reference<> >(
                                 "Deprecated. Use Av.")),
-          &DifferentialActionModelLQR::set_Aq, "position matrix")
+          bp::make_function(&DifferentialActionModelLQR::set_Fv,
+                            deprecated<>("Deprecated. Use set_LQR.")),
+          "position matrix")
       .add_property(
           "Fu",
           bp::make_function(&DifferentialActionModelLQR::get_B,
                             deprecated<bp::return_internal_reference<> >(
                                 "Deprecated. Use B.")),
-          bp::make_function(&DifferentialActionModelLQR::set_B,
-                            deprecated<>("Deprecated. Use B.")),
+          bp::make_function(&DifferentialActionModelLQR::set_Fu,
+                            deprecated<>("Deprecated. Use set_LQR.")),
           "input matrix")
       .add_property(
           "f0",
           bp::make_function(&DifferentialActionModelLQR::get_f,
                             deprecated<bp::return_internal_reference<> >(
                                 "Deprecated. Use f.")),
-          bp::make_function(&DifferentialActionModelLQR::set_f,
-                            deprecated<>("Deprecated. Use f.")),
+          bp::make_function(&DifferentialActionModelLQR::set_f0,
+                            deprecated<>("Deprecated. Use set_LQR.")),
           "dynamics drift")
       .add_property(
           "lx",
           bp::make_function(&DifferentialActionModelLQR::get_q,
                             deprecated<bp::return_internal_reference<> >(
                                 "Deprecated. Use q.")),
-          bp::make_function(&DifferentialActionModelLQR::set_q,
-                            deprecated<>("Deprecated. Use q.")),
+          bp::make_function(&DifferentialActionModelLQR::set_lx,
+                            deprecated<>("Deprecated. Use set_LQR.")),
           "state weight vector")
       .add_property(
           "lu",
           bp::make_function(&DifferentialActionModelLQR::get_r,
                             deprecated<bp::return_internal_reference<> >(
                                 "Deprecated. Use r.")),
-          bp::make_function(&DifferentialActionModelLQR::set_r,
-                            deprecated<>("Deprecated. Use r.")),
+          bp::make_function(&DifferentialActionModelLQR::set_lu,
+                            deprecated<>("Deprecated. Use set_LQR.")),
           "input weight vector")
       .add_property(
           "Lxx",
           bp::make_function(&DifferentialActionModelLQR::get_Q,
                             deprecated<bp::return_internal_reference<> >(
                                 "Deprecated. Use Q.")),
-          bp::make_function(&DifferentialActionModelLQR::set_Q,
-                            deprecated<>("Deprecated. Use Q.")),
+          bp::make_function(&DifferentialActionModelLQR::set_Lxx,
+                            deprecated<>("Deprecated. Use set_LQR.")),
           "state weight matrix")
       .add_property(
           "Lxu",
           bp::make_function(&DifferentialActionModelLQR::get_N,
                             deprecated<bp::return_internal_reference<> >(
                                 "Deprecated. Use N.")),
-          bp::make_function(&DifferentialActionModelLQR::set_N,
-                            deprecated<>("Deprecated. Use N.")),
+          bp::make_function(&DifferentialActionModelLQR::set_Lxu,
+                            deprecated<>("Deprecated. Use set_LQR.")),
           "state-input weight matrix")
       .add_property(
           "Luu",
           bp::make_function(&DifferentialActionModelLQR::get_R,
                             deprecated<bp::return_internal_reference<> >(
                                 "Deprecated. Use R.")),
-          bp::make_function(&DifferentialActionModelLQR::set_R,
-                            deprecated<>("Deprecated. Use R.")),
+          bp::make_function(&DifferentialActionModelLQR::set_Luu,
+                            deprecated<>("Deprecated. Use set_LQR.")),
           "input weight matrix")
       .def(CopyableVisitor<DifferentialActionModelLQR>());
 

--- a/bindings/python/crocoddyl/core/actions/lqr.cpp
+++ b/bindings/python/crocoddyl/core/actions/lqr.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2023, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2019-2024, LAAS-CNRS, University of Edinburgh
 //                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
@@ -12,11 +12,17 @@
 #include "python/crocoddyl/core/action-base.hpp"
 #include "python/crocoddyl/core/core.hpp"
 #include "python/crocoddyl/utils/copyable.hpp"
+#include "python/crocoddyl/utils/deprecate.hpp"
 
 namespace crocoddyl {
 namespace python {
 
 void exposeActionLQR() {
+// TODO: Remove once the deprecated update call has been removed in a future
+// release
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
   boost::python::register_ptr_to_python<boost::shared_ptr<ActionModelLQR> >();
 
   bp::class_<ActionModelLQR, bp::bases<ActionModelAbstract> >(
@@ -71,38 +77,101 @@ void exposeActionLQR() {
           bp::args("self", "data", "x"))
       .def("createData", &ActionModelLQR::createData, bp::args("self"),
            "Create the LQR action data.")
-      .add_property("Fx",
-                    bp::make_function(&ActionModelLQR::get_Fx,
+      .add_property("A",
+                    bp::make_function(&ActionModelLQR::get_A,
                                       bp::return_internal_reference<>()),
-                    &ActionModelLQR::set_Fx, "Jacobian of the dynamics")
-      .add_property("Fu",
-                    bp::make_function(&ActionModelLQR::get_Fu,
+                    &ActionModelLQR::set_A, "state matrix")
+      .add_property("B",
+                    bp::make_function(&ActionModelLQR::get_B,
                                       bp::return_internal_reference<>()),
-                    &ActionModelLQR::set_Fu, "Jacobian of the dynamics")
-      .add_property("f0",
-                    bp::make_function(&ActionModelLQR::get_f0,
+                    &ActionModelLQR::set_B, "input matrix")
+      .add_property("f",
+                    bp::make_function(&ActionModelLQR::get_f,
                                       bp::return_internal_reference<>()),
-                    &ActionModelLQR::set_f0, "dynamics drift")
-      .add_property("lx",
-                    bp::make_function(&ActionModelLQR::get_lx,
+                    &ActionModelLQR::set_f, "dynamics drift")
+      .add_property("Q",
+                    bp::make_function(&ActionModelLQR::get_Q,
                                       bp::return_internal_reference<>()),
-                    &ActionModelLQR::set_lx, "Jacobian of the cost")
-      .add_property("lu",
-                    bp::make_function(&ActionModelLQR::get_lu,
+                    &ActionModelLQR::set_Q, "state weight matrix")
+      .add_property("R",
+                    bp::make_function(&ActionModelLQR::get_R,
                                       bp::return_internal_reference<>()),
-                    &ActionModelLQR::set_lu, "Jacobian of the cost")
-      .add_property("Lxx",
-                    bp::make_function(&ActionModelLQR::get_Lxx,
+                    &ActionModelLQR::set_R, "input weight matrix")
+      .add_property("N",
+                    bp::make_function(&ActionModelLQR::get_N,
                                       bp::return_internal_reference<>()),
-                    &ActionModelLQR::set_Lxx, "Hessian of the cost")
-      .add_property("Lxu",
-                    bp::make_function(&ActionModelLQR::get_Lxu,
+                    &ActionModelLQR::set_N, "state-input weight matrix")
+      .add_property("q",
+                    bp::make_function(&ActionModelLQR::get_q,
                                       bp::return_internal_reference<>()),
-                    &ActionModelLQR::set_Lxu, "Hessian of the cost")
-      .add_property("Luu",
-                    bp::make_function(&ActionModelLQR::get_Luu,
+                    &ActionModelLQR::set_q, "state weight vector")
+      .add_property("r",
+                    bp::make_function(&ActionModelLQR::get_r,
                                       bp::return_internal_reference<>()),
-                    &ActionModelLQR::set_Luu, "Hessian of the cost")
+                    &ActionModelLQR::set_r, "input weight vector")
+      // deprecated function
+      .add_property(
+          "Fx",
+          bp::make_function(&ActionModelLQR::get_A,
+                            deprecated<bp::return_internal_reference<> >(
+                                "Deprecated. Use A.")),
+          &ActionModelLQR::set_A, "state matrix")
+      .add_property(
+          "Fu",
+          bp::make_function(&ActionModelLQR::get_B,
+                            deprecated<bp::return_internal_reference<> >(
+                                "Deprecated. Use B.")),
+          bp::make_function(&ActionModelLQR::set_B,
+                            deprecated<>("Deprecated. Use B.")),
+          "input matrix")
+      .add_property(
+          "f0",
+          bp::make_function(&ActionModelLQR::get_f,
+                            deprecated<bp::return_internal_reference<> >(
+                                "Deprecated. Use f.")),
+          bp::make_function(&ActionModelLQR::set_f,
+                            deprecated<>("Deprecated. Use f.")),
+          "dynamics drift")
+      .add_property(
+          "lx",
+          bp::make_function(&ActionModelLQR::get_q,
+                            deprecated<bp::return_internal_reference<> >(
+                                "Deprecated. Use q.")),
+          bp::make_function(&ActionModelLQR::set_q,
+                            deprecated<>("Deprecated. Use q.")),
+          "state weight vector")
+      .add_property(
+          "lu",
+          bp::make_function(&ActionModelLQR::get_r,
+                            deprecated<bp::return_internal_reference<> >(
+                                "Deprecated. Use r.")),
+          bp::make_function(&ActionModelLQR::set_r,
+                            deprecated<>("Deprecated. Use r.")),
+          "input weight vector")
+      .add_property(
+          "Lxx",
+          bp::make_function(&ActionModelLQR::get_Q,
+                            deprecated<bp::return_internal_reference<> >(
+                                "Deprecated. Use Q.")),
+          bp::make_function(&ActionModelLQR::set_Q,
+                            deprecated<>("Deprecated. Use Q.")),
+          "state weight matrix")
+      .add_property(
+          "Lxu",
+          bp::make_function(&ActionModelLQR::get_N,
+                            deprecated<bp::return_internal_reference<> >(
+                                "Deprecated. Use N.")),
+          bp::make_function(&ActionModelLQR::set_N,
+                            deprecated<>("Deprecated. Use N.")),
+          "state-input weight matrix")
+      .add_property(
+          "Luu",
+          bp::make_function(&ActionModelLQR::get_R,
+                            deprecated<bp::return_internal_reference<> >(
+                                "Deprecated. Use R.")),
+          bp::make_function(&ActionModelLQR::set_R,
+                            deprecated<>("Deprecated. Use R.")),
+          "input weight matrix")
       .def(CopyableVisitor<ActionModelLQR>());
 
   boost::python::register_ptr_to_python<boost::shared_ptr<ActionDataLQR> >();
@@ -113,6 +182,8 @@ void exposeActionLQR() {
                                 "Create LQR data.\n\n"
                                 ":param model: LQR action model"))
       .def(CopyableVisitor<ActionDataLQR>());
+
+#pragma GCC diagnostic pop
 }
 
 }  // namespace python

--- a/bindings/python/crocoddyl/core/actions/lqr.cpp
+++ b/bindings/python/crocoddyl/core/actions/lqr.cpp
@@ -77,100 +77,111 @@ void exposeActionLQR() {
           bp::args("self", "data", "x"))
       .def("createData", &ActionModelLQR::createData, bp::args("self"),
            "Create the LQR action data.")
+      .def("setLQR", &ActionModelLQR::set_LQR,
+           bp::args("self", "A", "B", "Q", "R", "N", "f", "q", "r"),
+           "Modify the LQR action model.\n\n"
+           ":param A: state matrix\n"
+           ":param B: input matrix\n"
+           ":param Q: state weight matrix\n"
+           ":param R: input weight matrix\n"
+           ":param N: state-input weight matrix\n"
+           ":param f: dynamics drift\n"
+           ":param q: state weight vector\n"
+           ":param r: input weight vector")
       .add_property("A",
                     bp::make_function(&ActionModelLQR::get_A,
                                       bp::return_internal_reference<>()),
-                    &ActionModelLQR::set_A, "state matrix")
+                    "state matrix")
       .add_property("B",
                     bp::make_function(&ActionModelLQR::get_B,
                                       bp::return_internal_reference<>()),
-                    &ActionModelLQR::set_B, "input matrix")
+                    "input matrix")
       .add_property("f",
                     bp::make_function(&ActionModelLQR::get_f,
                                       bp::return_internal_reference<>()),
-                    &ActionModelLQR::set_f, "dynamics drift")
+                    "dynamics drift")
       .add_property("Q",
                     bp::make_function(&ActionModelLQR::get_Q,
                                       bp::return_internal_reference<>()),
-                    &ActionModelLQR::set_Q, "state weight matrix")
+                    "state weight matrix")
       .add_property("R",
                     bp::make_function(&ActionModelLQR::get_R,
                                       bp::return_internal_reference<>()),
-                    &ActionModelLQR::set_R, "input weight matrix")
+                    "input weight matrix")
       .add_property("N",
                     bp::make_function(&ActionModelLQR::get_N,
                                       bp::return_internal_reference<>()),
-                    &ActionModelLQR::set_N, "state-input weight matrix")
+                    "state-input weight matrix")
       .add_property("q",
                     bp::make_function(&ActionModelLQR::get_q,
                                       bp::return_internal_reference<>()),
-                    &ActionModelLQR::set_q, "state weight vector")
+                    "state weight vector")
       .add_property("r",
                     bp::make_function(&ActionModelLQR::get_r,
                                       bp::return_internal_reference<>()),
-                    &ActionModelLQR::set_r, "input weight vector")
+                    "input weight vector")
       // deprecated function
       .add_property(
           "Fx",
           bp::make_function(&ActionModelLQR::get_A,
                             deprecated<bp::return_internal_reference<> >(
-                                "Deprecated. Use A.")),
-          &ActionModelLQR::set_A, "state matrix")
+                                "Deprecated. Use set_LQR.")),
+          &ActionModelLQR::set_Fx, "state matrix")
       .add_property(
           "Fu",
           bp::make_function(&ActionModelLQR::get_B,
                             deprecated<bp::return_internal_reference<> >(
                                 "Deprecated. Use B.")),
-          bp::make_function(&ActionModelLQR::set_B,
-                            deprecated<>("Deprecated. Use B.")),
+          bp::make_function(&ActionModelLQR::set_Fu,
+                            deprecated<>("Deprecated. Use set_LQR.")),
           "input matrix")
       .add_property(
           "f0",
           bp::make_function(&ActionModelLQR::get_f,
                             deprecated<bp::return_internal_reference<> >(
                                 "Deprecated. Use f.")),
-          bp::make_function(&ActionModelLQR::set_f,
-                            deprecated<>("Deprecated. Use f.")),
+          bp::make_function(&ActionModelLQR::set_f0,
+                            deprecated<>("Deprecated. Use set_LQR.")),
           "dynamics drift")
       .add_property(
           "lx",
           bp::make_function(&ActionModelLQR::get_q,
                             deprecated<bp::return_internal_reference<> >(
                                 "Deprecated. Use q.")),
-          bp::make_function(&ActionModelLQR::set_q,
-                            deprecated<>("Deprecated. Use q.")),
+          bp::make_function(&ActionModelLQR::set_lx,
+                            deprecated<>("Deprecated. Use set_LQR.")),
           "state weight vector")
       .add_property(
           "lu",
           bp::make_function(&ActionModelLQR::get_r,
                             deprecated<bp::return_internal_reference<> >(
                                 "Deprecated. Use r.")),
-          bp::make_function(&ActionModelLQR::set_r,
-                            deprecated<>("Deprecated. Use r.")),
+          bp::make_function(&ActionModelLQR::set_lu,
+                            deprecated<>("Deprecated. Use set_LQR.")),
           "input weight vector")
       .add_property(
           "Lxx",
           bp::make_function(&ActionModelLQR::get_Q,
                             deprecated<bp::return_internal_reference<> >(
                                 "Deprecated. Use Q.")),
-          bp::make_function(&ActionModelLQR::set_Q,
-                            deprecated<>("Deprecated. Use Q.")),
+          bp::make_function(&ActionModelLQR::set_Lxx,
+                            deprecated<>("Deprecated. Use set_LQR.")),
           "state weight matrix")
       .add_property(
           "Lxu",
           bp::make_function(&ActionModelLQR::get_N,
                             deprecated<bp::return_internal_reference<> >(
                                 "Deprecated. Use N.")),
-          bp::make_function(&ActionModelLQR::set_N,
-                            deprecated<>("Deprecated. Use N.")),
+          bp::make_function(&ActionModelLQR::set_Lxu,
+                            deprecated<>("Deprecated. Use set_LQR.")),
           "state-input weight matrix")
       .add_property(
           "Luu",
           bp::make_function(&ActionModelLQR::get_R,
                             deprecated<bp::return_internal_reference<> >(
                                 "Deprecated. Use R.")),
-          bp::make_function(&ActionModelLQR::set_R,
-                            deprecated<>("Deprecated. Use R.")),
+          bp::make_function(&ActionModelLQR::set_Luu,
+                            deprecated<>("Deprecated. Use set_LQR.")),
           "input weight matrix")
       .def(CopyableVisitor<ActionModelLQR>());
 

--- a/bindings/python/crocoddyl/core/actions/lqr.cpp
+++ b/bindings/python/crocoddyl/core/actions/lqr.cpp
@@ -30,9 +30,31 @@ void exposeActionLQR() {
       "LQR action model.\n\n"
       "A Linear-Quadratic Regulator problem has a transition model of the "
       "form\n"
-      "xnext(x,u) = Fx*x + Fu*u + f0. Its cost function is quadratic of the\n"
-      "form: 1/2 [x,u].T [Lxx Lxu; Lxu.T Luu] [x,u] + [lx,lu].T [x,u].",
-      bp::init<int, int, bp::optional<bool> >(
+      "xnext(x,u) = A x + B u + f. Its cost function is quadratic of the\n"
+      "form: 1/2 [x,u].T [Q N; N.T R] [x,u] + [q,r].T [x,u].",
+      bp::init<Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd,
+               Eigen::MatrixXd, Eigen::MatrixXd>(
+          bp::args("self", "A", "B", "Q", "R", "N"),
+          "Initialize the LQR action model.\n\n"
+          ":param A: state matrix\n"
+          ":param B: input matrix\n"
+          ":param Q: state weight matrix\n"
+          ":param R: input weight matrix\n"
+          ":param N: state-input weight matrix"))
+      .def(bp::init<Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd,
+                    Eigen::MatrixXd, Eigen::MatrixXd, Eigen::VectorXd,
+                    Eigen::VectorXd, Eigen::VectorXd>(
+          bp::args("self", "A", "B", "Q", "R", "N", "f", "q", "r"),
+          "Initialize the LQR action model.\n\n"
+          ":param A: state matrix\n"
+          ":param B: input matrix\n"
+          ":param Q: state weight matrix\n"
+          ":param R: input weight matrix\n"
+          ":param N: state-input weight matrix\n"
+          ":param f: dynamics drift\n"
+          ":param q: state weight vector\n"
+          ":param r: input weight vector"))
+      .def(bp::init<int, int, bp::optional<bool> >(
           bp::args("self", "nx", "nu", "driftFree"),
           "Initialize the LQR action model.\n\n"
           ":param nx: dimension of the state vector\n"
@@ -77,6 +99,10 @@ void exposeActionLQR() {
           bp::args("self", "data", "x"))
       .def("createData", &ActionModelLQR::createData, bp::args("self"),
            "Create the LQR action data.")
+      .def("Random", &ActionModelLQR::Random,
+           "Create a random LQR model.\n\n"
+           ":param: nx: state dimension\n"
+           ":param nu: control dimension")
       .def("setLQR", &ActionModelLQR::set_LQR,
            bp::args("self", "A", "B", "Q", "R", "N", "f", "q", "r"),
            "Modify the LQR action model.\n\n"

--- a/include/crocoddyl/core/actions/diff-lqr.hpp
+++ b/include/crocoddyl/core/actions/diff-lqr.hpp
@@ -52,24 +52,58 @@ class DifferentialActionModelLQRTpl
   virtual bool checkData(
       const boost::shared_ptr<DifferentialActionDataAbstract>& data);
 
+  /** @brief Return the position matrix */
   const MatrixXs& get_Aq() const;
+
+  /** @brief Return the velocity matrix */
   const MatrixXs& get_Av() const;
+
+  /** @brief Return the input matrix */
   const MatrixXs& get_B() const;
+
+  /** @brief Return the dynamics drift */
   const VectorXs& get_f() const;
-  const VectorXs& get_q() const;
-  const VectorXs& get_r() const;
+
+  /** @brief Return the state weight matrix */
   const MatrixXs& get_Q() const;
+
+  /** @brief Return the input weight matrix */
   const MatrixXs& get_R() const;
+
+  /** @brief Return the state-input weight matrix */
   const MatrixXs& get_N() const;
 
+  /** @brief Return the state weight vector */
+  const VectorXs& get_q() const;
+
+  /** @brief Return the input weight vector */
+  const VectorXs& get_r() const;
+
+  /** @brief Modify the position matrix */
   void set_Aq(const MatrixXs& Aq);
+
+  /** @brief Modify the velocity matrix */
   void set_Av(const MatrixXs& Av);
+
+  /** @brief Modify the input matrix */
   void set_B(const MatrixXs& B);
+
+  /** @brief Modify the dynamics drift */
   void set_f(const VectorXs& f);
+
+  /** @brief Modify the state weight matrix */
   void set_Q(const MatrixXs& Q);
+
+  /** @brief Modify the input weight matrix */
   void set_R(const MatrixXs& R);
+
+  /** @brief Modify the state-input weight matrix */
   void set_N(const MatrixXs& N);
+
+  /** @brief Modify the state weight vector */
   void set_q(const VectorXs& q);
+
+  /** @brief Modify the input weight vector */
   void set_r(const VectorXs& r);
 
   DEPRECATED("Use get_Aq", const MatrixXs& get_Fq() const { return get_Aq(); })

--- a/include/crocoddyl/core/actions/diff-lqr.hpp
+++ b/include/crocoddyl/core/actions/diff-lqr.hpp
@@ -137,7 +137,6 @@ class DifferentialActionModelLQRTpl
   using Base::state_;  //!< Model of the state
 
  private:
-  bool drift_free_;
   MatrixXs Aq_;
   MatrixXs Av_;
   MatrixXs B_;
@@ -147,6 +146,7 @@ class DifferentialActionModelLQRTpl
   VectorXs f_;
   VectorXs q_;
   VectorXs r_;
+  bool drift_free_;
 };
 
 template <typename _Scalar>

--- a/include/crocoddyl/core/actions/diff-lqr.hpp
+++ b/include/crocoddyl/core/actions/diff-lqr.hpp
@@ -79,32 +79,22 @@ class DifferentialActionModelLQRTpl
   /** @brief Return the input weight vector */
   const VectorXs& get_r() const;
 
-  /** @brief Modify the position matrix */
-  void set_Aq(const MatrixXs& Aq);
-
-  /** @brief Modify the velocity matrix */
-  void set_Av(const MatrixXs& Av);
-
-  /** @brief Modify the input matrix */
-  void set_B(const MatrixXs& B);
-
-  /** @brief Modify the dynamics drift */
-  void set_f(const VectorXs& f);
-
-  /** @brief Modify the state weight matrix */
-  void set_Q(const MatrixXs& Q);
-
-  /** @brief Modify the input weight matrix */
-  void set_R(const MatrixXs& R);
-
-  /** @brief Modify the state-input weight matrix */
-  void set_N(const MatrixXs& N);
-
-  /** @brief Modify the state weight vector */
-  void set_q(const VectorXs& q);
-
-  /** @brief Modify the input weight vector */
-  void set_r(const VectorXs& r);
+  /**
+   * @brief Modify the LQR action model
+   *
+   * @param[in] Aq  Position matrix
+   * @param[in] Av  Velocity matrix
+   * @param[in] B   Input matrix
+   * @param[in] Q   State weight matrix
+   * @param[in] R   Input weight matrix
+   * @param[in] N   State-input weight matrix
+   * @param[in] f   Dynamics drift
+   * @param[in] q   State weight vector
+   * @param[in] r   Input weight vector
+   */
+  void set_LQR(const MatrixXs& Aq, const MatrixXs& Av, const MatrixXs& B,
+               const MatrixXs& Q, const MatrixXs& R, const MatrixXs& N,
+               const VectorXs& f, const VectorXs& q, const VectorXs& r);
 
   DEPRECATED("Use get_Aq", const MatrixXs& get_Fq() const { return get_Aq(); })
   DEPRECATED("Use get_Av", const MatrixXs& get_Fv() const { return get_Av(); })
@@ -115,15 +105,42 @@ class DifferentialActionModelLQRTpl
   DEPRECATED("Use get_Q", const MatrixXs& get_Lxx() const { return get_Q(); })
   DEPRECATED("Use get_N", const MatrixXs& get_Lxu() const { return get_N(); })
   DEPRECATED("Use get_R", const MatrixXs& get_Luu() const { return get_R(); })
-  DEPRECATED("Use set_Aq", void set_Fq(const MatrixXs& Aq) { set_Aq(Aq); })
-  DEPRECATED("Use set_Av", void set_Fv(const MatrixXs& Av) { set_Av(Av); })
-  DEPRECATED("Use set_B", void set_Fu(const MatrixXs& B) { set_B(B); })
-  DEPRECATED("Use set_f", void set_f0(const VectorXs& f) { set_f(f); })
-  DEPRECATED("Use set_q", void set_lx(const VectorXs& q) { set_q(q); })
-  DEPRECATED("Use set_r", void set_lu(const VectorXs& r) { set_r(r); })
-  DEPRECATED("Use set_Q", void set_Lxx(const MatrixXs& Q) { set_Q(Q); })
-  DEPRECATED("Use set_N", void set_Lxu(const MatrixXs& N) { set_N(N); })
-  DEPRECATED("Use set_R", void set_Luu(const MatrixXs& R) { set_R(R); })
+  DEPRECATED(
+      "Use set_LQR", void set_Fq(const MatrixXs& Aq) {
+        set_LQR(Aq, Av_, B_, Q_, R_, N_, f_, q_, r_);
+      })
+  DEPRECATED(
+      "Use set_LQR", void set_Fv(const MatrixXs& Av) {
+        set_LQR(Aq_, Av, B_, Q_, R_, N_, f_, q_, r_);
+      })
+  DEPRECATED(
+      "Use set_LQR", void set_Fu(const MatrixXs& B) {
+        set_LQR(Aq_, Av_, B, Q_, R_, N_, f_, q_, r_);
+      })
+  DEPRECATED(
+      "Use set_LQR", void set_f0(const VectorXs& f) {
+        set_LQR(Aq_, Av_, B_, Q_, R_, N_, f, q_, r_);
+      })
+  DEPRECATED(
+      "Use set_LQR", void set_lx(const VectorXs& q) {
+        set_LQR(Aq_, Av_, B_, Q_, R_, N_, f_, q, r_);
+      })
+  DEPRECATED(
+      "Use set_LQR", void set_lu(const VectorXs& r) {
+        set_LQR(Aq_, Av_, B_, Q_, R_, N_, f_, q_, r);
+      })
+  DEPRECATED(
+      "Use set_LQR", void set_Lxx(const MatrixXs& Q) {
+        set_LQR(Aq_, Av_, B_, Q, R_, N_, f_, q_, r_);
+      })
+  DEPRECATED(
+      "Use set_LQR", void set_Lxu(const MatrixXs& N) {
+        set_LQR(Aq_, Av_, B_, Q_, R_, N, f_, q_, r_);
+      })
+  DEPRECATED(
+      "Use set_LQR", void set_Luu(const MatrixXs& R) {
+        set_LQR(Aq_, Av_, B_, Q_, R, N_, f_, q_, r_);
+      })
 
   /**
    * @brief Print relevant information of the LQR model
@@ -146,6 +163,7 @@ class DifferentialActionModelLQRTpl
   VectorXs f_;
   VectorXs q_;
   VectorXs r_;
+  MatrixXs H_;
   bool drift_free_;
 };
 

--- a/include/crocoddyl/core/actions/diff-lqr.hpp
+++ b/include/crocoddyl/core/actions/diff-lqr.hpp
@@ -32,8 +32,50 @@ class DifferentialActionModelLQRTpl
   typedef typename MathBase::VectorXs VectorXs;
   typedef typename MathBase::MatrixXs MatrixXs;
 
+  /**
+   * @brief Initialize the LQR action model
+   *
+   * @param[in] Aq  Position matrix
+   * @param[in] Av  Velocity matrix
+   * @param[in] B   Input matrix
+   * @param[in] Q   State weight matrix
+   * @param[in] R   Input weight matrix
+   * @param[in] N   State-input weight matrix
+   */
+  DifferentialActionModelLQRTpl(const MatrixXs& Aq, const MatrixXs& Av,
+                                const MatrixXs& B, const MatrixXs& Q,
+                                const MatrixXs& R, const MatrixXs& N);
+
+  /**
+   * @brief Initialize the LQR action model
+   *
+   * @param[in] Aq  Position matrix
+   * @param[in] Av  Velocity matrix
+   * @param[in] B   Input matrix
+   * @param[in] Q   State weight matrix
+   * @param[in] R   Input weight matrix
+   * @param[in] N   State-input weight matrix
+   * @param[in] f   Dynamics drift
+   * @param[in] q   State weight vector
+   * @param[in] r   Input weight vector
+   */
+  DifferentialActionModelLQRTpl(const MatrixXs& Aq, const MatrixXs& Av,
+                                const MatrixXs& B, const MatrixXs& Q,
+                                const MatrixXs& R, const MatrixXs& N,
+                                const VectorXs& f, const VectorXs& q,
+                                const VectorXs& r);
+
+  /**
+   * @brief Initialize the LQR action model
+   *
+   * @param[in] nq         Dimension of position vector
+   * @param[in] nu         Dimension of control vector
+   * @param[in] drif_free  Enable / disable the bias term of the linear dynamics
+   * (default true)
+   */
   DifferentialActionModelLQRTpl(const std::size_t nq, const std::size_t nu,
                                 const bool drift_free = true);
+
   virtual ~DifferentialActionModelLQRTpl();
 
   virtual void calc(
@@ -51,6 +93,15 @@ class DifferentialActionModelLQRTpl
   virtual boost::shared_ptr<DifferentialActionDataAbstract> createData();
   virtual bool checkData(
       const boost::shared_ptr<DifferentialActionDataAbstract>& data);
+
+  /**
+   * @brief Create a random LQR model
+   *
+   * @param[in] nq  Position dimension
+   * @param[in] nu  Control dimension
+   */
+  static DifferentialActionModelLQRTpl Random(const std::size_t nq,
+                                              const std::size_t nu);
 
   /** @brief Return the position matrix */
   const MatrixXs& get_Aq() const;

--- a/include/crocoddyl/core/actions/diff-lqr.hpp
+++ b/include/crocoddyl/core/actions/diff-lqr.hpp
@@ -297,6 +297,7 @@ class DifferentialActionModelLQRTpl
   VectorXs h_;
   MatrixXs L_;
   bool drift_free_;
+  bool updated_lqr_;
 };
 
 template <typename _Scalar>
@@ -311,19 +312,28 @@ struct DifferentialActionDataLQRTpl
   template <template <typename Scalar> class Model>
   explicit DifferentialActionDataLQRTpl(Model<Scalar>* const model)
       : Base(model) {
-    // Setting the linear model and quadratic cost here because they are
-    // constant
-    Fx.leftCols(model->get_state()->get_nq()) = model->get_Aq();
-    Fx.rightCols(model->get_state()->get_nv()) = model->get_Av();
+    // Setting the linear model and quadratic cost as they are constant
+    const std::size_t nq = model->get_state()->get_nq();
+    const std::size_t nu = model->get_nu();
+    Fx.leftCols(nq) = model->get_Aq();
+    Fx.rightCols(nq) = model->get_Av();
     Fu = model->get_B();
     Lxx = model->get_Q();
     Luu = model->get_R();
     Lxu = model->get_N();
+    Gx = model->get_G().leftCols(2 * nq);
+    Gu = model->get_G().rightCols(nu);
+    Hx = model->get_H().leftCols(2 * nq);
+    Hu = model->get_H().rightCols(nu);
   }
 
   using Base::cost;
   using Base::Fu;
   using Base::Fx;
+  using Base::Gu;
+  using Base::Gx;
+  using Base::Hu;
+  using Base::Hx;
   using Base::Lu;
   using Base::Luu;
   using Base::Lx;

--- a/include/crocoddyl/core/actions/diff-lqr.hpp
+++ b/include/crocoddyl/core/actions/diff-lqr.hpp
@@ -52,25 +52,44 @@ class DifferentialActionModelLQRTpl
   virtual bool checkData(
       const boost::shared_ptr<DifferentialActionDataAbstract>& data);
 
-  const MatrixXs& get_Fq() const;
-  const MatrixXs& get_Fv() const;
-  const MatrixXs& get_Fu() const;
-  const VectorXs& get_f0() const;
-  const VectorXs& get_lx() const;
-  const VectorXs& get_lu() const;
-  const MatrixXs& get_Lxx() const;
-  const MatrixXs& get_Lxu() const;
-  const MatrixXs& get_Luu() const;
+  const MatrixXs& get_Aq() const;
+  const MatrixXs& get_Av() const;
+  const MatrixXs& get_B() const;
+  const VectorXs& get_f() const;
+  const VectorXs& get_q() const;
+  const VectorXs& get_r() const;
+  const MatrixXs& get_Q() const;
+  const MatrixXs& get_R() const;
+  const MatrixXs& get_N() const;
 
-  void set_Fq(const MatrixXs& Fq);
-  void set_Fv(const MatrixXs& Fv);
-  void set_Fu(const MatrixXs& Fu);
-  void set_f0(const VectorXs& f0);
-  void set_lx(const VectorXs& lx);
-  void set_lu(const VectorXs& lu);
-  void set_Lxx(const MatrixXs& Lxx);
-  void set_Lxu(const MatrixXs& Lxu);
-  void set_Luu(const MatrixXs& Luu);
+  void set_Aq(const MatrixXs& Aq);
+  void set_Av(const MatrixXs& Av);
+  void set_B(const MatrixXs& B);
+  void set_f(const VectorXs& f);
+  void set_Q(const MatrixXs& Q);
+  void set_R(const MatrixXs& R);
+  void set_N(const MatrixXs& N);
+  void set_q(const VectorXs& q);
+  void set_r(const VectorXs& r);
+
+  DEPRECATED("Use get_Aq", const MatrixXs& get_Fq() const { return get_Aq(); })
+  DEPRECATED("Use get_Av", const MatrixXs& get_Fv() const { return get_Av(); })
+  DEPRECATED("Use get_B", const MatrixXs& get_Fu() const { return get_B(); })
+  DEPRECATED("Use get_f", const VectorXs& get_f0() const { return get_f(); })
+  DEPRECATED("Use get_q", const VectorXs& get_lx() const { return get_q(); })
+  DEPRECATED("Use get_r", const VectorXs& get_lu() const { return get_r(); })
+  DEPRECATED("Use get_Q", const MatrixXs& get_Lxx() const { return get_Q(); })
+  DEPRECATED("Use get_N", const MatrixXs& get_Lxu() const { return get_N(); })
+  DEPRECATED("Use get_R", const MatrixXs& get_Luu() const { return get_R(); })
+  DEPRECATED("Use set_Aq", void set_Fq(const MatrixXs& Aq) { set_Aq(Aq); })
+  DEPRECATED("Use set_Av", void set_Fv(const MatrixXs& Av) { set_Av(Av); })
+  DEPRECATED("Use set_B", void set_Fu(const MatrixXs& B) { set_B(B); })
+  DEPRECATED("Use set_f", void set_f0(const VectorXs& f) { set_f(f); })
+  DEPRECATED("Use set_q", void set_lx(const VectorXs& q) { set_q(q); })
+  DEPRECATED("Use set_r", void set_lu(const VectorXs& r) { set_r(r); })
+  DEPRECATED("Use set_Q", void set_Lxx(const MatrixXs& Q) { set_Q(Q); })
+  DEPRECATED("Use set_N", void set_Lxu(const MatrixXs& N) { set_N(N); })
+  DEPRECATED("Use set_R", void set_Luu(const MatrixXs& R) { set_R(R); })
 
   /**
    * @brief Print relevant information of the LQR model
@@ -110,12 +129,12 @@ struct DifferentialActionDataLQRTpl
       : Base(model) {
     // Setting the linear model and quadratic cost here because they are
     // constant
-    Fx.leftCols(model->get_state()->get_nq()) = model->get_Fq();
-    Fx.rightCols(model->get_state()->get_nv()) = model->get_Fv();
-    Fu = model->get_Fu();
-    Lxx = model->get_Lxx();
-    Luu = model->get_Luu();
-    Lxu = model->get_Lxu();
+    Fx.leftCols(model->get_state()->get_nq()) = model->get_Aq();
+    Fx.rightCols(model->get_state()->get_nv()) = model->get_Av();
+    Fu = model->get_B();
+    Lxx = model->get_Q();
+    Luu = model->get_R();
+    Lxu = model->get_N();
   }
 
   using Base::cost;

--- a/include/crocoddyl/core/actions/diff-lqr.hpp
+++ b/include/crocoddyl/core/actions/diff-lqr.hpp
@@ -18,6 +18,31 @@
 
 namespace crocoddyl {
 
+/**
+ * @brief Linear-quadratic regulator (LQR) differential action model
+ *
+ * A linear-quadratic regulator (LQR) action has a transition model of the form
+ * \f[ \begin{equation}
+ *   \mathbf{\dot{v}} = \mathbf{A_q q + A_v v + B u + f}.
+ * \end{equation} \f]
+ * Its cost function is quadratic of the form:
+ * \f[ \begin{equation}
+ * \ell(\mathbf{x},\mathbf{u}) = \begin{bmatrix}1
+ * \\ \mathbf{x} \\ \mathbf{u}\end{bmatrix}^T \begin{bmatrix}0 &
+ * \mathbf{q}^T & \mathbf{r}^T \\ \mathbf{q} & \mathbf{Q}
+ * &
+ * \mathbf{N}^T \\
+ * \mathbf{r} & \mathbf{N} & \mathbf{R}\end{bmatrix}
+ * \begin{bmatrix}1 \\ \mathbf{x} \\
+ * \mathbf{u}\end{bmatrix}
+ * \end{equation} \f]
+ * and the linear equality and inequality constraints has the form:
+ * \f[ \begin{aligned}
+ * \mathbf{g(x,u)} =  \mathbf{G}\begin{bmatrix} \mathbf{x} \\ \mathbf{u}
+ * \end{bmatrix} [x,u] + \mathbf{g}
+ * &\mathbf{h(x,u)} = \mathbf{H}\begin{bmatrix} \mathbf{x} \\ \mathbf{u}
+ * \end{bmatrix} [x,u] + \mathbf{h} \leq \mathbf{0} \end{aligned} \f]
+ */
 template <typename _Scalar>
 class DifferentialActionModelLQRTpl
     : public DifferentialActionModelAbstractTpl<_Scalar> {
@@ -68,6 +93,31 @@ class DifferentialActionModelLQRTpl
   /**
    * @brief Initialize the LQR action model
    *
+   * @param[in] Aq  Position matrix
+   * @param[in] Av  Velocity matrix
+   * @param[in] B   Input matrix
+   * @param[in] Q   State weight matrix
+   * @param[in] R   Input weight matrix
+   * @param[in] N   State-input weight matrix
+   * @param[in] H  State-input equality constraint matrix
+   * @param[in] G  State-input inequality constraint matrix
+   * @param[in] f   Dynamics drift
+   * @param[in] q   State weight vector
+   * @param[in] r   Input weight vector
+   * @param[in] g  State-input equality constraint bias
+   * @param[in] h  State-input inequality constraint bias
+   */
+  DifferentialActionModelLQRTpl(const MatrixXs& Aq, const MatrixXs& Av,
+                                const MatrixXs& B, const MatrixXs& Q,
+                                const MatrixXs& R, const MatrixXs& N,
+                                const MatrixXs& G, const MatrixXs& H,
+                                const VectorXs& f, const VectorXs& q,
+                                const VectorXs& r, const VectorXs& g,
+                                const VectorXs& h);
+
+  /**
+   * @brief Initialize the LQR action model
+   *
    * @param[in] nq         Dimension of position vector
    * @param[in] nu         Dimension of control vector
    * @param[in] drif_free  Enable / disable the bias term of the linear dynamics
@@ -102,9 +152,13 @@ class DifferentialActionModelLQRTpl
    *
    * @param[in] nq  Position dimension
    * @param[in] nu  Control dimension
+   * @param[in] ng  Equality constraint dimension (default 0)
+   * @param[in] nh  Inequality constraint dimension (default 0)
    */
   static DifferentialActionModelLQRTpl Random(const std::size_t nq,
-                                              const std::size_t nu);
+                                              const std::size_t nu,
+                                              const std::size_t ng = 0,
+                                              const std::size_t nh = 0);
 
   /** @brief Return the position matrix */
   const MatrixXs& get_Aq() const;
@@ -127,11 +181,23 @@ class DifferentialActionModelLQRTpl
   /** @brief Return the state-input weight matrix */
   const MatrixXs& get_N() const;
 
+  /** @brief Return the state-input equality constraint matrix */
+  const MatrixXs& get_G() const;
+
+  /** @brief Return the state-input inequality constraint matrix */
+  const MatrixXs& get_H() const;
+
   /** @brief Return the state weight vector */
   const VectorXs& get_q() const;
 
   /** @brief Return the input weight vector */
   const VectorXs& get_r() const;
+
+  /** @brief Return the state-input equality constraint bias */
+  const VectorXs& get_g() const;
+
+  /** @brief Return the state-input inequality constraint bias */
+  const VectorXs& get_h() const;
 
   /**
    * @brief Modify the LQR action model
@@ -142,13 +208,19 @@ class DifferentialActionModelLQRTpl
    * @param[in] Q   State weight matrix
    * @param[in] R   Input weight matrix
    * @param[in] N   State-input weight matrix
+   * @param[in] G  State-input equality constraint matrix
+   * @param[in] H  State-input inequality constraint matrix
    * @param[in] f   Dynamics drift
    * @param[in] q   State weight vector
    * @param[in] r   Input weight vector
+   * @param[in] g  State-input equality constraint bias
+   * @param[in] h  State-input inequality constraint bias
    */
   void set_LQR(const MatrixXs& Aq, const MatrixXs& Av, const MatrixXs& B,
                const MatrixXs& Q, const MatrixXs& R, const MatrixXs& N,
-               const VectorXs& f, const VectorXs& q, const VectorXs& r);
+               const MatrixXs& G, const MatrixXs& H, const VectorXs& f,
+               const VectorXs& q, const VectorXs& r, const VectorXs& g,
+               const VectorXs& h);
 
   DEPRECATED("Use get_Aq", const MatrixXs& get_Fq() const { return get_Aq(); })
   DEPRECATED("Use get_Av", const MatrixXs& get_Fv() const { return get_Av(); })
@@ -161,39 +233,39 @@ class DifferentialActionModelLQRTpl
   DEPRECATED("Use get_R", const MatrixXs& get_Luu() const { return get_R(); })
   DEPRECATED(
       "Use set_LQR", void set_Fq(const MatrixXs& Aq) {
-        set_LQR(Aq, Av_, B_, Q_, R_, N_, f_, q_, r_);
+        set_LQR(Aq, Av_, B_, Q_, R_, N_, G_, H_, f_, q_, r_, g_, h_);
       })
   DEPRECATED(
       "Use set_LQR", void set_Fv(const MatrixXs& Av) {
-        set_LQR(Aq_, Av, B_, Q_, R_, N_, f_, q_, r_);
+        set_LQR(Aq_, Av, B_, Q_, R_, N_, G_, H_, f_, q_, r_, g_, h_);
       })
   DEPRECATED(
       "Use set_LQR", void set_Fu(const MatrixXs& B) {
-        set_LQR(Aq_, Av_, B, Q_, R_, N_, f_, q_, r_);
+        set_LQR(Aq_, Av_, B, Q_, R_, N_, G_, H_, f_, q_, r_, g_, h_);
       })
   DEPRECATED(
       "Use set_LQR", void set_f0(const VectorXs& f) {
-        set_LQR(Aq_, Av_, B_, Q_, R_, N_, f, q_, r_);
+        set_LQR(Aq_, Av_, B_, Q_, R_, N_, G_, H_, f, q_, r_, g_, h_);
       })
   DEPRECATED(
       "Use set_LQR", void set_lx(const VectorXs& q) {
-        set_LQR(Aq_, Av_, B_, Q_, R_, N_, f_, q, r_);
+        set_LQR(Aq_, Av_, B_, Q_, R_, N_, G_, H_, f_, q, r_, g_, h_);
       })
   DEPRECATED(
       "Use set_LQR", void set_lu(const VectorXs& r) {
-        set_LQR(Aq_, Av_, B_, Q_, R_, N_, f_, q_, r);
+        set_LQR(Aq_, Av_, B_, Q_, R_, N_, G_, H_, f_, q_, r, g_, h_);
       })
   DEPRECATED(
       "Use set_LQR", void set_Lxx(const MatrixXs& Q) {
-        set_LQR(Aq_, Av_, B_, Q, R_, N_, f_, q_, r_);
+        set_LQR(Aq_, Av_, B_, Q, R_, N_, G_, H_, f_, q_, r_, g_, h_);
       })
   DEPRECATED(
       "Use set_LQR", void set_Lxu(const MatrixXs& N) {
-        set_LQR(Aq_, Av_, B_, Q_, R_, N, f_, q_, r_);
+        set_LQR(Aq_, Av_, B_, Q_, R_, N, G_, H_, f_, q_, r_, g_, h_);
       })
   DEPRECATED(
       "Use set_LQR", void set_Luu(const MatrixXs& R) {
-        set_LQR(Aq_, Av_, B_, Q_, R, N_, f_, q_, r_);
+        set_LQR(Aq_, Av_, B_, Q_, R, N_, G_, H_, f_, q_, r_, g_, h_);
       })
 
   /**
@@ -204,6 +276,8 @@ class DifferentialActionModelLQRTpl
   virtual void print(std::ostream& os) const;
 
  protected:
+  using Base::ng_;     //!< Equality constraint dimension
+  using Base::nh_;     //!< Inequality constraint dimension
   using Base::nu_;     //!< Control dimension
   using Base::state_;  //!< Model of the state
 
@@ -214,10 +288,14 @@ class DifferentialActionModelLQRTpl
   MatrixXs Q_;
   MatrixXs R_;
   MatrixXs N_;
+  MatrixXs G_;
+  MatrixXs H_;
   VectorXs f_;
   VectorXs q_;
   VectorXs r_;
-  MatrixXs H_;
+  VectorXs g_;
+  VectorXs h_;
+  MatrixXs L_;
   bool drift_free_;
 };
 

--- a/include/crocoddyl/core/actions/diff-lqr.hpp
+++ b/include/crocoddyl/core/actions/diff-lqr.hpp
@@ -1,7 +1,8 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2021, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2019-2024, LAAS-CNRS, University of Edinburgh,
+//                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -84,15 +85,15 @@ class DifferentialActionModelLQRTpl
 
  private:
   bool drift_free_;
-  MatrixXs Fq_;
-  MatrixXs Fv_;
-  MatrixXs Fu_;
-  VectorXs f0_;
-  MatrixXs Lxx_;
-  MatrixXs Lxu_;
-  MatrixXs Luu_;
-  VectorXs lx_;
-  VectorXs lu_;
+  MatrixXs Aq_;
+  MatrixXs Av_;
+  MatrixXs B_;
+  MatrixXs Q_;
+  MatrixXs R_;
+  MatrixXs N_;
+  VectorXs f_;
+  VectorXs q_;
+  VectorXs r_;
 };
 
 template <typename _Scalar>

--- a/include/crocoddyl/core/actions/diff-lqr.hpp
+++ b/include/crocoddyl/core/actions/diff-lqr.hpp
@@ -76,6 +76,9 @@ class DifferentialActionModelLQRTpl
   DifferentialActionModelLQRTpl(const std::size_t nq, const std::size_t nu,
                                 const bool drift_free = true);
 
+  /** @brief Copy constructor */
+  DifferentialActionModelLQRTpl(const DifferentialActionModelLQRTpl& copy);
+
   virtual ~DifferentialActionModelLQRTpl();
 
   virtual void calc(

--- a/include/crocoddyl/core/actions/diff-lqr.hxx
+++ b/include/crocoddyl/core/actions/diff-lqr.hxx
@@ -203,103 +203,77 @@ DifferentialActionModelLQRTpl<Scalar>::get_r() const {
 }
 
 template <typename Scalar>
-void DifferentialActionModelLQRTpl<Scalar>::set_Aq(const MatrixXs& Aq) {
-  if (static_cast<std::size_t>(Aq.rows()) != state_->get_nq() ||
-      static_cast<std::size_t>(Aq.cols()) != state_->get_nq()) {
+void DifferentialActionModelLQRTpl<Scalar>::set_LQR(
+    const MatrixXs& Aq, const MatrixXs& Av, const MatrixXs& B,
+    const MatrixXs& Q, const MatrixXs& R, const MatrixXs& N, const VectorXs& f,
+    const VectorXs& q, const VectorXs& r) {
+  const std::size_t nq = state_->get_nq();
+  if (static_cast<std::size_t>(Aq.rows()) != nq) {
     throw_pretty("Invalid argument: "
-                 << "Aq has wrong dimension (it should be " +
-                        std::to_string(state_->get_nq()) + "," +
-                        std::to_string(state_->get_nq()) + ")");
+                 << "Aq should be a squared matrix with size " +
+                        std::to_string(nq));
   }
-  Aq_ = Aq;
-}
-
-template <typename Scalar>
-void DifferentialActionModelLQRTpl<Scalar>::set_Av(const MatrixXs& Av) {
-  if (static_cast<std::size_t>(Av.rows()) != state_->get_nv() ||
-      static_cast<std::size_t>(Av.cols()) != state_->get_nv()) {
+  if (static_cast<std::size_t>(Av.rows()) != nq) {
     throw_pretty("Invalid argument: "
-                 << "Av has wrong dimension (it should be " +
-                        std::to_string(state_->get_nv()) + "," +
-                        std::to_string(state_->get_nv()) + ")");
+                 << "Av should be a squared matrix with size " +
+                        std::to_string(nq));
   }
-  Av_ = Av;
-}
-
-template <typename Scalar>
-void DifferentialActionModelLQRTpl<Scalar>::set_B(const MatrixXs& B) {
-  if (static_cast<std::size_t>(B.rows()) != state_->get_nv() ||
-      static_cast<std::size_t>(B.cols()) != nu_) {
+  if (static_cast<std::size_t>(B.rows()) != nq) {
     throw_pretty("Invalid argument: "
-                 << "B has wrong dimension (it should be " +
-                        std::to_string(state_->get_nv()) + "," +
-                        std::to_string(nu_) + ")");
+                 << "B has wrong dimension (it should have " +
+                        std::to_string(nq) + " rows)");
   }
-  B_ = B;
-}
-
-template <typename Scalar>
-void DifferentialActionModelLQRTpl<Scalar>::set_f(const VectorXs& f) {
-  if (static_cast<std::size_t>(f.size()) != state_->get_nv()) {
-    throw_pretty("Invalid argument: "
-                 << "f has wrong dimension (it should be " +
-                        std::to_string(state_->get_nv()) + ")");
-  }
-  f_ = f;
-}
-
-template <typename Scalar>
-void DifferentialActionModelLQRTpl<Scalar>::set_Q(const MatrixXs& Q) {
-  if (static_cast<std::size_t>(Q.rows()) != state_->get_nx() ||
-      static_cast<std::size_t>(Q.cols()) != state_->get_nx()) {
+  if (static_cast<std::size_t>(Q.rows()) != 2 * nq ||
+      static_cast<std::size_t>(Q.cols()) != 2 * nq) {
     throw_pretty("Invalid argument: "
                  << "Q has wrong dimension (it should be " +
-                        std::to_string(state_->get_nx()) + "," +
-                        std::to_string(state_->get_nx()) + ")");
+                        std::to_string(2 * nq) + "x " + std::to_string(2 * nq) +
+                        ")");
   }
-  Q_ = Q;
-}
-
-template <typename Scalar>
-void DifferentialActionModelLQRTpl<Scalar>::set_R(const MatrixXs& R) {
   if (static_cast<std::size_t>(R.rows()) != nu_ ||
       static_cast<std::size_t>(R.cols()) != nu_) {
     throw_pretty("Invalid argument: "
                  << "R has wrong dimension (it should be " +
-                        std::to_string(nu_) + "," + std::to_string(nu_) + ")");
+                        std::to_string(nu_) + "x " + std::to_string(nu_) + ")");
   }
-  R_ = R;
-}
-
-template <typename Scalar>
-void DifferentialActionModelLQRTpl<Scalar>::set_N(const MatrixXs& N) {
-  if (static_cast<std::size_t>(N.rows()) != state_->get_nx() ||
+  if (static_cast<std::size_t>(N.rows()) != 2 * nq ||
       static_cast<std::size_t>(N.cols()) != nu_) {
     throw_pretty("Invalid argument: "
                  << "N has wrong dimension (it should be " +
-                        std::to_string(state_->get_nx()) + "," +
-                        std::to_string(nu_) + ")");
+                        std::to_string(2 * nq) + "x " + std::to_string(nu_) +
+                        ")");
   }
-  N_ = N;
-}
-
-template <typename Scalar>
-void DifferentialActionModelLQRTpl<Scalar>::set_q(const VectorXs& q) {
-  if (static_cast<std::size_t>(q.size()) != state_->get_nx()) {
+  if (static_cast<std::size_t>(f.size()) != nq) {
+    throw_pretty("Invalid argument: "
+                 << "f has wrong dimension (it should be " +
+                        std::to_string(nq) + ")");
+  }
+  if (static_cast<std::size_t>(q.size()) != 2 * nq) {
     throw_pretty("Invalid argument: "
                  << "q has wrong dimension (it should be " +
-                        std::to_string(state_->get_nx()) + ")");
+                        std::to_string(2 * nq) + ")");
   }
-  q_ = q;
-}
-
-template <typename Scalar>
-void DifferentialActionModelLQRTpl<Scalar>::set_r(const VectorXs& r) {
   if (static_cast<std::size_t>(r.size()) != nu_) {
     throw_pretty("Invalid argument: "
                  << "r has wrong dimension (it should be " +
                         std::to_string(nu_) + ")");
   }
+  H_ = MatrixXs::Zero(2 * nq + nu_, 2 * nq + nu_);
+  H_ << Q, N, N.transpose(), R;
+  Eigen::LLT<MatrixXs> H_llt(H_);
+  if (!H_.isApprox(H_.transpose()) || H_llt.info() == Eigen::NumericalIssue) {
+    throw_pretty("Invalid argument "
+                 << "[Q, N; N.T, R] is not semi-positive definite");
+  }
+
+  Aq_ = Aq;
+  Av_ = Av;
+  B_ = B;
+  f_ = f;
+  Q_ = Q;
+  R_ = R;
+  N_ = N;
+  q_ = q;
   r_ = r;
 }
 

--- a/include/crocoddyl/core/actions/diff-lqr.hxx
+++ b/include/crocoddyl/core/actions/diff-lqr.hxx
@@ -155,157 +155,157 @@ void DifferentialActionModelLQRTpl<Scalar>::print(std::ostream& os) const {
 
 template <typename Scalar>
 const typename MathBaseTpl<Scalar>::MatrixXs&
-DifferentialActionModelLQRTpl<Scalar>::get_Fq() const {
+DifferentialActionModelLQRTpl<Scalar>::get_Aq() const {
   return Aq_;
 }
 
 template <typename Scalar>
 const typename MathBaseTpl<Scalar>::MatrixXs&
-DifferentialActionModelLQRTpl<Scalar>::get_Fv() const {
+DifferentialActionModelLQRTpl<Scalar>::get_Av() const {
   return Av_;
 }
 
 template <typename Scalar>
 const typename MathBaseTpl<Scalar>::MatrixXs&
-DifferentialActionModelLQRTpl<Scalar>::get_Fu() const {
+DifferentialActionModelLQRTpl<Scalar>::get_B() const {
   return B_;
 }
 
 template <typename Scalar>
 const typename MathBaseTpl<Scalar>::VectorXs&
-DifferentialActionModelLQRTpl<Scalar>::get_f0() const {
+DifferentialActionModelLQRTpl<Scalar>::get_f() const {
   return f_;
 }
 
 template <typename Scalar>
-const typename MathBaseTpl<Scalar>::VectorXs&
-DifferentialActionModelLQRTpl<Scalar>::get_lx() const {
-  return q_;
-}
-
-template <typename Scalar>
-const typename MathBaseTpl<Scalar>::VectorXs&
-DifferentialActionModelLQRTpl<Scalar>::get_lu() const {
-  return r_;
-}
-
-template <typename Scalar>
 const typename MathBaseTpl<Scalar>::MatrixXs&
-DifferentialActionModelLQRTpl<Scalar>::get_Lxx() const {
+DifferentialActionModelLQRTpl<Scalar>::get_Q() const {
   return Q_;
 }
 
 template <typename Scalar>
 const typename MathBaseTpl<Scalar>::MatrixXs&
-DifferentialActionModelLQRTpl<Scalar>::get_Lxu() const {
-  return N_;
-}
-
-template <typename Scalar>
-const typename MathBaseTpl<Scalar>::MatrixXs&
-DifferentialActionModelLQRTpl<Scalar>::get_Luu() const {
+DifferentialActionModelLQRTpl<Scalar>::get_R() const {
   return R_;
 }
 
 template <typename Scalar>
-void DifferentialActionModelLQRTpl<Scalar>::set_Fq(const MatrixXs& Fq) {
-  if (static_cast<std::size_t>(Fq.rows()) != state_->get_nq() ||
-      static_cast<std::size_t>(Fq.cols()) != state_->get_nq()) {
+const typename MathBaseTpl<Scalar>::MatrixXs&
+DifferentialActionModelLQRTpl<Scalar>::get_N() const {
+  return N_;
+}
+
+template <typename Scalar>
+const typename MathBaseTpl<Scalar>::VectorXs&
+DifferentialActionModelLQRTpl<Scalar>::get_q() const {
+  return q_;
+}
+
+template <typename Scalar>
+const typename MathBaseTpl<Scalar>::VectorXs&
+DifferentialActionModelLQRTpl<Scalar>::get_r() const {
+  return r_;
+}
+
+template <typename Scalar>
+void DifferentialActionModelLQRTpl<Scalar>::set_Aq(const MatrixXs& Aq) {
+  if (static_cast<std::size_t>(Aq.rows()) != state_->get_nq() ||
+      static_cast<std::size_t>(Aq.cols()) != state_->get_nq()) {
     throw_pretty("Invalid argument: "
-                 << "Fq has wrong dimension (it should be " +
+                 << "Aq has wrong dimension (it should be " +
                         std::to_string(state_->get_nq()) + "," +
                         std::to_string(state_->get_nq()) + ")");
   }
-  Aq_ = Fq;
+  Aq_ = Aq;
 }
 
 template <typename Scalar>
-void DifferentialActionModelLQRTpl<Scalar>::set_Fv(const MatrixXs& Fv) {
-  if (static_cast<std::size_t>(Fv.rows()) != state_->get_nv() ||
-      static_cast<std::size_t>(Fv.cols()) != state_->get_nv()) {
+void DifferentialActionModelLQRTpl<Scalar>::set_Av(const MatrixXs& Av) {
+  if (static_cast<std::size_t>(Av.rows()) != state_->get_nv() ||
+      static_cast<std::size_t>(Av.cols()) != state_->get_nv()) {
     throw_pretty("Invalid argument: "
-                 << "Fv has wrong dimension (it should be " +
+                 << "Av has wrong dimension (it should be " +
                         std::to_string(state_->get_nv()) + "," +
                         std::to_string(state_->get_nv()) + ")");
   }
-  Av_ = Fv;
+  Av_ = Av;
 }
 
 template <typename Scalar>
-void DifferentialActionModelLQRTpl<Scalar>::set_Fu(const MatrixXs& Fu) {
-  if (static_cast<std::size_t>(Fu.rows()) != state_->get_nq() ||
-      static_cast<std::size_t>(Fu.cols()) != nu_) {
+void DifferentialActionModelLQRTpl<Scalar>::set_B(const MatrixXs& B) {
+  if (static_cast<std::size_t>(B.rows()) != state_->get_nv() ||
+      static_cast<std::size_t>(B.cols()) != nu_) {
     throw_pretty("Invalid argument: "
-                 << "Fu has wrong dimension (it should be " +
-                        std::to_string(state_->get_nq()) + "," +
+                 << "B has wrong dimension (it should be " +
+                        std::to_string(state_->get_nv()) + "," +
                         std::to_string(nu_) + ")");
   }
-  B_ = Fu;
+  B_ = B;
 }
 
 template <typename Scalar>
-void DifferentialActionModelLQRTpl<Scalar>::set_f0(const VectorXs& f0) {
-  if (static_cast<std::size_t>(f0.size()) != state_->get_nv()) {
+void DifferentialActionModelLQRTpl<Scalar>::set_f(const VectorXs& f) {
+  if (static_cast<std::size_t>(f.size()) != state_->get_nv()) {
     throw_pretty("Invalid argument: "
-                 << "f0 has wrong dimension (it should be " +
+                 << "f has wrong dimension (it should be " +
                         std::to_string(state_->get_nv()) + ")");
   }
-  f_ = f0;
+  f_ = f;
 }
 
 template <typename Scalar>
-void DifferentialActionModelLQRTpl<Scalar>::set_lx(const VectorXs& lx) {
-  if (static_cast<std::size_t>(lx.size()) != state_->get_nx()) {
+void DifferentialActionModelLQRTpl<Scalar>::set_Q(const MatrixXs& Q) {
+  if (static_cast<std::size_t>(Q.rows()) != state_->get_nx() ||
+      static_cast<std::size_t>(Q.cols()) != state_->get_nx()) {
     throw_pretty("Invalid argument: "
-                 << "lx has wrong dimension (it should be " +
-                        std::to_string(state_->get_nx()) + ")");
-  }
-  q_ = lx;
-}
-
-template <typename Scalar>
-void DifferentialActionModelLQRTpl<Scalar>::set_lu(const VectorXs& lu) {
-  if (static_cast<std::size_t>(lu.size()) != nu_) {
-    throw_pretty("Invalid argument: "
-                 << "lu has wrong dimension (it should be " +
-                        std::to_string(nu_) + ")");
-  }
-  r_ = lu;
-}
-
-template <typename Scalar>
-void DifferentialActionModelLQRTpl<Scalar>::set_Lxx(const MatrixXs& Lxx) {
-  if (static_cast<std::size_t>(Lxx.rows()) != state_->get_nx() ||
-      static_cast<std::size_t>(Lxx.cols()) != state_->get_nx()) {
-    throw_pretty("Invalid argument: "
-                 << "Lxx has wrong dimension (it should be " +
+                 << "Q has wrong dimension (it should be " +
                         std::to_string(state_->get_nx()) + "," +
                         std::to_string(state_->get_nx()) + ")");
   }
-  Q_ = Lxx;
+  Q_ = Q;
 }
 
 template <typename Scalar>
-void DifferentialActionModelLQRTpl<Scalar>::set_Lxu(const MatrixXs& Lxu) {
-  if (static_cast<std::size_t>(Lxu.rows()) != state_->get_nx() ||
-      static_cast<std::size_t>(Lxu.cols()) != nu_) {
+void DifferentialActionModelLQRTpl<Scalar>::set_R(const MatrixXs& R) {
+  if (static_cast<std::size_t>(R.rows()) != nu_ ||
+      static_cast<std::size_t>(R.cols()) != nu_) {
     throw_pretty("Invalid argument: "
-                 << "Lxu has wrong dimension (it should be " +
-                        std::to_string(state_->get_nx()) + "," +
-                        std::to_string(nu_) + ")");
-  }
-  N_ = Lxu;
-}
-
-template <typename Scalar>
-void DifferentialActionModelLQRTpl<Scalar>::set_Luu(const MatrixXs& Luu) {
-  if (static_cast<std::size_t>(Luu.rows()) != nu_ ||
-      static_cast<std::size_t>(Luu.cols()) != nu_) {
-    throw_pretty("Invalid argument: "
-                 << "Fq has wrong dimension (it should be " +
+                 << "R has wrong dimension (it should be " +
                         std::to_string(nu_) + "," + std::to_string(nu_) + ")");
   }
-  R_ = Luu;
+  R_ = R;
+}
+
+template <typename Scalar>
+void DifferentialActionModelLQRTpl<Scalar>::set_N(const MatrixXs& N) {
+  if (static_cast<std::size_t>(N.rows()) != state_->get_nx() ||
+      static_cast<std::size_t>(N.cols()) != nu_) {
+    throw_pretty("Invalid argument: "
+                 << "N has wrong dimension (it should be " +
+                        std::to_string(state_->get_nx()) + "," +
+                        std::to_string(nu_) + ")");
+  }
+  N_ = N;
+}
+
+template <typename Scalar>
+void DifferentialActionModelLQRTpl<Scalar>::set_q(const VectorXs& q) {
+  if (static_cast<std::size_t>(q.size()) != state_->get_nx()) {
+    throw_pretty("Invalid argument: "
+                 << "q has wrong dimension (it should be " +
+                        std::to_string(state_->get_nx()) + ")");
+  }
+  q_ = q;
+}
+
+template <typename Scalar>
+void DifferentialActionModelLQRTpl<Scalar>::set_r(const VectorXs& r) {
+  if (static_cast<std::size_t>(r.size()) != nu_) {
+    throw_pretty("Invalid argument: "
+                 << "r has wrong dimension (it should be " +
+                        std::to_string(nu_) + ")");
+  }
+  r_ = r;
 }
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/core/actions/diff-lqr.hxx
+++ b/include/crocoddyl/core/actions/diff-lqr.hxx
@@ -51,6 +51,16 @@ DifferentialActionModelLQRTpl<Scalar>::DifferentialActionModelLQRTpl(
       drift_free_(drift_free) {}
 
 template <typename Scalar>
+DifferentialActionModelLQRTpl<Scalar>::DifferentialActionModelLQRTpl(
+    const DifferentialActionModelLQRTpl& copy)
+    : Base(boost::make_shared<StateVector>(2 * copy.get_Aq().cols()),
+           copy.get_B().cols(), 0),
+      drift_free_(false) {
+  set_LQR(copy.get_Aq(), copy.get_Av(), copy.get_B(), copy.get_Q(),
+          copy.get_R(), copy.get_N(), copy.get_f(), copy.get_q(), copy.get_r());
+}
+
+template <typename Scalar>
 DifferentialActionModelLQRTpl<Scalar>::~DifferentialActionModelLQRTpl() {}
 
 template <typename Scalar>

--- a/include/crocoddyl/core/actions/lqr.hpp
+++ b/include/crocoddyl/core/actions/lqr.hpp
@@ -1,7 +1,8 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2021, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2019-2024, LAAS-CNRS, University of Edinburgh
+//                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -77,14 +78,14 @@ class ActionModelLQRTpl : public ActionModelAbstractTpl<_Scalar> {
 
  private:
   bool drift_free_;
-  MatrixXs Fx_;
-  MatrixXs Fu_;
-  VectorXs f0_;
-  MatrixXs Lxx_;
-  MatrixXs Lxu_;
-  MatrixXs Luu_;
-  VectorXs lx_;
-  VectorXs lu_;
+  MatrixXs A_;
+  MatrixXs B_;
+  MatrixXs Q_;
+  MatrixXs R_;
+  MatrixXs N_;
+  VectorXs f_;
+  VectorXs q_;
+  VectorXs r_;
 };
 
 template <typename _Scalar>
@@ -97,8 +98,8 @@ struct ActionDataLQRTpl : public ActionDataAbstractTpl<_Scalar> {
   template <template <typename Scalar> class Model>
   explicit ActionDataLQRTpl(Model<Scalar>* const model)
       : Base(model),
-        Luu_u_tmp(VectorXs::Zero(static_cast<Eigen::Index>(model->get_nu()))),
-        Lxx_x_tmp(VectorXs::Zero(
+        R_u_tmp(VectorXs::Zero(static_cast<Eigen::Index>(model->get_nu()))),
+        Q_x_tmp(VectorXs::Zero(
             static_cast<Eigen::Index>(model->get_state()->get_ndx()))) {
     // Setting the linear model and quadratic cost here because they are
     // constant
@@ -119,10 +120,10 @@ struct ActionDataLQRTpl : public ActionDataAbstractTpl<_Scalar> {
   using Base::Lxx;
   using Base::r;
   using Base::xnext;
-  VectorXs Luu_u_tmp;  // Temporary variable for storing Hessian-vector product
-                       // (size: nu)
-  VectorXs Lxx_x_tmp;  // Temporary variable for storing Hessian-vector product
-                       // (size: nx)
+  VectorXs R_u_tmp;  // Temporary variable for storing Hessian-vector product
+                     // (size: nu)
+  VectorXs Q_x_tmp;  // Temporary variable for storing Hessian-vector product
+                     // (size: nx)
 };
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/core/actions/lqr.hpp
+++ b/include/crocoddyl/core/actions/lqr.hpp
@@ -47,23 +47,40 @@ class ActionModelLQRTpl : public ActionModelAbstractTpl<_Scalar> {
   virtual boost::shared_ptr<ActionDataAbstract> createData();
   virtual bool checkData(const boost::shared_ptr<ActionDataAbstract>& data);
 
-  const MatrixXs& get_Fx() const;
-  const MatrixXs& get_Fu() const;
-  const VectorXs& get_f0() const;
-  const VectorXs& get_lx() const;
-  const VectorXs& get_lu() const;
-  const MatrixXs& get_Lxx() const;
-  const MatrixXs& get_Lxu() const;
-  const MatrixXs& get_Luu() const;
+  const MatrixXs& get_A() const;
+  const MatrixXs& get_B() const;
+  const VectorXs& get_f() const;
+  const MatrixXs& get_Q() const;
+  const MatrixXs& get_R() const;
+  const MatrixXs& get_N() const;
+  const VectorXs& get_q() const;
+  const VectorXs& get_r() const;
 
-  void set_Fx(const MatrixXs& Fx);
-  void set_Fu(const MatrixXs& Fu);
-  void set_f0(const VectorXs& f0);
-  void set_lx(const VectorXs& lx);
-  void set_lu(const VectorXs& lu);
-  void set_Lxx(const MatrixXs& Lxx);
-  void set_Lxu(const MatrixXs& Lxu);
-  void set_Luu(const MatrixXs& Luu);
+  void set_A(const MatrixXs& A);
+  void set_B(const MatrixXs& B);
+  void set_f(const VectorXs& f);
+  void set_Q(const MatrixXs& Q);
+  void set_R(const MatrixXs& R);
+  void set_N(const MatrixXs& N);
+  void set_q(const VectorXs& q);
+  void set_r(const VectorXs& r);
+
+  DEPRECATED("Use get_A", const MatrixXs& get_Fx() const { return get_A(); })
+  DEPRECATED("Use get_B", const MatrixXs& get_Fu() const { return get_B(); })
+  DEPRECATED("Use get_f", const VectorXs& get_f0() const { return get_f(); })
+  DEPRECATED("Use get_q", const VectorXs& get_lx() const { return get_q(); })
+  DEPRECATED("Use get_r", const VectorXs& get_lu() const { return get_r(); })
+  DEPRECATED("Use get_Q", const MatrixXs& get_Lxx() const { return get_Q(); })
+  DEPRECATED("Use get_R", const MatrixXs& get_Lxu() const { return get_R(); })
+  DEPRECATED("Use get_N", const MatrixXs& get_Luu() const { return get_N(); })
+  DEPRECATED("Use set_A", void set_Fx(const MatrixXs& A) { set_A(A); })
+  DEPRECATED("Use set_B", void set_Fu(const MatrixXs& B) { set_B(B); })
+  DEPRECATED("Use set_f", void set_f0(const VectorXs& f) { set_f(f); })
+  DEPRECATED("Use set_q", void set_lx(const VectorXs& q) { set_q(q); })
+  DEPRECATED("Use set_r", void set_lu(const VectorXs& r) { set_r(r); })
+  DEPRECATED("Use set_Q", void set_Lxx(const MatrixXs& Q) { set_Q(Q); })
+  DEPRECATED("Use set_R", void set_Luu(const MatrixXs& R) { set_R(R); })
+  DEPRECATED("Use set_N", void set_Lxu(const MatrixXs& N) { set_N(N); })
 
   /**
    * @brief Print relevant information of the LQR model
@@ -103,11 +120,11 @@ struct ActionDataLQRTpl : public ActionDataAbstractTpl<_Scalar> {
             static_cast<Eigen::Index>(model->get_state()->get_ndx()))) {
     // Setting the linear model and quadratic cost here because they are
     // constant
-    Fx = model->get_Fx();
-    Fu = model->get_Fu();
-    Lxx = model->get_Lxx();
-    Luu = model->get_Luu();
-    Lxu = model->get_Lxu();
+    Fx = model->get_A();
+    Fu = model->get_B();
+    Lxx = model->get_Q();
+    Luu = model->get_R();
+    Lxu = model->get_N();
   }
 
   using Base::cost;

--- a/include/crocoddyl/core/actions/lqr.hpp
+++ b/include/crocoddyl/core/actions/lqr.hpp
@@ -18,6 +18,31 @@
 
 namespace crocoddyl {
 
+/**
+ * @brief Linear-quadratic regulator (LQR) action model
+ *
+ * A linear-quadratic regulator (LQR) action has a transition model of the form
+ * \f[ \begin{equation}
+ *   \mathbf{x}^' = \mathbf{A x + B u + f}.
+ * \end{equation} \f]
+ * Its cost function is quadratic of the form:
+ * \f[ \begin{equation}
+ * \ell(\mathbf{x},\mathbf{u}) = \begin{bmatrix}1
+ * \\ \mathbf{x} \\ \mathbf{u}\end{bmatrix}^T \begin{bmatrix}0 &
+ * \mathbf{q}^T & \mathbf{r}^T \\ \mathbf{q} & \mathbf{Q}
+ * &
+ * \mathbf{N}^T \\
+ * \mathbf{r} & \mathbf{N} & \mathbf{R}\end{bmatrix}
+ * \begin{bmatrix}1 \\ \mathbf{x} \\
+ * \mathbf{u}\end{bmatrix}
+ * \end{equation} \f]
+ * and the linear equality and inequality constraints has the form:
+ * \f[ \begin{aligned}
+ * \mathbf{g(x,u)} =  \mathbf{G}\begin{bmatrix} \mathbf{x} \\ \mathbf{u}
+ * \end{bmatrix} [x,u] + \mathbf{g}
+ * &\mathbf{h(x,u)} = \mathbf{H}\begin{bmatrix} \mathbf{x} \\ \mathbf{u}
+ * \end{bmatrix} [x,u] + \mathbf{h} \leq \mathbf{0} \end{aligned} \f]
+ */
 template <typename _Scalar>
 class ActionModelLQRTpl : public ActionModelAbstractTpl<_Scalar> {
  public:
@@ -61,6 +86,27 @@ class ActionModelLQRTpl : public ActionModelAbstractTpl<_Scalar> {
   /**
    * @brief Initialize the LQR action model
    *
+   * @param[in] A  State matrix
+   * @param[in] B  Input matrix
+   * @param[in] Q  State weight matrix
+   * @param[in] R  Input weight matrix
+   * @param[in] N  State-input weight matrix
+   * @param[in] H  State-input equality constraint matrix
+   * @param[in] G  State-input inequality constraint matrix
+   * @param[in] f  Dynamics drift
+   * @param[in] q  State weight vector
+   * @param[in] r  Input weight vector
+   * @param[in] g  State-input equality constraint bias
+   * @param[in] h  State-input inequality constraint bias
+   */
+  ActionModelLQRTpl(const MatrixXs& A, const MatrixXs& B, const MatrixXs& Q,
+                    const MatrixXs& R, const MatrixXs& N, const MatrixXs& G,
+                    const MatrixXs& H, const VectorXs& f, const VectorXs& q,
+                    const VectorXs& r, const VectorXs& g, const VectorXs& h);
+
+  /**
+   * @brief Initialize the LQR action model
+   *
    * @param[in] nx         Dimension of state vector
    * @param[in] nu         Dimension of control vector
    * @param[in] drif_free  Enable / disable the bias term of the linear dynamics
@@ -92,8 +138,12 @@ class ActionModelLQRTpl : public ActionModelAbstractTpl<_Scalar> {
    *
    * @param[in] nx  State dimension
    * @param[in] nu  Control dimension
+   * @param[in] ng  Equality constraint dimension (default 0)
+   * @param[in] nh  Inequality constraint dimension (defaul 0)
    */
-  static ActionModelLQRTpl Random(const std::size_t nx, const std::size_t nu);
+  static ActionModelLQRTpl Random(const std::size_t nx, const std::size_t nu,
+                                  const std::size_t ng = 0,
+                                  const std::size_t nh = 0);
 
   /** @brief Return the state matrix */
   const MatrixXs& get_A() const;
@@ -113,11 +163,23 @@ class ActionModelLQRTpl : public ActionModelAbstractTpl<_Scalar> {
   /** @brief Return the state-input weight matrix */
   const MatrixXs& get_N() const;
 
+  /** @brief Return the state-input equality constraint matrix */
+  const MatrixXs& get_G() const;
+
+  /** @brief Return the state-input inequality constraint matrix */
+  const MatrixXs& get_H() const;
+
   /** @brief Return the state weight vector */
   const VectorXs& get_q() const;
 
   /** @brief Return the input weight vector */
   const VectorXs& get_r() const;
+
+  /** @brief Return the state-input equality constraint bias */
+  const VectorXs& get_g() const;
+
+  /** @brief Return the state-input inequality constraint bias */
+  const VectorXs& get_h() const;
 
   /**
    * @brief Modify the LQR action model
@@ -127,13 +189,18 @@ class ActionModelLQRTpl : public ActionModelAbstractTpl<_Scalar> {
    * @param[in] Q  State weight matrix
    * @param[in] R  Input weight matrix
    * @param[in] N  State-input weight matrix
+   * @param[in] G  State-input equality constraint matrix
+   * @param[in] H  State-input inequality constraint matrix
    * @param[in] f  Dynamics drift
    * @param[in] q  State weight vector
    * @param[in] r  Input weight vector
+   * @param[in] g  State-input equality constraint bias
+   * @param[in] h  State-input inequality constraint bias
    */
   void set_LQR(const MatrixXs& A, const MatrixXs& B, const MatrixXs& Q,
-               const MatrixXs& R, const MatrixXs& N, const VectorXs& f,
-               const VectorXs& q, const VectorXs& r);
+               const MatrixXs& R, const MatrixXs& N, const MatrixXs& G,
+               const MatrixXs& H, const VectorXs& f, const VectorXs& q,
+               const VectorXs& r, const VectorXs& g, const VectorXs& h);
 
   DEPRECATED("Use get_A", const MatrixXs& get_Fx() const { return get_A(); })
   DEPRECATED("Use get_B", const MatrixXs& get_Fu() const { return get_B(); })
@@ -145,35 +212,35 @@ class ActionModelLQRTpl : public ActionModelAbstractTpl<_Scalar> {
   DEPRECATED("Use get_N", const MatrixXs& get_Luu() const { return get_N(); })
   DEPRECATED(
       "Use set_LQR", void set_Fx(const MatrixXs& A) {
-        set_LQR(A, B_, Q_, R_, N_, f_, q_, r_);
+        set_LQR(A, B_, Q_, R_, N_, G_, H_, f_, q_, r_, g_, h_);
       })
   DEPRECATED(
       "Use set_LQR", void set_Fu(const MatrixXs& B) {
-        set_LQR(A_, B, Q_, R_, N_, f_, q_, r_);
+        set_LQR(A_, B, Q_, R_, N_, G_, H_, f_, q_, r_, g_, h_);
       })
   DEPRECATED(
       "Use set_LQR", void set_f0(const VectorXs& f) {
-        set_LQR(A_, B_, Q_, R_, N_, f, q_, r_);
+        set_LQR(A_, B_, Q_, R_, N_, G_, H_, f, q_, r_, g_, h_);
       })
   DEPRECATED(
       "Use set_LQR", void set_lx(const VectorXs& q) {
-        set_LQR(A_, B_, Q_, R_, N_, f_, q, r_);
+        set_LQR(A_, B_, Q_, R_, N_, G_, H_, f_, q, r_, g_, h_);
       })
   DEPRECATED(
       "Use set_LQR", void set_lu(const VectorXs& r) {
-        set_LQR(A_, B_, Q_, R_, N_, f_, q_, r);
+        set_LQR(A_, B_, Q_, R_, N_, G_, H_, f_, q_, r, g_, h_);
       })
   DEPRECATED(
       "Use set_LQR", void set_Lxx(const MatrixXs& Q) {
-        set_LQR(A_, B_, Q, R_, N_, f_, q_, r_);
+        set_LQR(A_, B_, Q, R_, N_, G_, H_, f_, q_, r_, g_, h_);
       })
   DEPRECATED(
       "Use set_LQR", void set_Luu(const MatrixXs& R) {
-        set_LQR(A_, B_, Q_, R, N_, f_, q_, r_);
+        set_LQR(A_, B_, Q_, R, N_, G_, H_, f_, q_, r_, g_, h_);
       })
   DEPRECATED(
       "Use set_LQR", void set_Lxu(const MatrixXs& N) {
-        set_LQR(A_, B_, Q_, R_, N, f_, q_, r_);
+        set_LQR(A_, B_, Q_, R_, N, G_, H_, f_, q_, r_, g_, h_);
       })
 
   /**
@@ -184,6 +251,8 @@ class ActionModelLQRTpl : public ActionModelAbstractTpl<_Scalar> {
   virtual void print(std::ostream& os) const;
 
  protected:
+  using Base::ng_;     //!< Equality constraint dimension
+  using Base::nh_;     //!< Inequality constraint dimension
   using Base::nu_;     //!< Control dimension
   using Base::state_;  //!< Model of the state
 
@@ -193,10 +262,14 @@ class ActionModelLQRTpl : public ActionModelAbstractTpl<_Scalar> {
   MatrixXs Q_;
   MatrixXs R_;
   MatrixXs N_;
+  MatrixXs G_;
+  MatrixXs H_;
   VectorXs f_;
   VectorXs q_;
   VectorXs r_;
-  MatrixXs H_;
+  VectorXs g_;
+  VectorXs h_;
+  MatrixXs L_;
   bool drift_free_;
 };
 

--- a/include/crocoddyl/core/actions/lqr.hpp
+++ b/include/crocoddyl/core/actions/lqr.hpp
@@ -47,22 +47,52 @@ class ActionModelLQRTpl : public ActionModelAbstractTpl<_Scalar> {
   virtual boost::shared_ptr<ActionDataAbstract> createData();
   virtual bool checkData(const boost::shared_ptr<ActionDataAbstract>& data);
 
+  /** @brief Return the state matrix */
   const MatrixXs& get_A() const;
+
+  /** @brief Return the input matrix */
   const MatrixXs& get_B() const;
+
+  /** @brief Return the dynamics drift */
   const VectorXs& get_f() const;
+
+  /** @brief Return the state weight matrix */
   const MatrixXs& get_Q() const;
+
+  /** @brief Return the input weight matrix */
   const MatrixXs& get_R() const;
+
+  /** @brief Return the state-input weight matrix */
   const MatrixXs& get_N() const;
+
+  /** @brief Return the state weight vector */
   const VectorXs& get_q() const;
+
+  /** @brief Return the input weight vector */
   const VectorXs& get_r() const;
 
+  /** @brief Modify the state matrix */
   void set_A(const MatrixXs& A);
+
+  /** @brief Modify the input matrix */
   void set_B(const MatrixXs& B);
+
+  /** @brief Modify the dynamics drift */
   void set_f(const VectorXs& f);
+
+  /** @brief Modify the state weight matrix */
   void set_Q(const MatrixXs& Q);
+
+  /** @brief Modify the input weight matrix */
   void set_R(const MatrixXs& R);
+
+  /** @brief Modify the state-input weight matrix */
   void set_N(const MatrixXs& N);
+
+  /** @brief Modify the state weigth vector */
   void set_q(const VectorXs& q);
+
+  /** @brief Modify the input weight vector */
   void set_r(const VectorXs& r);
 
   DEPRECATED("Use get_A", const MatrixXs& get_Fx() const { return get_A(); })

--- a/include/crocoddyl/core/actions/lqr.hpp
+++ b/include/crocoddyl/core/actions/lqr.hpp
@@ -271,6 +271,7 @@ class ActionModelLQRTpl : public ActionModelAbstractTpl<_Scalar> {
   VectorXs h_;
   MatrixXs L_;
   bool drift_free_;
+  bool updated_lqr_;
 };
 
 template <typename _Scalar>
@@ -286,18 +287,27 @@ struct ActionDataLQRTpl : public ActionDataAbstractTpl<_Scalar> {
         R_u_tmp(VectorXs::Zero(static_cast<Eigen::Index>(model->get_nu()))),
         Q_x_tmp(VectorXs::Zero(
             static_cast<Eigen::Index>(model->get_state()->get_ndx()))) {
-    // Setting the linear model and quadratic cost here because they are
-    // constant
+    // Setting the linear model and quadratic cost as they are constant
+    const std::size_t nq = model->get_state()->get_nq();
+    const std::size_t nu = model->get_nu();
     Fx = model->get_A();
     Fu = model->get_B();
     Lxx = model->get_Q();
     Luu = model->get_R();
     Lxu = model->get_N();
+    Gx = model->get_G().leftCols(2 * nq);
+    Gu = model->get_G().rightCols(nu);
+    Hx = model->get_H().leftCols(2 * nq);
+    Hu = model->get_H().rightCols(nu);
   }
 
   using Base::cost;
   using Base::Fu;
   using Base::Fx;
+  using Base::Gu;
+  using Base::Gx;
+  using Base::Hu;
+  using Base::Hx;
   using Base::Lu;
   using Base::Luu;
   using Base::Lx;
@@ -305,6 +315,7 @@ struct ActionDataLQRTpl : public ActionDataAbstractTpl<_Scalar> {
   using Base::Lxx;
   using Base::r;
   using Base::xnext;
+
   VectorXs R_u_tmp;  // Temporary variable for storing Hessian-vector product
                      // (size: nu)
   VectorXs Q_x_tmp;  // Temporary variable for storing Hessian-vector product

--- a/include/crocoddyl/core/actions/lqr.hpp
+++ b/include/crocoddyl/core/actions/lqr.hpp
@@ -69,6 +69,9 @@ class ActionModelLQRTpl : public ActionModelAbstractTpl<_Scalar> {
   ActionModelLQRTpl(const std::size_t nx, const std::size_t nu,
                     const bool drift_free = true);
 
+  /** @brief Copy constructor */
+  ActionModelLQRTpl(const ActionModelLQRTpl& copy);
+
   virtual ~ActionModelLQRTpl();
 
   virtual void calc(const boost::shared_ptr<ActionDataAbstract>& data,

--- a/include/crocoddyl/core/actions/lqr.hpp
+++ b/include/crocoddyl/core/actions/lqr.hpp
@@ -124,7 +124,6 @@ class ActionModelLQRTpl : public ActionModelAbstractTpl<_Scalar> {
   using Base::state_;  //!< Model of the state
 
  private:
-  bool drift_free_;
   MatrixXs A_;
   MatrixXs B_;
   MatrixXs Q_;
@@ -133,6 +132,7 @@ class ActionModelLQRTpl : public ActionModelAbstractTpl<_Scalar> {
   VectorXs f_;
   VectorXs q_;
   VectorXs r_;
+  bool drift_free_;
 };
 
 template <typename _Scalar>

--- a/include/crocoddyl/core/actions/lqr.hpp
+++ b/include/crocoddyl/core/actions/lqr.hpp
@@ -30,8 +30,45 @@ class ActionModelLQRTpl : public ActionModelAbstractTpl<_Scalar> {
   typedef typename MathBase::VectorXs VectorXs;
   typedef typename MathBase::MatrixXs MatrixXs;
 
+  /**
+   * @brief Initialize the LQR action model
+   *
+   * @param[in] A  State matrix
+   * @param[in] B  Input matrix
+   * @param[in] Q  State weight matrix
+   * @param[in] R  Input weight matrix
+   * @param[in] N  State-input weight matrix
+   */
+  ActionModelLQRTpl(const MatrixXs& A, const MatrixXs& B, const MatrixXs& Q,
+                    const MatrixXs& R, const MatrixXs& N);
+
+  /**
+   * @brief Initialize the LQR action model
+   *
+   * @param[in] A  State matrix
+   * @param[in] B  Input matrix
+   * @param[in] Q  State weight matrix
+   * @param[in] R  Input weight matrix
+   * @param[in] N  State-input weight matrix
+   * @param[in] f  Dynamics drift
+   * @param[in] q  State weight vector
+   * @param[in] r  Input weight vector
+   */
+  ActionModelLQRTpl(const MatrixXs& A, const MatrixXs& B, const MatrixXs& Q,
+                    const MatrixXs& R, const MatrixXs& N, const VectorXs& f,
+                    const VectorXs& q, const VectorXs& r);
+
+  /**
+   * @brief Initialize the LQR action model
+   *
+   * @param[in] nx         Dimension of state vector
+   * @param[in] nu         Dimension of control vector
+   * @param[in] drif_free  Enable / disable the bias term of the linear dynamics
+   * (default true)
+   */
   ActionModelLQRTpl(const std::size_t nx, const std::size_t nu,
                     const bool drift_free = true);
+
   virtual ~ActionModelLQRTpl();
 
   virtual void calc(const boost::shared_ptr<ActionDataAbstract>& data,
@@ -46,6 +83,14 @@ class ActionModelLQRTpl : public ActionModelAbstractTpl<_Scalar> {
                         const Eigen::Ref<const VectorXs>& x);
   virtual boost::shared_ptr<ActionDataAbstract> createData();
   virtual bool checkData(const boost::shared_ptr<ActionDataAbstract>& data);
+
+  /**
+   * @brief Create a random LQR model
+   *
+   * @param[in] nx  State dimension
+   * @param[in] nu  Control dimension
+   */
+  static ActionModelLQRTpl Random(const std::size_t nx, const std::size_t nu);
 
   /** @brief Return the state matrix */
   const MatrixXs& get_A() const;

--- a/include/crocoddyl/core/actions/lqr.hpp
+++ b/include/crocoddyl/core/actions/lqr.hpp
@@ -71,29 +71,21 @@ class ActionModelLQRTpl : public ActionModelAbstractTpl<_Scalar> {
   /** @brief Return the input weight vector */
   const VectorXs& get_r() const;
 
-  /** @brief Modify the state matrix */
-  void set_A(const MatrixXs& A);
-
-  /** @brief Modify the input matrix */
-  void set_B(const MatrixXs& B);
-
-  /** @brief Modify the dynamics drift */
-  void set_f(const VectorXs& f);
-
-  /** @brief Modify the state weight matrix */
-  void set_Q(const MatrixXs& Q);
-
-  /** @brief Modify the input weight matrix */
-  void set_R(const MatrixXs& R);
-
-  /** @brief Modify the state-input weight matrix */
-  void set_N(const MatrixXs& N);
-
-  /** @brief Modify the state weigth vector */
-  void set_q(const VectorXs& q);
-
-  /** @brief Modify the input weight vector */
-  void set_r(const VectorXs& r);
+  /**
+   * @brief Modify the LQR action model
+   *
+   * @param[in] A  State matrix
+   * @param[in] B  Input matrix
+   * @param[in] Q  State weight matrix
+   * @param[in] R  Input weight matrix
+   * @param[in] N  State-input weight matrix
+   * @param[in] f  Dynamics drift
+   * @param[in] q  State weight vector
+   * @param[in] r  Input weight vector
+   */
+  void set_LQR(const MatrixXs& A, const MatrixXs& B, const MatrixXs& Q,
+               const MatrixXs& R, const MatrixXs& N, const VectorXs& f,
+               const VectorXs& q, const VectorXs& r);
 
   DEPRECATED("Use get_A", const MatrixXs& get_Fx() const { return get_A(); })
   DEPRECATED("Use get_B", const MatrixXs& get_Fu() const { return get_B(); })
@@ -103,14 +95,38 @@ class ActionModelLQRTpl : public ActionModelAbstractTpl<_Scalar> {
   DEPRECATED("Use get_Q", const MatrixXs& get_Lxx() const { return get_Q(); })
   DEPRECATED("Use get_R", const MatrixXs& get_Lxu() const { return get_R(); })
   DEPRECATED("Use get_N", const MatrixXs& get_Luu() const { return get_N(); })
-  DEPRECATED("Use set_A", void set_Fx(const MatrixXs& A) { set_A(A); })
-  DEPRECATED("Use set_B", void set_Fu(const MatrixXs& B) { set_B(B); })
-  DEPRECATED("Use set_f", void set_f0(const VectorXs& f) { set_f(f); })
-  DEPRECATED("Use set_q", void set_lx(const VectorXs& q) { set_q(q); })
-  DEPRECATED("Use set_r", void set_lu(const VectorXs& r) { set_r(r); })
-  DEPRECATED("Use set_Q", void set_Lxx(const MatrixXs& Q) { set_Q(Q); })
-  DEPRECATED("Use set_R", void set_Luu(const MatrixXs& R) { set_R(R); })
-  DEPRECATED("Use set_N", void set_Lxu(const MatrixXs& N) { set_N(N); })
+  DEPRECATED(
+      "Use set_LQR", void set_Fx(const MatrixXs& A) {
+        set_LQR(A, B_, Q_, R_, N_, f_, q_, r_);
+      })
+  DEPRECATED(
+      "Use set_LQR", void set_Fu(const MatrixXs& B) {
+        set_LQR(A_, B, Q_, R_, N_, f_, q_, r_);
+      })
+  DEPRECATED(
+      "Use set_LQR", void set_f0(const VectorXs& f) {
+        set_LQR(A_, B_, Q_, R_, N_, f, q_, r_);
+      })
+  DEPRECATED(
+      "Use set_LQR", void set_lx(const VectorXs& q) {
+        set_LQR(A_, B_, Q_, R_, N_, f_, q, r_);
+      })
+  DEPRECATED(
+      "Use set_LQR", void set_lu(const VectorXs& r) {
+        set_LQR(A_, B_, Q_, R_, N_, f_, q_, r);
+      })
+  DEPRECATED(
+      "Use set_LQR", void set_Lxx(const MatrixXs& Q) {
+        set_LQR(A_, B_, Q, R_, N_, f_, q_, r_);
+      })
+  DEPRECATED(
+      "Use set_LQR", void set_Luu(const MatrixXs& R) {
+        set_LQR(A_, B_, Q_, R, N_, f_, q_, r_);
+      })
+  DEPRECATED(
+      "Use set_LQR", void set_Lxu(const MatrixXs& N) {
+        set_LQR(A_, B_, Q_, R_, N, f_, q_, r_);
+      })
 
   /**
    * @brief Print relevant information of the LQR model
@@ -132,6 +148,7 @@ class ActionModelLQRTpl : public ActionModelAbstractTpl<_Scalar> {
   VectorXs f_;
   VectorXs q_;
   VectorXs r_;
+  MatrixXs H_;
   bool drift_free_;
 };
 

--- a/include/crocoddyl/core/actions/lqr.hxx
+++ b/include/crocoddyl/core/actions/lqr.hxx
@@ -51,6 +51,15 @@ ActionModelLQRTpl<Scalar>::ActionModelLQRTpl(const std::size_t nx,
       drift_free_(drift_free) {}
 
 template <typename Scalar>
+ActionModelLQRTpl<Scalar>::ActionModelLQRTpl(const ActionModelLQRTpl& copy)
+    : Base(boost::make_shared<StateVector>(copy.get_A().cols()),
+           copy.get_B().cols(), 0),
+      drift_free_(false) {
+  set_LQR(copy.get_A(), copy.get_B(), copy.get_Q(), copy.get_R(), copy.get_N(),
+          copy.get_f(), copy.get_q(), copy.get_r());
+}
+
+template <typename Scalar>
 ActionModelLQRTpl<Scalar>::~ActionModelLQRTpl() {}
 
 template <typename Scalar>

--- a/include/crocoddyl/core/actions/lqr.hxx
+++ b/include/crocoddyl/core/actions/lqr.hxx
@@ -154,140 +154,140 @@ void ActionModelLQRTpl<Scalar>::print(std::ostream& os) const {
 }
 
 template <typename Scalar>
-const typename MathBaseTpl<Scalar>::MatrixXs&
-ActionModelLQRTpl<Scalar>::get_Fx() const {
+const typename MathBaseTpl<Scalar>::MatrixXs& ActionModelLQRTpl<Scalar>::get_A()
+    const {
   return A_;
 }
 
 template <typename Scalar>
-const typename MathBaseTpl<Scalar>::MatrixXs&
-ActionModelLQRTpl<Scalar>::get_Fu() const {
+const typename MathBaseTpl<Scalar>::MatrixXs& ActionModelLQRTpl<Scalar>::get_B()
+    const {
   return B_;
 }
 
 template <typename Scalar>
-const typename MathBaseTpl<Scalar>::VectorXs&
-ActionModelLQRTpl<Scalar>::get_f0() const {
+const typename MathBaseTpl<Scalar>::VectorXs& ActionModelLQRTpl<Scalar>::get_f()
+    const {
   return f_;
 }
 
 template <typename Scalar>
-const typename MathBaseTpl<Scalar>::VectorXs&
-ActionModelLQRTpl<Scalar>::get_lx() const {
-  return q_;
-}
-
-template <typename Scalar>
-const typename MathBaseTpl<Scalar>::VectorXs&
-ActionModelLQRTpl<Scalar>::get_lu() const {
-  return r_;
-}
-
-template <typename Scalar>
-const typename MathBaseTpl<Scalar>::MatrixXs&
-ActionModelLQRTpl<Scalar>::get_Lxx() const {
+const typename MathBaseTpl<Scalar>::MatrixXs& ActionModelLQRTpl<Scalar>::get_Q()
+    const {
   return Q_;
 }
 
 template <typename Scalar>
-const typename MathBaseTpl<Scalar>::MatrixXs&
-ActionModelLQRTpl<Scalar>::get_Lxu() const {
-  return N_;
-}
-
-template <typename Scalar>
-const typename MathBaseTpl<Scalar>::MatrixXs&
-ActionModelLQRTpl<Scalar>::get_Luu() const {
+const typename MathBaseTpl<Scalar>::MatrixXs& ActionModelLQRTpl<Scalar>::get_R()
+    const {
   return R_;
 }
 
 template <typename Scalar>
-void ActionModelLQRTpl<Scalar>::set_Fx(const MatrixXs& Fx) {
-  if (static_cast<std::size_t>(Fx.rows()) != state_->get_nx() ||
-      static_cast<std::size_t>(Fx.cols()) != state_->get_nx()) {
+const typename MathBaseTpl<Scalar>::MatrixXs& ActionModelLQRTpl<Scalar>::get_N()
+    const {
+  return N_;
+}
+
+template <typename Scalar>
+const typename MathBaseTpl<Scalar>::VectorXs& ActionModelLQRTpl<Scalar>::get_q()
+    const {
+  return q_;
+}
+
+template <typename Scalar>
+const typename MathBaseTpl<Scalar>::VectorXs& ActionModelLQRTpl<Scalar>::get_r()
+    const {
+  return r_;
+}
+
+template <typename Scalar>
+void ActionModelLQRTpl<Scalar>::set_A(const MatrixXs& A) {
+  if (static_cast<std::size_t>(A.rows()) != state_->get_nx() ||
+      static_cast<std::size_t>(A.cols()) != state_->get_nx()) {
     throw_pretty("Invalid argument: "
-                 << "Fx has wrong dimension (it should be " +
+                 << "A has wrong dimension (it should be " +
                         std::to_string(state_->get_nx()) + "," +
                         std::to_string(state_->get_nx()) + ")");
   }
-  A_ = Fx;
+  A_ = A;
 }
 
 template <typename Scalar>
-void ActionModelLQRTpl<Scalar>::set_Fu(const MatrixXs& Fu) {
-  if (static_cast<std::size_t>(Fu.rows()) != state_->get_nx() ||
-      static_cast<std::size_t>(Fu.cols()) != nu_) {
+void ActionModelLQRTpl<Scalar>::set_B(const MatrixXs& B) {
+  if (static_cast<std::size_t>(B.rows()) != state_->get_nx() ||
+      static_cast<std::size_t>(B.cols()) != nu_) {
     throw_pretty("Invalid argument: "
-                 << "Fu has wrong dimension (it should be " +
-                        std::to_string(state_->get_nx()) + "," +
-                        std::to_string(nu_) + ")");
-  }
-  B_ = Fu;
-}
-
-template <typename Scalar>
-void ActionModelLQRTpl<Scalar>::set_f0(const VectorXs& f0) {
-  if (static_cast<std::size_t>(f0.size()) != state_->get_nx()) {
-    throw_pretty("Invalid argument: "
-                 << "f0 has wrong dimension (it should be " +
-                        std::to_string(state_->get_nx()) + ")");
-  }
-  f_ = f0;
-}
-
-template <typename Scalar>
-void ActionModelLQRTpl<Scalar>::set_lx(const VectorXs& lx) {
-  if (static_cast<std::size_t>(lx.size()) != state_->get_nx()) {
-    throw_pretty("Invalid argument: "
-                 << "lx has wrong dimension (it should be " +
-                        std::to_string(state_->get_nx()) + ")");
-  }
-  q_ = lx;
-}
-
-template <typename Scalar>
-void ActionModelLQRTpl<Scalar>::set_lu(const VectorXs& lu) {
-  if (static_cast<std::size_t>(lu.size()) != nu_) {
-    throw_pretty("Invalid argument: "
-                 << "lu has wrong dimension (it should be " +
-                        std::to_string(nu_) + ")");
-  }
-  r_ = lu;
-}
-
-template <typename Scalar>
-void ActionModelLQRTpl<Scalar>::set_Lxx(const MatrixXs& Lxx) {
-  if (static_cast<std::size_t>(Lxx.rows()) != state_->get_nx() ||
-      static_cast<std::size_t>(Lxx.cols()) != state_->get_nx()) {
-    throw_pretty("Invalid argument: "
-                 << "Lxx has wrong dimension (it should be " +
-                        std::to_string(state_->get_nx()) + "," +
-                        std::to_string(state_->get_nx()) + ")");
-  }
-  Q_ = Lxx;
-}
-
-template <typename Scalar>
-void ActionModelLQRTpl<Scalar>::set_Lxu(const MatrixXs& Lxu) {
-  if (static_cast<std::size_t>(Lxu.rows()) != state_->get_nx() ||
-      static_cast<std::size_t>(Lxu.cols()) != nu_) {
-    throw_pretty("Invalid argument: "
-                 << "Lxu has wrong dimension (it should be " +
+                 << "B has wrong dimension (it should be " +
                         std::to_string(state_->get_nx()) + "," +
                         std::to_string(nu_) + ")");
   }
-  N_ = Lxu;
+  B_ = B;
 }
 
 template <typename Scalar>
-void ActionModelLQRTpl<Scalar>::set_Luu(const MatrixXs& Luu) {
-  if (static_cast<std::size_t>(Luu.rows()) != nu_ ||
-      static_cast<std::size_t>(Luu.cols()) != nu_) {
+void ActionModelLQRTpl<Scalar>::set_f(const VectorXs& f) {
+  if (static_cast<std::size_t>(f.size()) != state_->get_nx()) {
     throw_pretty("Invalid argument: "
-                 << "Fq has wrong dimension (it should be " +
+                 << "f has wrong dimension (it should be " +
+                        std::to_string(state_->get_nx()) + ")");
+  }
+  f_ = f;
+}
+
+template <typename Scalar>
+void ActionModelLQRTpl<Scalar>::set_Q(const MatrixXs& Q) {
+  if (static_cast<std::size_t>(Q.rows()) != state_->get_nx() ||
+      static_cast<std::size_t>(Q.cols()) != state_->get_nx()) {
+    throw_pretty("Invalid argument: "
+                 << "Q has wrong dimension (it should be " +
+                        std::to_string(state_->get_nx()) + "," +
+                        std::to_string(state_->get_nx()) + ")");
+  }
+  Q_ = Q;
+}
+
+template <typename Scalar>
+void ActionModelLQRTpl<Scalar>::set_N(const MatrixXs& N) {
+  if (static_cast<std::size_t>(N.rows()) != state_->get_nx() ||
+      static_cast<std::size_t>(N.cols()) != nu_) {
+    throw_pretty("Invalid argument: "
+                 << "N has wrong dimension (it should be " +
+                        std::to_string(state_->get_nx()) + "," +
+                        std::to_string(nu_) + ")");
+  }
+  N_ = N;
+}
+
+template <typename Scalar>
+void ActionModelLQRTpl<Scalar>::set_R(const MatrixXs& R) {
+  if (static_cast<std::size_t>(R.rows()) != nu_ ||
+      static_cast<std::size_t>(R.cols()) != nu_) {
+    throw_pretty("Invalid argument: "
+                 << "R has wrong dimension (it should be " +
                         std::to_string(nu_) + "," + std::to_string(nu_) + ")");
   }
-  R_ = Luu;
+  R_ = R;
+}
+
+template <typename Scalar>
+void ActionModelLQRTpl<Scalar>::set_q(const VectorXs& q) {
+  if (static_cast<std::size_t>(q.size()) != state_->get_nx()) {
+    throw_pretty("Invalid argument: "
+                 << "q has wrong dimension (it should be " +
+                        std::to_string(state_->get_nx()) + ")");
+  }
+  q_ = q;
+}
+
+template <typename Scalar>
+void ActionModelLQRTpl<Scalar>::set_r(const VectorXs& r) {
+  if (static_cast<std::size_t>(r.size()) != nu_) {
+    throw_pretty("Invalid argument: "
+                 << "r has wrong dimension (it should be " +
+                        std::to_string(nu_) + ")");
+  }
+  r_ = r;
 }
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/core/actions/lqr.hxx
+++ b/include/crocoddyl/core/actions/lqr.hxx
@@ -16,17 +16,17 @@ ActionModelLQRTpl<Scalar>::ActionModelLQRTpl(const std::size_t nx,
                                              const std::size_t nu,
                                              const bool drift_free)
     : Base(boost::make_shared<StateVector>(nx), nu, 0),
+      A_(MatrixXs::Identity(nx, nx)),
+      B_(MatrixXs::Identity(nx, nu)),
+      Q_(MatrixXs::Identity(nx, nx)),
+      R_(MatrixXs::Identity(nu, nu)),
+      N_(MatrixXs::Zero(nx, nu)),
+      f_(drift_free ? VectorXs::Zero(nx) : VectorXs::Ones(nx)),
+      q_(VectorXs::Ones(nx)),
+      r_(VectorXs::Ones(nu)),
       drift_free_(drift_free) {
   // TODO(cmastalli): substitute by random (vectors) and random-orthogonal
   // (matrices)
-  A_ = MatrixXs::Identity(nx, nx);
-  B_ = MatrixXs::Identity(nx, nu);
-  Q_ = MatrixXs::Identity(nx, nx);
-  R_ = MatrixXs::Identity(nu, nu);
-  N_ = MatrixXs::Identity(nx, nu);
-  f_ = VectorXs::Ones(nx);
-  q_ = VectorXs::Ones(nx);
-  r_ = VectorXs::Ones(nu);
 }
 
 template <typename Scalar>
@@ -48,14 +48,9 @@ void ActionModelLQRTpl<Scalar>::calc(
   }
   Data* d = static_cast<Data*>(data.get());
 
-  if (drift_free_) {
-    data->xnext.noalias() = A_ * x;
-    data->xnext.noalias() += B_ * u;
-  } else {
-    data->xnext.noalias() = A_ * x;
-    data->xnext.noalias() += B_ * u;
-    data->xnext += f_;
-  }
+  data->xnext.noalias() = A_ * x;
+  data->xnext.noalias() += B_ * u;
+  data->xnext += f_;
 
   // cost = 0.5 * x^T * Q * x + 0.5 * u^T * R * u + x^T * N * u + q^T * x + r^T
   // * u

--- a/unittest/bindings/factory.py
+++ b/unittest/bindings/factory.py
@@ -249,7 +249,7 @@ class LQRModelDerived(crocoddyl.ActionModelAbstract):
         self.B = np.eye(self.state.nx)[:, : self.nu]
         self.Q = np.eye(self.state.nx)
         self.R = np.eye(self.nu)
-        self.N = np.eye(self.state.nx)[:, : self.nu]
+        self.N = np.zeros((self.state.nx, self.nu))
         self.f = [np.zeros(self.state.nx) if driftFree else np.ones(self.state.nx)]
         self.q = np.ones(self.state.nx)
         self.r = np.ones(self.nu)
@@ -299,7 +299,7 @@ class DifferentialLQRModelDerived(crocoddyl.DifferentialActionModelAbstract):
         self.f = [np.zeros(nq) if driftFree else np.ones(nq)]
         self.Q = np.eye(self.state.nx)
         self.R = np.eye(self.nu)
-        self.N = np.eye(self.state.nx)[:, : self.nu]
+        self.N = np.zeros((self.state.nx, self.nu))
         self.q = np.ones(self.state.nx)
         self.r = np.ones(self.nu)
 

--- a/unittest/bindings/factory.py
+++ b/unittest/bindings/factory.py
@@ -245,33 +245,33 @@ class UnicycleDataDerived(crocoddyl.ActionDataAbstract):
 class LQRModelDerived(crocoddyl.ActionModelAbstract):
     def __init__(self, nx, nu, driftFree=True):
         crocoddyl.ActionModelAbstract.__init__(self, crocoddyl.StateVector(nx), nu)
-        self.Fx = np.eye(self.state.nx)
-        self.Fu = np.eye(self.state.nx)[:, : self.nu]
-        self.f0 = np.zeros(self.state.nx)
-        self.Lxx = np.eye(self.state.nx)
-        self.Lxu = np.eye(self.state.nx)[:, : self.nu]
-        self.Luu = np.eye(self.nu)
-        self.lx = np.ones(self.state.nx)
-        self.lu = np.ones(self.nu)
+        self.A = np.eye(self.state.nx)
+        self.B = np.eye(self.state.nx)[:, : self.nu]
+        self.Q = np.eye(self.state.nx)
+        self.R = np.eye(self.nu)
+        self.N = np.eye(self.state.nx)[:, : self.nu]
+        self.f = [np.zeros(self.state.nx) if driftFree else np.ones(self.state.nx)]
+        self.q = np.ones(self.state.nx)
+        self.r = np.ones(self.nu)
 
     def calc(self, data, x, u=None):
         if u is None:
             data.xnext[:] = x
-            data.cost = 0.5 * np.dot(x.T, np.dot(self.Lxx, x))
-            data.cost += np.dot(self.lx.T, x)
+            data.cost = 0.5 * np.dot(x.T, np.dot(self.Q, x))
+            data.cost += np.dot(self.q.T, x)
         else:
-            data.xnext[:] = np.dot(self.Fx, x) + np.dot(self.Fu, u) + self.f0
-            data.cost = 0.5 * np.dot(x.T, np.dot(self.Lxx, x))
-            data.cost += 0.5 * np.dot(u.T, np.dot(self.Luu, u))
-            data.cost += np.dot(x.T, np.dot(self.Lxu, u))
-            data.cost += np.dot(self.lx.T, x) + np.dot(self.lu.T, u)
+            data.xnext[:] = np.dot(self.A, x) + np.dot(self.B, u) + self.f
+            data.cost = 0.5 * np.dot(x.T, np.dot(self.Q, x))
+            data.cost += 0.5 * np.dot(u.T, np.dot(self.R, u))
+            data.cost += np.dot(x.T, np.dot(self.N, u))
+            data.cost += np.dot(self.q.T, x) + np.dot(self.r.T, u)
 
     def calcDiff(self, data, x, u=None):
         if u is None:
-            data.Lx[:] = self.lx + np.dot(self.Lxx, x)
+            data.Lx[:] = self.q + np.dot(self.Q, x)
         else:
-            data.Lx[:] = self.lx + np.dot(self.Lxx, x) + np.dot(self.Lxu, u)
-            data.Lu[:] = self.lu + np.dot(self.Lxu.T, x) + np.dot(self.Luu, u)
+            data.Lx[:] = self.q + np.dot(self.Q, x) + np.dot(self.N, u)
+            data.Lu[:] = self.r + np.dot(self.R, u) + np.dot(self.N.T, x)
 
     def createData(self):
         data = LQRDataDerived(self)
@@ -281,11 +281,11 @@ class LQRModelDerived(crocoddyl.ActionModelAbstract):
 class LQRDataDerived(crocoddyl.ActionDataAbstract):
     def __init__(self, model):
         crocoddyl.ActionDataAbstract.__init__(self, model)
-        self.Fx[:, :] = model.Fx
-        self.Fu[:, :] = model.Fu
-        self.Lxx[:, :] = model.Lxx
-        self.Luu[:, :] = model.Luu
-        self.Lxu[:, :] = model.Lxu
+        self.Fx[:, :] = model.A
+        self.Fu[:, :] = model.B
+        self.Lxx[:, :] = model.Q
+        self.Luu[:, :] = model.R
+        self.Lxu[:, :] = model.N
 
 
 class DifferentialLQRModelDerived(crocoddyl.DifferentialActionModelAbstract):
@@ -293,36 +293,36 @@ class DifferentialLQRModelDerived(crocoddyl.DifferentialActionModelAbstract):
         crocoddyl.DifferentialActionModelAbstract.__init__(
             self, crocoddyl.StateVector(2 * nq), nu
         )
-        self.Fq = np.eye(self.state.nq)
-        self.Fv = np.eye(self.state.nv)
-        self.Fu = np.eye(self.state.nq)[:, : self.nu]
-        self.f0 = np.zeros(self.state.nq)
-        self.Lxx = np.eye(self.state.nx)
-        self.Lxu = np.eye(self.state.nx)[:, : self.nu]
-        self.Luu = np.eye(self.nu)
-        self.lx = np.ones(self.state.nx)
-        self.lu = np.ones(self.nu)
+        self.Aq = np.eye(self.state.nq)
+        self.Av = np.eye(self.state.nv)
+        self.B = np.eye(self.state.nq)[:, : self.nu]
+        self.f = [np.zeros(nq) if driftFree else np.ones(nq)]
+        self.Q = np.eye(self.state.nx)
+        self.R = np.eye(self.nu)
+        self.N = np.eye(self.state.nx)[:, : self.nu]
+        self.q = np.ones(self.state.nx)
+        self.r = np.ones(self.nu)
 
     def calc(self, data, x, u=None):
         if u is None:
-            data.cost = 0.5 * np.dot(x.T, np.dot(self.Lxx, x))
-            data.cost += np.dot(self.lx.T, x)
+            data.cost = 0.5 * np.dot(x.T, np.dot(self.Q, x))
+            data.cost += np.dot(self.q.T, x)
         else:
             q, v = x[: self.state.nq], x[self.state.nq :]
             data.xout[:] = (
-                np.dot(self.Fq, q) + np.dot(self.Fv, v) + np.dot(self.Fu, u) + self.f0
+                np.dot(self.Aq, q) + np.dot(self.Av, v) + np.dot(self.B, u) + self.f
             )
-            data.cost = 0.5 * np.dot(x.T, np.dot(self.Lxx, x))
-            data.cost += 0.5 * np.dot(u.T, np.dot(self.Luu, u))
-            data.cost += np.dot(x.T, np.dot(self.Lxu, u))
-            data.cost += np.dot(self.lx.T, x) + np.dot(self.lu.T, u)
+            data.cost = 0.5 * np.dot(x.T, np.dot(self.Q, x))
+            data.cost += 0.5 * np.dot(u.T, np.dot(self.R, u))
+            data.cost += np.dot(x.T, np.dot(self.N, u))
+            data.cost += np.dot(self.q.T, x) + np.dot(self.r.T, u)
 
     def calcDiff(self, data, x, u=None):
         if u is None:
-            data.Lx[:] = self.lx + np.dot(self.Lxx, x)
+            data.Lx[:] = self.q + np.dot(self.Q, x)
         else:
-            data.Lx[:] = self.lx + np.dot(self.Lxx, x) + np.dot(self.Lxu, u)
-            data.Lu[:] = self.lu + np.dot(self.Lxu.T, x) + np.dot(self.Luu, u)
+            data.Lx[:] = self.q + np.dot(self.Q, x) + np.dot(self.N, u)
+            data.Lu[:] = self.r + np.dot(self.R, u) + np.dot(self.N.T, x)
 
     def createData(self):
         data = DifferentialLQRDataDerived(self)
@@ -332,11 +332,11 @@ class DifferentialLQRModelDerived(crocoddyl.DifferentialActionModelAbstract):
 class DifferentialLQRDataDerived(crocoddyl.DifferentialActionDataAbstract):
     def __init__(self, model):
         crocoddyl.DifferentialActionDataAbstract.__init__(self, model)
-        self.Lxx[:, :] = model.Lxx
-        self.Luu[:, :] = model.Luu
-        self.Lxu[:, :] = model.Lxu
-        self.Fx[:, :] = np.hstack([model.Fq, model.Fv])
-        self.Fu[:, :] = model.Fu
+        self.Fx[:, :] = np.hstack([model.Aq, model.Av])
+        self.Fu[:, :] = model.B
+        self.Lxx[:, :] = model.Q
+        self.Luu[:, :] = model.R
+        self.Lxu[:, :] = model.N
 
 
 class DifferentialFreeFwdDynamicsModelDerived(

--- a/unittest/bindings/factory.py
+++ b/unittest/bindings/factory.py
@@ -254,6 +254,19 @@ class LQRModelDerived(crocoddyl.ActionModelAbstract):
         self.q = np.ones(self.state.nx)
         self.r = np.ones(self.nu)
 
+    @classmethod
+    def fromLQR(cls, A, B, Q, R, N, f, q, r):
+        model = cls(A.shape[1], B.shape[1], False)
+        model.A = A
+        model.B = B
+        model.Q = Q
+        model.R = R
+        model.N = N
+        model.f = f
+        model.q = q
+        model.r = r
+        return model
+
     def calc(self, data, x, u=None):
         if u is None:
             data.xnext[:] = x
@@ -302,6 +315,20 @@ class DifferentialLQRModelDerived(crocoddyl.DifferentialActionModelAbstract):
         self.N = np.zeros((self.state.nx, self.nu))
         self.q = np.ones(self.state.nx)
         self.r = np.ones(self.nu)
+
+    @classmethod
+    def fromLQR(cls, Aq, Av, B, Q, R, N, f, q, r):
+        model = cls(Aq.shape[1], B.shape[1], False)
+        model.Aq = Aq
+        model.Av = Av
+        model.B = B
+        model.Q = Q
+        model.R = R
+        model.N = N
+        model.f = f
+        model.q = q
+        model.r = r
+        return model
 
     def calc(self, data, x, u=None):
         if u is None:

--- a/unittest/bindings/test_actions.py
+++ b/unittest/bindings/test_actions.py
@@ -181,11 +181,37 @@ class LQRTest(ActionModelAbstractTestCase):
     MODEL_DER = LQRModelDerived(NX, NU)
 
 
-class DifferentialLQRTest(ActionModelAbstractTestCase):
+class RandomLQRTest(ActionModelAbstractTestCase):
     NX = randint(2, 21)
     NU = randint(2, NX)
-    MODEL = crocoddyl.DifferentialActionModelLQR(NX, NU)
-    MODEL_DER = DifferentialLQRModelDerived(NX, NU)
+    MODEL = crocoddyl.ActionModelLQR.Random(NX, NU)
+    MODEL_DER = LQRModelDerived.fromLQR(
+        MODEL.A, MODEL.B, MODEL.Q, MODEL.R, MODEL.N, MODEL.f, MODEL.q, MODEL.r
+    )
+
+
+class DifferentialLQRTest(ActionModelAbstractTestCase):
+    NQ = randint(2, 21)
+    NU = randint(2, NQ)
+    MODEL = crocoddyl.DifferentialActionModelLQR(NQ, NU)
+    MODEL_DER = DifferentialLQRModelDerived(NQ, NU)
+
+
+class RandomDifferentialLQRTest(ActionModelAbstractTestCase):
+    NQ = randint(2, 21)
+    NU = randint(2, NQ)
+    MODEL = crocoddyl.DifferentialActionModelLQR.Random(NQ, NU)
+    MODEL_DER = DifferentialLQRModelDerived.fromLQR(
+        MODEL.Aq,
+        MODEL.Av,
+        MODEL.B,
+        MODEL.Q,
+        MODEL.R,
+        MODEL.N,
+        MODEL.f,
+        MODEL.q,
+        MODEL.r,
+    )
 
 
 class TalosArmFreeFwdDynamicsTest(ActionModelAbstractTestCase):
@@ -400,7 +426,9 @@ if __name__ == "__main__":
     test_classes_to_run = [
         UnicycleTest,
         LQRTest,
+        RandomLQRTest,
         DifferentialLQRTest,
+        RandomDifferentialLQRTest,
         TalosArmFreeFwdDynamicsTest,
         TalosArmFreeFwdDynamicsWithArmatureTest,
         AnymalFreeFwdDynamicsTest,

--- a/unittest/factory/action.cpp
+++ b/unittest/factory/action.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2023, University of Edinburgh, LAAS-CNRS,
+// Copyright (C) 2019-2024, University of Edinburgh, LAAS-CNRS,
 //                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
@@ -41,6 +41,9 @@ std::ostream& operator<<(std::ostream& os, ActionModelTypes::Type type) {
     case ActionModelTypes::ActionModelLQR:
       os << "ActionModelLQR";
       break;
+    case ActionModelTypes::ActionModelRandomLQR:
+      os << "ActionModelRandomLQR";
+      break;
     case ActionModelTypes::ActionModelImpulseFwdDynamics_HyQ:
       os << "ActionModelImpulseFwdDynamics_HyQ";
       break;
@@ -78,6 +81,15 @@ boost::shared_ptr<crocoddyl::ActionModelAbstract> ActionModelFactory::create(
         action = boost::make_shared<crocoddyl::ActionModelLQR>(8, 4, false);
       } else {
         action = boost::make_shared<crocoddyl::ActionModelLQR>(8, 2, false);
+      }
+      break;
+    case ActionModelTypes::ActionModelRandomLQR:
+      if (secondInstance) {
+        action = boost::make_shared<crocoddyl::ActionModelLQR>(
+            crocoddyl::ActionModelLQR::Random(8, 4));
+      } else {
+        action = boost::make_shared<crocoddyl::ActionModelLQR>(
+            crocoddyl::ActionModelLQR::Random(8, 2));
       }
       break;
     case ActionModelTypes::ActionModelImpulseFwdDynamics_HyQ:

--- a/unittest/factory/action.hpp
+++ b/unittest/factory/action.hpp
@@ -1,7 +1,8 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2019-2024, LAAS-CNRS, University of Edinburgh,
+//                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -24,6 +25,7 @@ struct ActionModelTypes {
     ActionModelUnicycle,
     ActionModelLQRDriftFree,
     ActionModelLQR,
+    ActionModelRandomLQR,
     ActionModelImpulseFwdDynamics_HyQ,
     ActionModelImpulseFwdDynamics_Talos,
     NbActionModelTypes

--- a/unittest/factory/diff_action.cpp
+++ b/unittest/factory/diff_action.cpp
@@ -42,6 +42,9 @@ std::ostream& operator<<(std::ostream& os,
     case DifferentialActionModelTypes::DifferentialActionModelLQRDriftFree:
       os << "DifferentialActionModelLQRDriftFree";
       break;
+    case DifferentialActionModelTypes::DifferentialActionModelRandomLQR:
+      os << "DifferentialActionModelRandomLQR";
+      break;
     case DifferentialActionModelTypes::
         DifferentialActionModelFreeFwdDynamics_Hector:
       os << "DifferentialActionModelFreeFwdDynamics_Hector";
@@ -146,6 +149,10 @@ DifferentialActionModelFactory::create(DifferentialActionModelTypes::Type type,
     case DifferentialActionModelTypes::DifferentialActionModelLQRDriftFree:
       action = boost::make_shared<crocoddyl::DifferentialActionModelLQR>(40, 40,
                                                                          true);
+      break;
+    case DifferentialActionModelTypes::DifferentialActionModelRandomLQR:
+      action = boost::make_shared<crocoddyl::DifferentialActionModelLQR>(
+          crocoddyl::DifferentialActionModelLQR::Random(40, 40));
       break;
     case DifferentialActionModelTypes::
         DifferentialActionModelFreeFwdDynamics_Hector:

--- a/unittest/factory/diff_action.hpp
+++ b/unittest/factory/diff_action.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2023, University of Edinburgh, CTU, INRIA,
+// Copyright (C) 2019-2024, University of Edinburgh, CTU, INRIA,
 //                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
@@ -29,6 +29,7 @@ struct DifferentialActionModelTypes {
   enum Type {
     DifferentialActionModelLQR,
     DifferentialActionModelLQRDriftFree,
+    DifferentialActionModelRandomLQR,
     DifferentialActionModelFreeFwdDynamics_Hector,
     DifferentialActionModelFreeFwdDynamics_TalosArm,
     DifferentialActionModelFreeFwdDynamics_TalosArm_Squashed,

--- a/unittest/factory/solver.cpp
+++ b/unittest/factory/solver.cpp
@@ -1,8 +1,9 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2020, LAAS-CNRS, New York University,
-//                          Max Planck Gesellschaft, University of Edinburgh
+// Copyright (C) 2019-2024, LAAS-CNRS, New York University,
+//                          Max Planck Gesellschaft, University of Edinburgh,
+//                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -59,13 +60,10 @@ SolverFactory::SolverFactory() {}
 SolverFactory::~SolverFactory() {}
 
 boost::shared_ptr<crocoddyl::SolverAbstract> SolverFactory::create(
-    SolverTypes::Type solver_type, ActionModelTypes::Type action_type,
-    size_t T) const {
+    SolverTypes::Type solver_type,
+    boost::shared_ptr<crocoddyl::ActionModelAbstract> model,
+    boost::shared_ptr<crocoddyl::ActionModelAbstract> model2, size_t T) const {
   boost::shared_ptr<crocoddyl::SolverAbstract> solver;
-  boost::shared_ptr<crocoddyl::ActionModelAbstract> model =
-      ActionModelFactory().create(action_type);
-  boost::shared_ptr<crocoddyl::ActionModelAbstract> model2 =
-      ActionModelFactory().create(action_type, true);
   std::vector<boost::shared_ptr<crocoddyl::ActionModelAbstract> >
       running_models;
   const size_t halfway = T / 2;

--- a/unittest/factory/solver.hpp
+++ b/unittest/factory/solver.hpp
@@ -1,8 +1,9 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2021, University of Edinburgh, LAAS-CNRS,
-//                          New York University, Max Planck Gesellschaft
+// Copyright (C) 2019-2024, University of Edinburgh, LAAS-CNRS,
+//                          New York University, Max Planck Gesellschaft,
+//                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -53,8 +54,9 @@ class SolverFactory {
   ~SolverFactory();
 
   boost::shared_ptr<crocoddyl::SolverAbstract> create(
-      SolverTypes::Type solver_type, ActionModelTypes::Type action_type,
-      size_t T) const;
+      SolverTypes::Type solver_type,
+      boost::shared_ptr<crocoddyl::ActionModelAbstract> model,
+      boost::shared_ptr<crocoddyl::ActionModelAbstract> model2, size_t T) const;
 };
 
 }  // namespace unittest

--- a/unittest/test_solvers.cpp
+++ b/unittest/test_solvers.cpp
@@ -1,9 +1,9 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2021, LAAS-CNRS, New York University,
+// Copyright (C) 2019-2024, LAAS-CNRS, New York University,
 //                          Max Planck Gesellschaft, University of Edinburgh,
-//                          INRIA
+//                          INRIA, Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -21,11 +21,17 @@ using namespace crocoddyl::unittest;
 //____________________________________________________________________________//
 
 void test_kkt_dimension(ActionModelTypes::Type action_type, size_t T) {
+  // Create action models
+  boost::shared_ptr<crocoddyl::ActionModelAbstract> model =
+      ActionModelFactory().create(action_type);
+  boost::shared_ptr<crocoddyl::ActionModelAbstract> model2 =
+      ActionModelFactory().create(action_type, true);
+
   // Create the kkt solver
   SolverFactory factory;
   boost::shared_ptr<crocoddyl::SolverKKT> kkt =
       boost::static_pointer_cast<crocoddyl::SolverKKT>(
-          factory.create(SolverTypes::SolverKKT, action_type, T));
+          factory.create(SolverTypes::SolverKKT, model, model2, T));
 
   // define some aliases
   const std::size_t ndx = kkt->get_ndx();
@@ -43,11 +49,17 @@ void test_kkt_dimension(ActionModelTypes::Type action_type, size_t T) {
 //____________________________________________________________________________//
 
 void test_kkt_search_direction(ActionModelTypes::Type action_type, size_t T) {
+  // Create action models
+  boost::shared_ptr<crocoddyl::ActionModelAbstract> model =
+      ActionModelFactory().create(action_type);
+  boost::shared_ptr<crocoddyl::ActionModelAbstract> model2 =
+      ActionModelFactory().create(action_type, true);
+
   // Create the kkt solver
   SolverFactory factory;
   boost::shared_ptr<crocoddyl::SolverKKT> kkt =
       boost::static_pointer_cast<crocoddyl::SolverKKT>(
-          factory.create(SolverTypes::SolverKKT, action_type, T));
+          factory.create(SolverTypes::SolverKKT, model, model2, T));
 
   // Generate the different state along the trajectory
   const boost::shared_ptr<crocoddyl::ShootingProblem>& problem =
@@ -88,12 +100,18 @@ void test_kkt_search_direction(ActionModelTypes::Type action_type, size_t T) {
 void test_solver_against_kkt_solver(SolverTypes::Type solver_type,
                                     ActionModelTypes::Type action_type,
                                     size_t T) {
+  // Create action models
+  boost::shared_ptr<crocoddyl::ActionModelAbstract> model =
+      ActionModelFactory().create(action_type);
+  boost::shared_ptr<crocoddyl::ActionModelAbstract> model2 =
+      ActionModelFactory().create(action_type, true);
+
   // Create the testing and KKT solvers
   SolverFactory solver_factory;
   boost::shared_ptr<crocoddyl::SolverAbstract> solver =
-      solver_factory.create(solver_type, action_type, T);
+      solver_factory.create(solver_type, model, model2, T);
   boost::shared_ptr<crocoddyl::SolverAbstract> kkt =
-      solver_factory.create(SolverTypes::SolverKKT, action_type, T);
+      solver_factory.create(SolverTypes::SolverKKT, model, model2, T);
 
   // Get the pointer to the problem so we can create the equivalent kkt solver.
   const boost::shared_ptr<crocoddyl::ShootingProblem>& problem =
@@ -152,8 +170,9 @@ void test_solver_against_kkt_solver(SolverTypes::Type solver_type,
 void register_kkt_solver_unit_tests(ActionModelTypes::Type action_type,
                                     const std::size_t T) {
   boost::test_tools::output_test_stream test_name;
-  test_name << "test_" << action_type;
+  test_name << "test_SolverKKT_" << action_type;
   test_suite* ts = BOOST_TEST_SUITE(test_name.str());
+  std::cout << "Running " << test_name.str() << std::endl;
   ts->add(BOOST_TEST_CASE(boost::bind(&test_kkt_dimension, action_type, T)));
   ts->add(
       BOOST_TEST_CASE(boost::bind(&test_kkt_search_direction, action_type, T)));
@@ -164,7 +183,7 @@ void register_solvers_againt_kkt_unit_tests(SolverTypes::Type solver_type,
                                             ActionModelTypes::Type action_type,
                                             const std::size_t T) {
   boost::test_tools::output_test_stream test_name;
-  test_name << "test_" << solver_type << "_" << action_type;
+  test_name << "test_" << solver_type << "_vs_SolverKKT_" << action_type;
   test_suite* ts = BOOST_TEST_SUITE(test_name.str());
   std::cout << "Running " << test_name.str() << std::endl;
   ts->add(BOOST_TEST_CASE(boost::bind(&test_solver_against_kkt_solver,


### PR DESCRIPTION
This PR proposes the following extensions to LQR actions:
  - Define constructor to pass LQR matrices and vectors
  - Introduce `Random` function to generate random LQR problems
  - Add a check procedure for inspecting if the cost hessian is s.d.f. (i.e., convex optimization problem)
  -  Deprecate set/get functions to avoid users defining nonconvex problems
  - Add C++ and Python unit tests with random LQR models
  - Include equality and inequality linear constraints
  - Improve documentation

In short, the LQR actions are now useful beyond unit testing. Users can build LQR problems much more easily.