### PR TITLE
Changed return policy to be compliant with Pinocchio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+* Changed return policy in std::vector of Eigen's vector and matrices to be compliant with Pinocchio in https://github.com/loco-3d/crocoddyl/pull/1338
 * Prevent users to improperly setting residual references in https://github.com/loco-3d/crocoddyl/pull/1332
 * Fixed the inequality constraints' feasibility computation by incorporating bounds into the calculation in https://github.com/loco-3d/crocoddyl/pull/1307
 * Improved the action factory used for unit testing in https://github.com/loco-3d/crocoddyl/pull/1300

--- a/bindings/python/crocoddyl/core/solvers/box-ddp.cpp
+++ b/bindings/python/crocoddyl/core/solvers/box-ddp.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2023, LAAS-CNRS, University of Edinburgh
+// Copyright (C) 2019-2025, LAAS-CNRS, University of Edinburgh
 //                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
@@ -27,10 +27,12 @@ void exposeSolverBoxDDP() {
           bp::args("self", "problem"),
           "Initialize the vector dimension.\n\n"
           ":param problem: shooting problem."))
-      .add_property("Quu_inv",
-                    make_function(&SolverBoxDDP::get_Quu_inv,
-                                  bp::return_internal_reference<>()),
-                    "inverse of the Quu computed by the box QP")
+      .add_property(
+          "Quu_inv",
+          make_function(
+              &SolverBoxDDP::get_Quu_inv,
+              bp::return_value_policy<bp::reference_existing_object>()),
+          "inverse of the Quu computed by the box QP")
       .def(CopyableVisitor<SolverBoxDDP>());
 }
 

--- a/bindings/python/crocoddyl/core/solvers/box-fddp.cpp
+++ b/bindings/python/crocoddyl/core/solvers/box-fddp.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2023, University of Edinburgh, Heriot-Watt University
+// Copyright (C) 2019-2025, University of Edinburgh, Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -26,10 +26,12 @@ void exposeSolverBoxFDDP() {
           bp::args("self", "problem"),
           "Initialize the vector dimension.\n\n"
           ":param problem: shooting problem."))
-      .add_property("Quu_inv",
-                    make_function(&SolverBoxFDDP::get_Quu_inv,
-                                  bp::return_internal_reference<>()),
-                    "inverse of the Quu computed by the box QP")
+      .add_property(
+          "Quu_inv",
+          make_function(
+              &SolverBoxFDDP::get_Quu_inv,
+              bp::return_value_policy<bp::reference_existing_object>()),
+          "inverse of the Quu computed by the box QP")
       .def(CopyableVisitor<SolverBoxFDDP>());
 }
 

--- a/bindings/python/crocoddyl/core/solvers/ddp.cpp
+++ b/bindings/python/crocoddyl/core/solvers/ddp.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2023, LAAS-CNRS, University of Edinburgh,
+// Copyright (C) 2019-2025, LAAS-CNRS, University of Edinburgh,
 //                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
