### PR TITLE
Add install version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+* Add install version in https://github.com/loco-3d/crocoddyl/pull/1355
 * Removed absolute path for boost library in https://github.com/loco-3d/crocoddyl/pull/1353
 * Fixed checking of positive semi-define condition in LQR problems in https://github.com/loco-3d/crocoddyl/pull/1352
 * Compute LU decomposition using permutationP in https://github.com/loco-3d/crocoddyl/pull/1351

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,6 +235,7 @@ if(UNIX)
                         Boost::serialization)
   target_compile_definitions(
     ${PROJECT_NAME} PUBLIC PINOCCHIO_ENABLE_COMPATIBILITY_WITH_VERSION_2)
+  set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${PROJECT_VERSION})
 
   if(BUILD_WITH_MULTITHREADS)
     target_link_libraries(${PROJECT_NAME} OpenMP::OpenMP_CXX)


### PR DESCRIPTION
This will install libcrocoddyl.so.2.2.0 as a binary and libcrocoddyl.so as a symlink, instead of just libcrocoddyl.so as a binary.