### PR TITLE
update ruff config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,8 +8,6 @@ repos:
     args:
     - --fix
     - --exit-non-zero-on-fix
-    - --ignore
-    - UP036
   - id: ruff-format
 - repo: https://github.com/cheshirekow/cmake-format-precommit
   rev: v0.6.13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+* Ignore ruff issues in ipython notebook files in https://github.com/loco-3d/crocoddyl/pull/1297
 * Improved efficiency for computing impulse-dynamics derivatives in https://github.com/loco-3d/crocoddyl/pull/1294
 * Fixed bug of wrench cone fields not being updated with setters in https://github.com/loco-3d/crocoddyl/pull/1274
 * Replaced parent by parentJoint (which was introduced in Pinocchio 3) in https://github.com/loco-3d/crocoddyl/pull/1271

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 extend-exclude = ["cmake"]
 
 [tool.ruff.lint]
-extend-ignore = ["RUF012"]
+extend-ignore = ["RUF012", "UP036"]
 extend-select = ["I", "NPY", "RUF", "UP", "W"]
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.ruff]
-extend-exclude = ["cmake"]
+extend-exclude = ["*.ipynb", "cmake"]
 
 [tool.ruff.lint]
 extend-ignore = ["RUF012", "UP036"]


### PR DESCRIPTION
Hi,

pre-commit CI is currently failing, because since [ruff v0.5.6](https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md#056) ipython notebook files are included by default.

Ours have many issues, so this PR just disable this check to get CI green again.

While here, move one config option from pre-commit config to global config in pyproject.toml.