### PR TITLE
Force contacts to update force derivatives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+* Force DifferentialActionDataContactInvDynamics to update df_du for all contacts in  https://github.com/loco-3d/crocoddyl/pull/1348
 * :warning: BREAKING: replaced boost shared pointers by std ones in https://github.com/loco-3d/crocoddyl/pull/1339
 
 ## [2.2.0] - 1980-01-01

--- a/include/crocoddyl/multibody/actions/contact-invdyn.hpp
+++ b/include/crocoddyl/multibody/actions/contact-invdyn.hpp
@@ -574,7 +574,23 @@ struct DifferentialActionDataContactInvDynamicsTpl
       df_du.block(fid, nv + fid, nc, nc).diagonal().setOnes();
       fid += nc;
     }
+    std::vector<bool> contact_status;
+    for (typename ContactModelMultiple::ContactModelContainer::const_iterator
+        it = model->get_contacts()->get_contacts().begin();
+        it != model->get_contacts()->get_contacts().end(); ++it) {
+      const std::shared_ptr<ContactItem>& m_i = it->second;
+      contact_status.push_back(m_i->active);
+      m_i->active = true;
+    }
     model->get_contacts()->updateForceDiff(multibody.contacts, df_dx, df_du);
+    std::size_t cid = 0;
+    for (typename ContactModelMultiple::ContactModelContainer::const_iterator
+        it = model->get_contacts()->get_contacts().begin();
+        it != model->get_contacts()->get_contacts().end(); ++it) {
+      const std::shared_ptr<ContactItem>& m_i = it->second;
+      m_i->active = contact_status[cid];
+      cid++;
+    }
     costs = model->get_costs()->createData(&multibody);
     constraints = model->get_constraints()->createData(&multibody);
     costs->shareMemory(this);

--- a/include/crocoddyl/multibody/actions/contact-invdyn.hpp
+++ b/include/crocoddyl/multibody/actions/contact-invdyn.hpp
@@ -576,8 +576,8 @@ struct DifferentialActionDataContactInvDynamicsTpl
     }
     std::vector<bool> contact_status;
     for (typename ContactModelMultiple::ContactModelContainer::const_iterator
-        it = model->get_contacts()->get_contacts().begin();
-        it != model->get_contacts()->get_contacts().end(); ++it) {
+             it = model->get_contacts()->get_contacts().begin();
+         it != model->get_contacts()->get_contacts().end(); ++it) {
       const std::shared_ptr<ContactItem>& m_i = it->second;
       contact_status.push_back(m_i->active);
       m_i->active = true;
@@ -585,8 +585,8 @@ struct DifferentialActionDataContactInvDynamicsTpl
     model->get_contacts()->updateForceDiff(multibody.contacts, df_dx, df_du);
     std::size_t cid = 0;
     for (typename ContactModelMultiple::ContactModelContainer::const_iterator
-        it = model->get_contacts()->get_contacts().begin();
-        it != model->get_contacts()->get_contacts().end(); ++it) {
+             it = model->get_contacts()->get_contacts().begin();
+         it != model->get_contacts()->get_contacts().end(); ++it) {
       const std::shared_ptr<ContactItem>& m_i = it->second;
       m_i->active = contact_status[cid];
       cid++;


### PR DESCRIPTION
Hi @cmastalli this PR fixes a bug in the computation of the derivatives of the contact forces.
This bug can be observed by adding a disabled contact to the `DifferentialActionModelContactInvDynamics` class: 
```python
contactModel = crocoddyl.ContactModelMultiple(state, nu)
supportContactModel = crocoddyl.ContactModel6D(
    state,
    target_id,
    pinocchio.SE3.Identity(),
    pinocchio.LOCAL,
    nu,
    np.array([0, 0]),
)
contactModel.addContact("contact", supportContactModel, False)
runningModel = crocoddyl.IntegratedActionModelEuler(
    crocoddyl.DifferentialActionModelContactInvDynamics(
        state, actuation, contactModel, runningCosts), dt
)
```
when running `calc` and `calcDiff` it can be observed that the jacobian of the constraint `Hu` is empty as `df_du` is only updated when the contact is active.

The proposed fix, termporally sets all the contacts to active before calling `updateForceDiff` and then restores the original status