@@ -92,7 +92,7 @@ void exposeSolverDDP() {
            "Return a sum of positive parameters whose sum quantifies the DDP "
            "termination.")
       .def("expectedImprovement", &SolverDDP::expectedImprovement,
-           bp::return_value_policy<bp::copy_const_reference>(),
+           bp::return_value_policy<bp::reference_existing_object>(),
            bp::args("self"),
            "Return two scalars denoting the quadratic improvement model\n\n"
            "For computing the expected improvement, you need to compute first\n"
@@ -131,48 +131,57 @@ void exposeSolverDDP() {
            ":param model: action model in the given time instance")
       .add_property(
           "Vxx",
-          make_function(&SolverDDP::get_Vxx,
-                        bp::return_value_policy<bp::copy_const_reference>()),
+          make_function(
+              &SolverDDP::get_Vxx,
+              bp::return_value_policy<bp::reference_existing_object>()),
           "Vxx")
       .add_property(
           "Vx",
-          make_function(&SolverDDP::get_Vx,
-                        bp::return_value_policy<bp::copy_const_reference>()),
+          make_function(
+              &SolverDDP::get_Vx,
+              bp::return_value_policy<bp::reference_existing_object>()),
           "Vx")
       .add_property(
           "Qxx",
-          make_function(&SolverDDP::get_Qxx,
-                        bp::return_value_policy<bp::copy_const_reference>()),
+          make_function(
+              &SolverDDP::get_Qxx,
+              bp::return_value_policy<bp::reference_existing_object>()),
           "Qxx")
       .add_property(
           "Qxu",
-          make_function(&SolverDDP::get_Qxu,
-                        bp::return_value_policy<bp::copy_const_reference>()),
+          make_function(
+              &SolverDDP::get_Qxu,
+              bp::return_value_policy<bp::reference_existing_object>()),
           "Qxu")
       .add_property(
           "Quu",
-          make_function(&SolverDDP::get_Quu,
-                        bp::return_value_policy<bp::copy_const_reference>()),
+          make_function(
+              &SolverDDP::get_Quu,
+              bp::return_value_policy<bp::reference_existing_object>()),
           "Quu")
       .add_property(
           "Qx",
-          make_function(&SolverDDP::get_Qx,
-                        bp::return_value_policy<bp::copy_const_reference>()),
+          make_function(
+              &SolverDDP::get_Qx,
+              bp::return_value_policy<bp::reference_existing_object>()),
           "Qx")
       .add_property(
           "Qu",
-          make_function(&SolverDDP::get_Qu,
-                        bp::return_value_policy<bp::copy_const_reference>()),
+          make_function(
+              &SolverDDP::get_Qu,
+              bp::return_value_policy<bp::reference_existing_object>()),
           "Qu")
       .add_property(
           "K",
-          make_function(&SolverDDP::get_K,
-                        bp::return_value_policy<bp::copy_const_reference>()),
+          make_function(
+              &SolverDDP::get_K,
+              bp::return_value_policy<bp::reference_existing_object>()),
           "K")
       .add_property(
           "k",
-          make_function(&SolverDDP::get_k,
-                        bp::return_value_policy<bp::copy_const_reference>()),
+          make_function(
+              &SolverDDP::get_k,
+              bp::return_value_policy<bp::reference_existing_object>()),
           "k")
       .add_property(
           "reg_incFactor", bp::make_function(&SolverDDP::get_reg_incfactor),
@@ -231,12 +240,13 @@ void exposeSolverDDP() {
           bp::make_function(&SolverDDP::set_th_gaptol,
                             deprecated<>("Deprecated. Use th_gapTol")),
           "threshold for accepting a gap as non-zero")
-      .add_property("alphas",
-                    bp::make_function(
-                        &SolverDDP::get_alphas,
-                        bp::return_value_policy<bp::copy_const_reference>()),
-                    bp::make_function(&SolverDDP::set_alphas),
-                    "list of step length (alpha) values")
+      .add_property(
+          "alphas",
+          bp::make_function(
+              &SolverDDP::get_alphas,
+              bp::return_value_policy<bp::reference_existing_object>()),
+          bp::make_function(&SolverDDP::set_alphas),
+          "list of step length (alpha) values")
       .def(CopyableVisitor<SolverDDP>());
 }
 

--- a/bindings/python/crocoddyl/core/solvers/fddp.cpp
+++ b/bindings/python/crocoddyl/core/solvers/fddp.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2023, LAAS-CNRS, University of Edinburgh,
+// Copyright (C) 2019-2025, LAAS-CNRS, University of Edinburgh,
 //                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
@@ -68,7 +68,7 @@ void exposeSolverFDDP() {
                ":returns the optimal trajectory xopt, uopt and a boolean that "
                "describes if convergence was reached."))
       .def("updateExpectedImprovement", &SolverFDDP::updateExpectedImprovement,
-           bp::return_value_policy<bp::copy_const_reference>(),
+           bp::return_value_policy<bp::reference_existing_object>(),
            bp::args("self"), "Update the expected improvement model\n\n")
       .add_property("th_acceptNegStep",
                     bp::make_function(&SolverFDDP::get_th_acceptnegstep),

--- a/bindings/python/crocoddyl/core/solvers/intro.cpp
+++ b/bindings/python/crocoddyl/core/solvers/intro.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2021-2023, Heriot-Watt University, University of Edinburgh
+// Copyright (C) 2021-2025, Heriot-Watt University, University of Edinburgh
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -88,58 +88,69 @@ void exposeSolverIntro() {
                     "zero when solve is called.")
       .add_property(
           "Hu_rank",
-          make_function(&SolverIntro::get_Hu_rank,
-                        bp::return_value_policy<bp::copy_const_reference>()),
+          make_function(
+              &SolverIntro::get_Hu_rank,
+              bp::return_value_policy<bp::reference_existing_object>()),
           "rank of Hu")
       .add_property(
           "YZ",
-          make_function(&SolverIntro::get_YZ,
-                        bp::return_value_policy<bp::copy_const_reference>()),
+          make_function(
+              &SolverIntro::get_YZ,
+              bp::return_value_policy<bp::reference_existing_object>()),
           "span and kernel of Hu")
       .add_property(
           "Qzz",
-          make_function(&SolverIntro::get_Qzz,
-                        bp::return_value_policy<bp::copy_const_reference>()),
+          make_function(
+              &SolverIntro::get_Qzz,
+              bp::return_value_policy<bp::reference_existing_object>()),
           "Qzz")
       .add_property(
           "Qxz",
-          make_function(&SolverIntro::get_Qxz,
-                        bp::return_value_policy<bp::copy_const_reference>()),
+          make_function(
+              &SolverIntro::get_Qxz,
+              bp::return_value_policy<bp::reference_existing_object>()),
           "Qxz")
       .add_property(
           "Quz",
-          make_function(&SolverIntro::get_Quz,
-                        bp::return_value_policy<bp::copy_const_reference>()),
+          make_function(
+              &SolverIntro::get_Quz,
+              bp::return_value_policy<bp::reference_existing_object>()),
           "Quz")
       .add_property(
           "Qz",
-          make_function(&SolverIntro::get_Qz,
-                        bp::return_value_policy<bp::copy_const_reference>()),
+          make_function(
+              &SolverIntro::get_Qz,
+              bp::return_value_policy<bp::reference_existing_object>()),
           "Qz")
       .add_property(
           "Hy",
-          make_function(&SolverIntro::get_Hy,
-                        bp::return_value_policy<bp::copy_const_reference>()),
+          make_function(
+              &SolverIntro::get_Hy,
+              bp::return_value_policy<bp::reference_existing_object>()),
           "Hy")
       .add_property(
           "Kz",
-          make_function(&SolverIntro::get_Kz,
-                        bp::return_value_policy<bp::copy_const_reference>()),
+          make_function(
+              &SolverIntro::get_Kz,
+              bp::return_value_policy<bp::reference_existing_object>()),
           "Kz")
       .add_property(
           "kz",
-          make_function(&SolverIntro::get_kz,
-                        bp::return_value_policy<bp::copy_const_reference>()),
+          make_function(
+              &SolverIntro::get_kz,
+              bp::return_value_policy<bp::reference_existing_object>()),
           "kz")
       .add_property(
           "Ks",
-          make_function(&SolverIntro::get_Ks,
-                        bp::return_value_policy<bp::copy_const_reference>()),
+          make_function(
+              &SolverIntro::get_Ks,
+              bp::return_value_policy<bp::reference_existing_object>()),
           "Ks")
       .add_property(
           "ks",
-          make_function(&SolverIntro::get_ks,
-                        bp::return_value_policy<bp::copy_const_reference>()),
+          make_function(
+              &SolverIntro::get_ks,
+              bp::return_value_policy<bp::reference_existing_object>()),
           "ks")
       .def(CopyableVisitor<SolverIntro>());
 }

