### PR TITLE
Topic/virtual binding constraint dimension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+* Created Python bindings for (diff)-action getters in https://github.com/loco-3d/crocoddyl/pull/1362
 * Enabled casting and multi-scalar Python bindings in https://github.com/loco-3d/crocoddyl/pull/1346
 * Add install version in https://github.com/loco-3d/crocoddyl/pull/1355
 * Removed absolute path for boost library in https://github.com/loco-3d/crocoddyl/pull/1353

--- a/bindings/python/crocoddyl/core/action-base.cpp
+++ b/bindings/python/crocoddyl/core/action-base.cpp
@@ -97,18 +97,26 @@ struct ActionModelAbstractVisitor
             "ng", bp::make_function(&Model::get_ng),
             bp::make_setter(&Model::ng_, bp::return_internal_reference<>()),
             "number of inequality constraints")
+        .def("get_ng", &Model::get_ng, &Model::default_get_ng,
+            "Return the number of inequality constraints.")
         .add_property(
             "nh", bp::make_function(&Model::get_nh),
             bp::make_setter(&Model::nh_, bp::return_internal_reference<>()),
             "number of equality constraints")
+        .def("get_nh", &Model::get_nh, &Model::default_get_nh,
+            "Return the number of equality constraints.")
         .add_property(
             "ng_T", bp::make_function(&Model::get_ng_T),
             bp::make_setter(&Model::ng_T_, bp::return_internal_reference<>()),
             "number of inequality terminal constraints")
+        .def("get_ng_T", &Model::get_ng_T, &Model::default_get_ng_T,
+            "Return the number of inequality terminal constraints.")
         .add_property(
             "nh_T", bp::make_function(&Model::get_nh_T),
             bp::make_setter(&Model::nh_T_, bp::return_internal_reference<>()),
             "number of equality terminal constraints")
