### PR TITLE
[actuation] fixed thrust direction for calculation of thrust jacobian

### DIFF
--- a/include/crocoddyl/multibody/actuations/floating-base-thrusters.hpp
+++ b/include/crocoddyl/multibody/actuations/floating-base-thrusters.hpp
@@ -288,7 +288,7 @@ class ActuationModelFloatingBaseThrustersTpl
       const Vector3s& f_z = p.pose.rotation() * Vector3s::UnitZ();
       W_thrust_.template topRows<3>().col(i) += f_z;
       W_thrust_.template middleRows<3>(3).col(i).noalias() +=
-          p.pose.translation().cross(Vector3s::UnitZ());
+          p.pose.translation().cross(f_z);
       switch (p.type) {
         case CW:
           W_thrust_.template middleRows<3>(3).col(i) += p.ctorque * f_z;


### PR DESCRIPTION
I fixed the direction of thrust which is required for calculation of thrust jacobian. 
When the orientation of thruster is not identical to that of parent link, this patch is required.

Since rotational moment generated by thrust is $\lambda p \times u$, where $\lambda$, $p$, and $u$ are thrust, position of thruster, and direction of thrust, respectively. 
