### PR TITLE
Provide more efficient of profilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,8 +91,8 @@ if(APPLE) # Use the handmade approach
   set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/find-external/OpenMP
                         ${CMAKE_MODULE_PATH})
 elseif(UNIX)
-  if(${CMAKE_VERSION} VERSION_GREATER "3.20.0" OR ${CMAKE_VERSION}
-                                                  VERSION_EQUAL "3.20.0")
+  if(${CMAKE_VERSION} VERSION_GREATER "3.25.0" OR ${CMAKE_VERSION}
+                                                  VERSION_EQUAL "3.25.0")
     set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/find-external/OpenMP
                           ${CMAKE_MODULE_PATH})
   endif()

--- a/include/crocoddyl/core/utils/stop-watch.hpp
+++ b/include/crocoddyl/core/utils/stop-watch.hpp
@@ -29,6 +29,7 @@
 #include <iostream>
 #include <map>
 #include <sstream>
+#include <limits>
 
 #ifndef WIN32
 /* The classes below are exported */
@@ -151,7 +152,20 @@ enum StopwatchMode {
 
 */
 class Stopwatch {
+ protected:
+  struct PerformanceData;
+
  public:
+  struct Watcher {
+    Stopwatch &w;
+    std::string n;
+    PerformanceData *p;
+
+    Watcher(Stopwatch &_w, std::string _n, PerformanceData *_p) : w(_w), n(_n), p(_p) {}
+    void start();
+    void stop();
+  };
+
   /** @brief Constructor */
   Stopwatch(StopwatchMode _mode = NONE);
 
@@ -172,6 +186,9 @@ class Stopwatch {
 
   /** @brief Initialize stopwatch to use a certain time taking mode */
   void set_mode(StopwatchMode mode);
+
+  /** @brief create a Start the stopwatch related to a certain piece of code */
+  Watcher watcher(const std::string &perf_name);
 
   /** @brief Start the stopwatch related to a certain piece of code */
   void start(const std::string &perf_name);
@@ -231,8 +248,8 @@ class Stopwatch {
     PerformanceData()
         : clock_start(0),
           total_time(0),
-          min_time(0),
-          max_time(0),
+          min_time(std::numeric_limits<long double>::max()),
+          max_time(std::numeric_limits<long double>::min()),
           last_time(0),
           paused(false),
           stops(0) {}
@@ -246,6 +263,10 @@ class Stopwatch {
                   //!< internal use
     int stops;    //!< How many cycles have been this stopwatch executed?
   };
+
+  PerformanceData& get_or_create_perf(const std::string &perf_name);
+
+  void stop_perf(PerformanceData& perf_info, long double clock_end);
 
   bool active;         //!< Flag to hold the clock's status
   StopwatchMode mode;  //!< Time taking mode

--- a/include/crocoddyl/core/utils/stop-watch.hpp
+++ b/include/crocoddyl/core/utils/stop-watch.hpp
@@ -27,9 +27,9 @@
 
 #include <ctime>
 #include <iostream>
+#include <limits>
 #include <map>
 #include <sstream>
-#include <limits>
 
 #ifndef WIN32
 /* The classes below are exported */
@@ -161,7 +161,8 @@ class Stopwatch {
     std::string n;
     PerformanceData *p;
 
-    Watcher(Stopwatch &_w, std::string _n, PerformanceData *_p) : w(_w), n(_n), p(_p) {}
+    Watcher(Stopwatch &_w, std::string _n, PerformanceData *_p)
+        : w(_w), n(_n), p(_p) {}
     void start();
     void stop();
   };
@@ -264,9 +265,9 @@ class Stopwatch {
     int stops;    //!< How many cycles have been this stopwatch executed?
   };
 
-  PerformanceData& get_or_create_perf(const std::string &perf_name);
+  PerformanceData &get_or_create_perf(const std::string &perf_name);
 
-  void stop_perf(PerformanceData& perf_info, long double clock_end);
+  void stop_perf(PerformanceData &perf_info, long double clock_end);
 
   bool active;         //!< Flag to hold the clock's status
   StopwatchMode mode;  //!< Time taking mode

--- a/src/core/utils/stop-watch.cpp
+++ b/src/core/utils/stop-watch.cpp
@@ -104,7 +104,8 @@ long double Stopwatch::take_time() {
   }
 }
 
-Stopwatch::PerformanceData& Stopwatch::get_or_create_perf(const string& perf_name) {
+Stopwatch::PerformanceData& Stopwatch::get_or_create_perf(
+    const string& perf_name) {
   const auto it = records_of->insert(make_pair(perf_name, PerformanceData()));
   return it.first->second;
 }
@@ -352,7 +353,7 @@ void Stopwatch::Watcher::start() {
   if (p == nullptr) {
     p = &w.get_or_create_perf(n);
   }
-  
+
   p->clock_start = w.take_time();
   p->paused = false;
 }


### PR DESCRIPTION
In this PR,
- I add to the existing profilers a more efficient version that does not repeatedly use `std::map::find`.
- I upgrade the minimum CMake version above with `cmake/find-internal/OpenMP` is used rather than the platform specific one. @ManifoldFR FYI

I can make two separate PRs if that is more convenient for you.