### PR TITLE
Fix bug of wrench cone fields not being updated with setters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+* Fixed bug of wrench cone fields not being updated with setters in https://github.com/loco-3d/crocoddyl/pull/1274
 * Replaced parent by parentJoint (which was introduced in Pinocchio 3) in https://github.com/loco-3d/crocoddyl/pull/1271
 * Introduced the notion of terminal dimension, residuals and constraints in https://github.com/loco-3d/crocoddyl/pull/1269
 * General clean ups about std::size_t in https://github.com/loco-3d/crocoddyl/pull/1265

--- a/include/crocoddyl/multibody/wrench-cone.hxx
+++ b/include/crocoddyl/multibody/wrench-cone.hxx
@@ -299,6 +299,7 @@ void WrenchConeTpl<Scalar>::set_box(const Vector2s& box) {
 
 template <typename Scalar>
 void WrenchConeTpl<Scalar>::set_mu(const Scalar mu) {
+  mu_ = mu;
   if (mu < Scalar(0.)) {
     mu_ = Scalar(1.);
     std::cerr << "Warning: mu has to be a positive value, set to 1."

--- a/include/crocoddyl/multibody/wrench-cone.hxx
+++ b/include/crocoddyl/multibody/wrench-cone.hxx
@@ -314,6 +314,7 @@ void WrenchConeTpl<Scalar>::set_inner_appr(const bool inner_appr) {
 
 template <typename Scalar>
 void WrenchConeTpl<Scalar>::set_min_nforce(const Scalar min_nforce) {
+  min_nforce_ = min_nforce;
   if (min_nforce < Scalar(0.)) {
     min_nforce_ = Scalar(0.);
     std::cerr << "Warning: min_nforce has to be a positive value, set to 0"
@@ -323,6 +324,7 @@ void WrenchConeTpl<Scalar>::set_min_nforce(const Scalar min_nforce) {
 
 template <typename Scalar>
 void WrenchConeTpl<Scalar>::set_max_nforce(const Scalar max_nforce) {
+  max_nforce_ = max_nforce;
   if (max_nforce < Scalar(0.)) {
     max_nforce_ = std::numeric_limits<Scalar>::infinity();
     std::cerr << "Warning: max_nforce has to be a positive value, set to "


### PR DESCRIPTION
If merged. this PR will fix some bugs with the `WrenchCone` object, where the setters for `mu`, `min_nforce`, and `max_nforce` were not updating the member fields of the class.