### PR TITLE
Remove absolute path for boost library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+* Removed absolute path for boost library in https://github.com/loco-3d/crocoddyl/pull/1353
 * Fixed checking of positive semi-define condition in LQR problems in https://github.com/loco-3d/crocoddyl/pull/1352
 * Compute LU decomposition using permutationP in https://github.com/loco-3d/crocoddyl/pull/1351
 * Force DifferentialActionDataContactInvDynamics to update df_du for all contacts in  https://github.com/loco-3d/crocoddyl/pull/1348

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,4 +280,6 @@ endif()
 
 # PkgConfig packaging of the project
 pkg_config_append_libs(${PROJECT_NAME})
-pkg_config_append_boost_libs(${BOOST_REQUIRED_COMPONENTS})
+foreach(boostlib ${BOOST_REQUIRED_COMPONENTS})
+  pkg_config_append_libs("boost_${boostlib}")
+endforeach()


### PR DESCRIPTION
I encountered the same problem as in pinocchio (https://github.com/stack-of-tasks/pinocchio/issues/2187).
I propose to fix it with the same fix https://github.com/stack-of-tasks/pinocchio/pull/2202