--- a/bindings/python/crocoddyl/core/solvers/kkt.cpp
+++ b/bindings/python/crocoddyl/core/solvers/kkt.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2020-2023, LAAS-CNRS, Heriot-Watt University
+// Copyright (C) 2020-2025, LAAS-CNRS, Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -77,7 +77,7 @@ void exposeSolverKKT() {
            "Return a sum of positive parameters whose sum quantifies the DDP "
            "termination.")
       .def("expectedImprovement", &SolverKKT::expectedImprovement,
-           bp::return_value_policy<bp::copy_const_reference>(),
+           bp::return_value_policy<bp::reference_existing_object>(),
            bp::args("self"),
            "Return two scalars denoting the quadratic improvement model\n\n"
            "For computing the expected improvement, you need to compute first\n"
@@ -86,33 +86,39 @@ void exposeSolverKKT() {
            "d2*a**2/2.")
       .add_property(
           "kkt",
-          make_function(&SolverKKT::get_kkt,
-                        bp::return_value_policy<bp::copy_const_reference>()),
+          make_function(
+              &SolverKKT::get_kkt,
+              bp::return_value_policy<bp::reference_existing_object>()),
           "kkt")
       .add_property(
           "kktref",
-          make_function(&SolverKKT::get_kktref,
-                        bp::return_value_policy<bp::copy_const_reference>()),
+          make_function(
+              &SolverKKT::get_kktref,
+              bp::return_value_policy<bp::reference_existing_object>()),
           "kktref")
       .add_property(
           "primaldual",
-          make_function(&SolverKKT::get_primaldual,
-                        bp::return_value_policy<bp::copy_const_reference>()),
+          make_function(
+              &SolverKKT::get_primaldual,
+              bp::return_value_policy<bp::reference_existing_object>()),
           "primaldual")
       .add_property(
           "lambdas",
-          make_function(&SolverKKT::get_lambdas,
-                        bp::return_value_policy<bp::copy_const_reference>()),
+          make_function(
+              &SolverKKT::get_lambdas,
+              bp::return_value_policy<bp::reference_existing_object>()),
           "lambdas")
       .add_property(
           "dxs",
-          make_function(&SolverKKT::get_dxs,
-                        bp::return_value_policy<bp::copy_const_reference>()),
+          make_function(
+              &SolverKKT::get_dxs,
+              bp::return_value_policy<bp::reference_existing_object>()),
           "dxs")
       .add_property(
           "dus",
-          make_function(&SolverKKT::get_dus,
-                        bp::return_value_policy<bp::copy_const_reference>()),
+          make_function(
+              &SolverKKT::get_dus,
+              bp::return_value_policy<bp::reference_existing_object>()),
           "dus")
       .def(CopyableVisitor<SolverKKT>());
 }


### PR DESCRIPTION
In Python, we return garbage when accessing an item in list of matrices without using `tolist()`. Note that this doesn't happens when using `tolist()`.

This is an issue that I believe comes from Pinocchio's new StdVec_MatrixXs bindings.

Anyways, these changes fixed the problem in Python.