+        .def("get_nh_T", &Model::get_nh_T, &Model::default_get_nh_T,
+            "Return the number of equality terminal constraints.")
         .add_property(
             "state",
             bp::make_function(&Model::get_state,

--- a/bindings/python/crocoddyl/core/action-base.cpp
+++ b/bindings/python/crocoddyl/core/action-base.cpp
@@ -9,6 +9,7 @@
 
 #include "python/crocoddyl/core/action-base.hpp"
 
+#include "python/crocoddyl/utils/deprecate.hpp"
 #include "python/crocoddyl/utils/vector-converter.hpp"
 
 namespace crocoddyl {
@@ -95,28 +96,40 @@ struct ActionModelAbstractVisitor
                       "dimension of cost-residual vector")
         .add_property(
             "ng", bp::make_function(&Model::get_ng),
-            bp::make_setter(&Model::ng_, bp::return_internal_reference<>()),
+            bp::make_setter(
+                &Model::ng_,
+                deprecated<bp::return_internal_reference<>>(
+                    "Deprecated. Contraint dimension should not be modified.")),
             "number of inequality constraints")
         .def("get_ng", &Model::get_ng, &Model::default_get_ng,
-            "Return the number of inequality constraints.")
+             "Return the number of inequality constraints.")
         .add_property(
             "nh", bp::make_function(&Model::get_nh),
-            bp::make_setter(&Model::nh_, bp::return_internal_reference<>()),
+            bp::make_setter(
+                &Model::nh_,
+                deprecated<bp::return_internal_reference<>>(
+                    "Deprecated. Contraint dimension should not be modified.")),
             "number of equality constraints")
         .def("get_nh", &Model::get_nh, &Model::default_get_nh,
-            "Return the number of equality constraints.")
+             "Return the number of equality constraints.")
         .add_property(
             "ng_T", bp::make_function(&Model::get_ng_T),
-            bp::make_setter(&Model::ng_T_, bp::return_internal_reference<>()),
+            bp::make_setter(
+                &Model::ng_T_,
+                deprecated<bp::return_internal_reference<>>(
+                    "Deprecated. Contraint dimension should not be modified.")),
             "number of inequality terminal constraints")
         .def("get_ng_T", &Model::get_ng_T, &Model::default_get_ng_T,
-            "Return the number of inequality terminal constraints.")
+             "Return the number of inequality terminal constraints.")
         .add_property(
             "nh_T", bp::make_function(&Model::get_nh_T),
-            bp::make_setter(&Model::nh_T_, bp::return_internal_reference<>()),
+            bp::make_setter(
+                &Model::nh_T_,
+                deprecated<bp::return_internal_reference<>>(
+                    "Deprecated. Contraint dimension should not be modified.")),
             "number of equality terminal constraints")
         .def("get_nh_T", &Model::get_nh_T, &Model::default_get_nh_T,
-            "Return the number of equality terminal constraints.")
+             "Return the number of equality terminal constraints.")
         .add_property(
             "state",
             bp::make_function(&Model::get_state,

--- a/bindings/python/crocoddyl/core/action-base.hpp
+++ b/bindings/python/crocoddyl/core/action-base.hpp
@@ -132,6 +132,42 @@ class ActionModelAbstractTpl_wrap
     return this->ActionModel::quasiStatic(data, u, x, maxiter, tol);
   }
 
+  std::size_t get_ng() {
+    if (boost::python::override get_ng = this->get_override("get_ng")) {
+      return bp::call<std::size_t>(get_ng.ptr());
+    }
+    return this->ActionModel::get_ng();
+  }
+
+  std::size_t default_get_ng() { return this->ActionModel::get_ng(); }
+
+  std::size_t get_nh() {
+    if (boost::python::override get_nh = this->get_override("get_nh")) {
+      return bp::call<std::size_t>(get_nh.ptr());
+    }
+    return this->ActionModel::get_nh();
+  }
+
+  std::size_t default_get_nh() { return this->ActionModel::get_nh(); }
+
+  std::size_t get_ng_T() {
+    if (boost::python::override get_ng_T = this->get_override("get_ng_T")) {
+      return bp::call<std::size_t>(get_ng_T.ptr());
+    }
+    return this->ActionModel::get_ng_T();
+  }
+
+  std::size_t default_get_ng_T() { return this->ActionModel::get_ng_T(); }
+
+  std::size_t get_nh_T() {
+    if (boost::python::override get_nh_T = this->get_override("get_nh_T")) {
+      return bp::call<std::size_t>(get_nh_T.ptr());
+    }
+    return this->ActionModel::get_nh_T();
+  }
+
+  std::size_t default_get_nh_T() { return this->ActionModel::get_nh_T(); }
+
   template <typename NewScalar>
   ActionModelAbstractTpl_wrap<NewScalar> cast() const {
     typedef ActionModelAbstractTpl_wrap<NewScalar> ReturnType;

--- a/bindings/python/crocoddyl/core/action-base.hpp
+++ b/bindings/python/crocoddyl/core/action-base.hpp
@@ -132,41 +132,41 @@ class ActionModelAbstractTpl_wrap
     return this->ActionModel::quasiStatic(data, u, x, maxiter, tol);
   }
 
-  std::size_t get_ng() {
+  std::size_t get_ng() const override {
     if (boost::python::override get_ng = this->get_override("get_ng")) {
       return bp::call<std::size_t>(get_ng.ptr());
     }
     return this->ActionModel::get_ng();
   }
 
-  std::size_t default_get_ng() { return this->ActionModel::get_ng(); }
+  std::size_t default_get_ng() const { return this->ActionModel::get_ng(); }
 
-  std::size_t get_nh() {
+  std::size_t get_nh() const override {
     if (boost::python::override get_nh = this->get_override("get_nh")) {
       return bp::call<std::size_t>(get_nh.ptr());
     }
     return this->ActionModel::get_nh();
   }
 
-  std::size_t default_get_nh() { return this->ActionModel::get_nh(); }
+  std::size_t default_get_nh() const { return this->ActionModel::get_nh(); }
 
-  std::size_t get_ng_T() {
+  std::size_t get_ng_T() const override {
     if (boost::python::override get_ng_T = this->get_override("get_ng_T")) {
       return bp::call<std::size_t>(get_ng_T.ptr());
     }
     return this->ActionModel::get_ng_T();
   }
 
-  std::size_t default_get_ng_T() { return this->ActionModel::get_ng_T(); }
+  std::size_t default_get_ng_T() const { return this->ActionModel::get_ng_T(); }
 
-  std::size_t get_nh_T() {
+  std::size_t get_nh_T() const override {
     if (boost::python::override get_nh_T = this->get_override("get_nh_T")) {
       return bp::call<std::size_t>(get_nh_T.ptr());
     }
     return this->ActionModel::get_nh_T();
   }
 
-  std::size_t default_get_nh_T() { return this->ActionModel::get_nh_T(); }
+  std::size_t default_get_nh_T() const { return this->ActionModel::get_nh_T(); }
 
   template <typename NewScalar>
   ActionModelAbstractTpl_wrap<NewScalar> cast() const {


### PR DESCRIPTION
Hi @cmastalli this PR set the constraint dimension getters as virtual functions for the python bindings.
Additionally, it deprecates the setters as the user should not be able to modify these values (they should come from the constructor)