### PR TITLE
LQR clean ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+* Fixed issues in LQR extensions in https://github.com/loco-3d/crocoddyl/pull/1263
 * Computed dynamic feasibility everytime in https://github.com/loco-3d/crocoddyl/pull/1262
 * Extend LQR actions in https://github.com/loco-3d/crocoddyl/pull/1261
 * Print log with grad absolute + updated logs with Pinocchio 3 in https://github.com/loco-3d/crocoddyl/pull/1260

--- a/bindings/python/crocoddyl/core/actions/diff-lqr.cpp
+++ b/bindings/python/crocoddyl/core/actions/diff-lqr.cpp
@@ -70,6 +70,27 @@ void exposeDifferentialActionLQR() {
           ":param f: dynamics drift\n"
           ":param q: state weight vector\n"
           ":param r: input weight vector"))
+      .def(bp::init<Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd,
+                    Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd,
+                    Eigen::MatrixXd, Eigen::MatrixXd, Eigen::VectorXd,
+                    Eigen::VectorXd, Eigen::VectorXd, Eigen::VectorXd,
+                    Eigen::VectorXd>(
+          bp::args("self", "Aq", "Av", "B", "Q", "R", "N", "G", "H", "f", "q",
+                   "r", "g", "h"),
+          "Initialize the differential LQR action model.\n\n"
+          ":param Aq: position matrix\n"
+          ":param Av: velocity matrix\n"
+          ":param B: input matrix\n"
+          ":param Q: state weight matrix\n"
+          ":param R: input weight matrix\n"
+          ":param N: state-input weight matrix\n"
+          ":param G: state-input inequality constraint matrix\n"
+          ":param H: state-input equality constraint matrix\n"
+          ":param f: dynamics drift\n"
+          ":param q: state weight vector\n"
+          ":param r: input weight vector\n"
+          ":param g: state-input inequality constraint bias\n"
+          ":param h: state-input equality constraint bias"))
       .def(bp::init<int, int, bp::optional<bool> >(
           bp::args("self", "nq", "nu", "driftFree"),
           "Initialize the differential LQR action model.\n\n"

--- a/bindings/python/crocoddyl/core/actions/diff-lqr.cpp
+++ b/bindings/python/crocoddyl/core/actions/diff-lqr.cpp
@@ -44,8 +44,8 @@ void exposeDifferentialActionLQR() {
       "hand, the cost function is given by\n"
       "  l(x,u) = 1/2 [x,u].T [Q N; N.T R] [x,u] + [q,r].T [x,u],\n"
       "and the linear equality and inequality constraints has the form:\n"
-      "  g(x,u) = G [x,u] + g\n"
-      "  h(x,u) = H [x,u] + h<=0.",
+      "  g(x,u) = G [x,u] + g<=0\n"
+      "  h(x,u) = H [x,u] + h.",
       bp::init<Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd,
                Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd>(
           bp::args("self", "Aq", "Av", "B", "Q", "R", "N"),
@@ -125,8 +125,8 @@ void exposeDifferentialActionLQR() {
                "Create a random LQR model.\n\n"
                ":param: nq: position dimension\n"
                ":param nu: control dimension\n"
-               ":param ng: equality constraint dimension (default 0)\n"
-               ":param nh: inequality constraint dimension (default 0)"))
+               ":param ng: inequality constraint dimension (default 0)\n"
+               ":param nh: equality constraint dimension (default 0)"))
       .staticmethod("Random")
       .def("setLQR", &DifferentialActionModelLQR::set_LQR,
            bp::args("self", "Aq", "Av", "B", "Q", "R", "N", "f", "q", "r"),
@@ -171,11 +171,11 @@ void exposeDifferentialActionLQR() {
       .add_property("G",
                     bp::make_function(&DifferentialActionModelLQR::get_G,
                                       bp::return_internal_reference<>()),
-                    "state-input equality constraint matrix")
+                    "state-input inequality constraint matrix")
       .add_property("H",
                     bp::make_function(&DifferentialActionModelLQR::get_H,
                                       bp::return_internal_reference<>()),
-                    "state-input inequality constraint matrix")
+                    "state-input equality constraint matrix")
       .add_property("q",
                     bp::make_function(&DifferentialActionModelLQR::get_q,
                                       bp::return_internal_reference<>()),
@@ -187,11 +187,11 @@ void exposeDifferentialActionLQR() {
       .add_property("g",
                     bp::make_function(&DifferentialActionModelLQR::get_g,
                                       bp::return_internal_reference<>()),
-                    "state-input equality constraint bias")
+                    "state-input inequality constraint bias")
       .add_property("h",
                     bp::make_function(&DifferentialActionModelLQR::get_h,
                                       bp::return_internal_reference<>()),
-                    "state-input inequality constraint bias")
+                    "state-input equality constraint bias")
       // deprecated function
       .add_property(
           "Fq",

--- a/bindings/python/crocoddyl/core/actions/lqr.cpp
+++ b/bindings/python/crocoddyl/core/actions/lqr.cpp
@@ -37,8 +37,8 @@ void exposeActionLQR() {
       "Its cost function is quadratic of the form:\n"
       "  1/2 [x,u].T [Q N; N.T R] [x,u] + [q,r].T [x,u],\n"
       "and the linear equality and inequality constraints has the form:\n"
-      "  g(x,u) = G [x,u] + g\n"
-      "  h(x,u) = H [x,u] + h<=0.",
+      "  g(x,u) = G [x,u] + g<=0\n"
+      "  h(x,u) = H [x,u] + h.",
       bp::init<Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd,
                Eigen::MatrixXd, Eigen::MatrixXd>(
           bp::args("self", "A", "B", "Q", "R", "N"),
@@ -60,13 +60,13 @@ void exposeActionLQR() {
           ":param Q: state weight matrix\n"
           ":param R: input weight matrix\n"
           ":param N: state-input weight matrix\n"
-          ":param G: state-input equality constraint matrix\n"
+          ":param G: state-input inequality constraint matrix\n"
           ":param H: state-input equality constraint matrix\n"
           ":param f: dynamics drift\n"
           ":param q: state weight vector\n"
           ":param r: input weight vector\n"
-          ":param g: state-input equality constraint bias\n"
-          ":param h: state-input inequality constraint bias"))
+          ":param g: state-input inequality constraint bias\n"
+          ":param h: state-input equality constraint bias"))
       .def(bp::init<int, int, bp::optional<bool> >(
           bp::args("self", "nx", "nu", "driftFree"),
           "Initialize the LQR action model.\n\n"
@@ -118,8 +118,8 @@ void exposeActionLQR() {
                "Create a random LQR model.\n\n"
                ":param nx: state dimension\n"
                ":param nu: control dimension\n"
-               ":param ng: equality constraint dimension (default 0)\n"
-               ":param nh: inequality constraint dimension (default 0)"))
+               ":param ng: inequality constraint dimension (default 0)\n"
+               ":param nh: equality constraint dimension (default 0)"))
       .staticmethod("Random")
       .def("setLQR", &ActionModelLQR::set_LQR,
            bp::args("self", "A", "B", "Q", "R", "N", "G", "H", "f", "q", "r",
@@ -130,13 +130,13 @@ void exposeActionLQR() {
            ":param Q: state weight matrix\n"
            ":param R: input weight matrix\n"
            ":param N: state-input weight matrix\n"
-           ":param G: state-input equality constraint matrix\n"
+           ":param G: state-input inequality constraint matrix\n"
            ":param H: state-input equality constraint matrix\n"
            ":param f: dynamics drift\n"
            ":param q: state weight vector\n"
            ":param r: input weight vector\n"
-           ":param g: state-input equality constraint bias\n"
-           ":param h: state-input inequality constraint bias")
+           ":param g: state-input inequality constraint bias\n"
+           ":param h: state-input equality constraint bias")
       .add_property("A",
                     bp::make_function(&ActionModelLQR::get_A,
                                       bp::return_internal_reference<>()),
@@ -164,11 +164,11 @@ void exposeActionLQR() {
       .add_property("G",
                     bp::make_function(&ActionModelLQR::get_G,
                                       bp::return_internal_reference<>()),
-                    "state-input equality constraint matrix")
+                    "state-input inequality constraint matrix")
       .add_property("H",
                     bp::make_function(&ActionModelLQR::get_H,
                                       bp::return_internal_reference<>()),
-                    "state-input inequality constraint matrix")
+                    "state-input equality constraint matrix")
       .add_property("q",
                     bp::make_function(&ActionModelLQR::get_q,
                                       bp::return_internal_reference<>()),
@@ -180,11 +180,11 @@ void exposeActionLQR() {
       .add_property("g",
                     bp::make_function(&ActionModelLQR::get_g,
                                       bp::return_internal_reference<>()),
-                    "state-input equality constraint bias")
+                    "state-input inequality constraint bias")
       .add_property("h",
                     bp::make_function(&ActionModelLQR::get_h,
                                       bp::return_internal_reference<>()),
-                    "state-input inequality constraint bias")
+                    "state-input equality constraint bias")
       // deprecated function
       .add_property(
           "Fx",

--- a/bindings/python/crocoddyl/core/actions/lqr.cpp
+++ b/bindings/python/crocoddyl/core/actions/lqr.cpp
@@ -49,6 +49,19 @@ void exposeActionLQR() {
           ":param R: input weight matrix\n"
           ":param N: state-input weight matrix"))
       .def(bp::init<Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd,
+                    Eigen::MatrixXd, Eigen::MatrixXd, Eigen::VectorXd,
+                    Eigen::VectorXd, Eigen::VectorXd>(
+          bp::args("self", "A", "B", "Q", "R", "N", "f", "q", "r"),
+          "Initialize the differential LQR action model.\n\n"
+          ":param A: state matrix\n"
+          ":param B: input matrix\n"
+          ":param Q: state weight matrix\n"
+          ":param R: input weight matrix\n"
+          ":param N: state-input weight matrix\n"
+          ":param f: dynamics drift\n"
+          ":param q: state weight vector\n"
+          ":param r: input weight vector"))
+      .def(bp::init<Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd,
                     Eigen::MatrixXd, Eigen::MatrixXd, Eigen::MatrixXd,
                     Eigen::MatrixXd, Eigen::VectorXd, Eigen::VectorXd,
                     Eigen::VectorXd, Eigen::VectorXd, Eigen::VectorXd>(

--- a/include/crocoddyl/core/actions/diff-lqr.hpp
+++ b/include/crocoddyl/core/actions/diff-lqr.hpp
@@ -39,9 +39,9 @@ namespace crocoddyl {
  * and the linear equality and inequality constraints has the form:
  * \f[ \begin{aligned}
  * \mathbf{g(x,u)} =  \mathbf{G}\begin{bmatrix} \mathbf{x} \\ \mathbf{u}
- * \end{bmatrix} [x,u] + \mathbf{g}
+ * \end{bmatrix} [x,u] + \mathbf{g} \leq \mathbf{0}
  * &\mathbf{h(x,u)} = \mathbf{H}\begin{bmatrix} \mathbf{x} \\ \mathbf{u}
- * \end{bmatrix} [x,u] + \mathbf{h} \leq \mathbf{0} \end{aligned} \f]
+ * \end{bmatrix} [x,u] + \mathbf{h} \end{aligned} \f]
  */
 template <typename _Scalar>
 class DifferentialActionModelLQRTpl
@@ -99,13 +99,13 @@ class DifferentialActionModelLQRTpl
    * @param[in] Q   State weight matrix
    * @param[in] R   Input weight matrix
    * @param[in] N   State-input weight matrix
-   * @param[in] H  State-input equality constraint matrix
-   * @param[in] G  State-input inequality constraint matrix
+   * @param[in] G   State-input inequality constraint matrix
+   * @param[in] H   State-input equality constraint matrix
    * @param[in] f   Dynamics drift
    * @param[in] q   State weight vector
    * @param[in] r   Input weight vector
-   * @param[in] g  State-input equality constraint bias
-   * @param[in] h  State-input inequality constraint bias
+   * @param[in] g   State-input inequality constraint bias
+   * @param[in] h   State-input equality constraint bias
    */
   DifferentialActionModelLQRTpl(const MatrixXs& Aq, const MatrixXs& Av,
                                 const MatrixXs& B, const MatrixXs& Q,
@@ -152,8 +152,8 @@ class DifferentialActionModelLQRTpl
    *
    * @param[in] nq  Position dimension
    * @param[in] nu  Control dimension
-   * @param[in] ng  Equality constraint dimension (default 0)
-   * @param[in] nh  Inequality constraint dimension (default 0)
+   * @param[in] ng  Inequality constraint dimension (default 0)
+   * @param[in] nh  Equality constraint dimension (default 0)
    */
   static DifferentialActionModelLQRTpl Random(const std::size_t nq,
                                               const std::size_t nu,
@@ -181,10 +181,10 @@ class DifferentialActionModelLQRTpl
   /** @brief Return the state-input weight matrix */
   const MatrixXs& get_N() const;
 
-  /** @brief Return the state-input equality constraint matrix */
+  /** @brief Return the state-input inequality constraint matrix */
   const MatrixXs& get_G() const;
 
-  /** @brief Return the state-input inequality constraint matrix */
+  /** @brief Return the state-input equality constraint matrix */
   const MatrixXs& get_H() const;
 
   /** @brief Return the state weight vector */
@@ -193,10 +193,10 @@ class DifferentialActionModelLQRTpl
   /** @brief Return the input weight vector */
   const VectorXs& get_r() const;
 
-  /** @brief Return the state-input equality constraint bias */
+  /** @brief Return the state-input inequality constraint bias */
   const VectorXs& get_g() const;
 
-  /** @brief Return the state-input inequality constraint bias */
+  /** @brief Return the state-input equality constraint bias */
   const VectorXs& get_h() const;
 
   /**
@@ -208,13 +208,13 @@ class DifferentialActionModelLQRTpl
    * @param[in] Q   State weight matrix
    * @param[in] R   Input weight matrix
    * @param[in] N   State-input weight matrix
-   * @param[in] G  State-input equality constraint matrix
-   * @param[in] H  State-input inequality constraint matrix
+   * @param[in] G   State-input inequality constraint matrix
+   * @param[in] H   State-input equality constraint matrix
    * @param[in] f   Dynamics drift
    * @param[in] q   State weight vector
    * @param[in] r   Input weight vector
-   * @param[in] g  State-input equality constraint bias
-   * @param[in] h  State-input inequality constraint bias
+   * @param[in] g   State-input inequality constraint bias
+   * @param[in] h   State-input equality constraint bias
    */
   void set_LQR(const MatrixXs& Aq, const MatrixXs& Av, const MatrixXs& B,
                const MatrixXs& Q, const MatrixXs& R, const MatrixXs& N,

--- a/include/crocoddyl/core/actions/diff-lqr.hxx
+++ b/include/crocoddyl/core/actions/diff-lqr.hxx
@@ -135,7 +135,7 @@ void DifferentialActionModelLQRTpl<Scalar>::calc(
   data->h.noalias() = H_.leftCols(nq) * q;
   data->h.noalias() += H_.middleCols(nq, nq) * v;
   data->h.noalias() += H_.rightCols(nu_) * u;
-  data->h += g_;
+  data->h += h_;
 }
 
 template <typename Scalar>
@@ -163,7 +163,7 @@ void DifferentialActionModelLQRTpl<Scalar>::calc(
   data->g += g_;
   data->h.noalias() = H_.leftCols(nq) * q;
   data->h.noalias() += H_.middleCols(nq, nq) * v;
-  data->h += g_;
+  data->h += h_;
 }
 
 template <typename Scalar>

--- a/include/crocoddyl/core/actions/lqr.hpp
+++ b/include/crocoddyl/core/actions/lqr.hpp
@@ -39,9 +39,9 @@ namespace crocoddyl {
  * and the linear equality and inequality constraints has the form:
  * \f[ \begin{aligned}
  * \mathbf{g(x,u)} =  \mathbf{G}\begin{bmatrix} \mathbf{x} \\ \mathbf{u}
- * \end{bmatrix} [x,u] + \mathbf{g}
+ * \end{bmatrix} [x,u] + \mathbf{g} \leq \mathbf{0}
  * &\mathbf{h(x,u)} = \mathbf{H}\begin{bmatrix} \mathbf{x} \\ \mathbf{u}
- * \end{bmatrix} [x,u] + \mathbf{h} \leq \mathbf{0} \end{aligned} \f]
+ * \end{bmatrix} [x,u] + \mathbf{h} \end{aligned} \f]
  */
 template <typename _Scalar>
 class ActionModelLQRTpl : public ActionModelAbstractTpl<_Scalar> {
@@ -91,13 +91,13 @@ class ActionModelLQRTpl : public ActionModelAbstractTpl<_Scalar> {
    * @param[in] Q  State weight matrix
    * @param[in] R  Input weight matrix
    * @param[in] N  State-input weight matrix
-   * @param[in] H  State-input equality constraint matrix
    * @param[in] G  State-input inequality constraint matrix
+   * @param[in] H  State-input equality constraint matrix
    * @param[in] f  Dynamics drift
    * @param[in] q  State weight vector
    * @param[in] r  Input weight vector
-   * @param[in] g  State-input equality constraint bias
-   * @param[in] h  State-input inequality constraint bias
+   * @param[in] g  State-input inequality constraint bias
+   * @param[in] h  State-input equality constraint bias
    */
   ActionModelLQRTpl(const MatrixXs& A, const MatrixXs& B, const MatrixXs& Q,
                     const MatrixXs& R, const MatrixXs& N, const MatrixXs& G,
@@ -138,8 +138,8 @@ class ActionModelLQRTpl : public ActionModelAbstractTpl<_Scalar> {
    *
    * @param[in] nx  State dimension
    * @param[in] nu  Control dimension
-   * @param[in] ng  Equality constraint dimension (default 0)
-   * @param[in] nh  Inequality constraint dimension (defaul 0)
+   * @param[in] ng  Inequality constraint dimension (default 0)
+   * @param[in] nh  Equality constraint dimension (defaul 0)
    */
   static ActionModelLQRTpl Random(const std::size_t nx, const std::size_t nu,
                                   const std::size_t ng = 0,
@@ -163,10 +163,10 @@ class ActionModelLQRTpl : public ActionModelAbstractTpl<_Scalar> {
   /** @brief Return the state-input weight matrix */
   const MatrixXs& get_N() const;
 
-  /** @brief Return the state-input equality constraint matrix */
+  /** @brief Return the state-input inequality constraint matrix */
   const MatrixXs& get_G() const;
 
-  /** @brief Return the state-input inequality constraint matrix */
+  /** @brief Return the state-input equality constraint matrix */
   const MatrixXs& get_H() const;
 
   /** @brief Return the state weight vector */
@@ -175,10 +175,10 @@ class ActionModelLQRTpl : public ActionModelAbstractTpl<_Scalar> {
   /** @brief Return the input weight vector */
   const VectorXs& get_r() const;
 
-  /** @brief Return the state-input equality constraint bias */
+  /** @brief Return the state-input inequality constraint bias */
   const VectorXs& get_g() const;
 
-  /** @brief Return the state-input inequality constraint bias */
+  /** @brief Return the state-input equality constraint bias */
   const VectorXs& get_h() const;
 
   /**
@@ -189,13 +189,13 @@ class ActionModelLQRTpl : public ActionModelAbstractTpl<_Scalar> {
    * @param[in] Q  State weight matrix
    * @param[in] R  Input weight matrix
    * @param[in] N  State-input weight matrix
-   * @param[in] G  State-input equality constraint matrix
-   * @param[in] H  State-input inequality constraint matrix
+   * @param[in] G  State-input inequality constraint matrix
+   * @param[in] H  State-input equality constraint matrix
    * @param[in] f  Dynamics drift
    * @param[in] q  State weight vector
    * @param[in] r  Input weight vector
-   * @param[in] g  State-input equality constraint bias
-   * @param[in] h  State-input inequality constraint bias
+   * @param[in] g  State-input inequality constraint bias
+   * @param[in] h  State-input equality constraint bias
    */
   void set_LQR(const MatrixXs& A, const MatrixXs& B, const MatrixXs& Q,
                const MatrixXs& R, const MatrixXs& N, const MatrixXs& G,

--- a/include/crocoddyl/core/actions/lqr.hxx
+++ b/include/crocoddyl/core/actions/lqr.hxx
@@ -129,7 +129,7 @@ void ActionModelLQRTpl<Scalar>::calc(
   data->g += g_;
   data->h.noalias() = H_.leftCols(nx) * x;
   data->h.noalias() += H_.rightCols(nu_) * u;
-  data->h += g_;
+  data->h += h_;
 }
 
 template <typename Scalar>
@@ -155,7 +155,7 @@ void ActionModelLQRTpl<Scalar>::calc(
   data->g.noalias() = G_.leftCols(nx) * x;
   data->g += g_;
   data->h.noalias() = H_.leftCols(nx) * x;
-  data->h += g_;
+  data->h += h_;
 }
 
 template <typename Scalar>


### PR DESCRIPTION
This PR cleans up a few inconsistencies from the previous PR #1261:
  - Errors in the documentation
  - Missed Python bindings of LQR constructors
  - Bug in the calc function for computing equality constraints