### PR TITLE
Introducing explicit template instantiation

### DIFF
--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -44,7 +44,7 @@ jobs:
         # os: ["ubuntu-latest", "macos-latest"]
         os: ["macos-latest"]
         build_type: [Release, Debug]
-        python-version: ["3.8", "3.12"]
+        # python-version: ["3.8", "3.12"]
         compiler: [clang]
 
         include:

--- a/.github/workflows/conda/conda-env.yml
+++ b/.github/workflows/conda/conda-env.yml
@@ -7,7 +7,7 @@ dependencies:
   - numpy
   - scipy
   - python
-  - eigen=3.4.0
+  - eigen
   - eigenpy
   - hpp-fcl
   - urdfdom

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+* Introduced explicit template instantiation in https://github.com/loco-3d/crocoddyl/pull/1367
 * Created Python bindings for (diff)-action getters in https://github.com/loco-3d/crocoddyl/pull/1362
 * Enabled casting and multi-scalar Python bindings in https://github.com/loco-3d/crocoddyl/pull/1346
 * Compute LU decomposition using permutationP in https://github.com/loco-3d/crocoddyl/pull/1351

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,9 @@ set(PROJECT_URL https://github.com/${PROJECT_NAMESPACE}/${PROJECT_NAME})
 
 option(INSTALL_DOCUMENTATION "Generate and install the documentation" OFF)
 
+# Set up Crocoddyl's scalar types
+set(SCALAR_TYPES float double)
+
 # Check if the submodule cmake have been initialized
 set(JRL_CMAKE_MODULES "${CMAKE_CURRENT_LIST_DIR}/cmake")
 if(EXISTS "${JRL_CMAKE_MODULES}/base.cmake")
@@ -171,6 +174,7 @@ if(BUILD_WITH_CODEGEN_SUPPORT)
         "${PACKAGE_EXTRA_MACROS}\nADD_DEFINITIONS(-DPINOCCHIO_CPPAD_REQUIRES_MATRIX_BASE_PLUGIN)"
     )
   endif()
+  list(APPEND SCALAR_TYPES CppAD::AD<CppAD::cg::CG<double>>)
 endif()
 
 # Add OpenMP
@@ -221,6 +225,27 @@ if(NOT BUILD_WITH_IPOPT OR (NOT IPOPT_FOUND))
        ${PROJECT_SOURCE_DIR}/src/core/solvers/ipopt.cpp)
 endif()
 
+function(project_config directory lib_name)
+  string(TOUPPER ${lib_name} upper_lib_name)
+  generate_configuration_header_v2(
+    INCLUDE_DIR
+    ${PROJECT_BINARY_DIR}/include
+    HEADER_DIR
+    ${directory}
+    FILENAME
+    config.hpp
+    LIBRARY_NAME
+    ${upper_lib_name}
+    EXPORT_SYMBOL
+    ${lib_name}_EXPORTS)
+  # By default DEFINE_SYMBOL add -D${lib_name}_EXPORTS. Don't use
+  # ${lib_name}_EXPORTS define since crocoddyl/config.hpp use crocoddyl_EXPORTS.
+  # This allow to use the same DLLAPI define for all template instantiation
+  # libraries.
+  set_target_properties(${lib_name} PROPERTIES DEFINE_SYMBOL
+                                               "${PROJECT_NAME}_EXPORTS")
+endfunction()
+
 if(UNIX)
   # Build options We'd like to deactivate sign conversion since we frequently
   # convert Eigen::Index<>std::size_t Otherwise, activate all warnings.
@@ -245,6 +270,46 @@ if(UNIX)
     target_link_libraries(${PROJECT_NAME} ipopt)
     target_include_directories(${PROJECT_NAME} PUBLIC ${IPOPT_INCLUDE_DIRS})
   endif()
+
+  project_config(crocoddyl crocoddyl)
+
+  # Function to sanitize the scalar type for filenames
+  function(sanitize_scalar_name scalar sanitized_name)
+    string(REPLACE "::" "_" sanitized "${scalar}")
+    string(REPLACE "<" "_" sanitized "${sanitized}")
+    string(REPLACE ">" "" sanitized "${sanitized}")
+    string(REPLACE "," "_" sanitized "${sanitized}")
+    set(${sanitized_name}
+        "${sanitized}"
+        PARENT_SCOPE)
+  endfunction()
+  # Find all .cpp.in template files recursively
+  file(GLOB_RECURSE ETI_TEMPLATE_FILES FOLLOW_SYMLINKS
+       ${CMAKE_SOURCE_DIR}/src/**/*.cpp.in)
+  set(generated_eti_files "")
+  foreach(template_file ${ETI_TEMPLATE_FILES})
+    # Extract the relative path from src/
+    file(RELATIVE_PATH rel_path "${CMAKE_SOURCE_DIR}/src" "${template_file}")
+    # Remove .in extension and get the subdirectory
+    string(REPLACE ".cpp.in" ".cpp" rel_output_file "${rel_path}")
+    # Generate full output path in the build directory
+    set(output_file "${CMAKE_BINARY_DIR}/src/${rel_output_file}")
+    # Ensure the output subdirectory exists
+    get_filename_component(output_dir "${output_file}" DIRECTORY)
+    file(MAKE_DIRECTORY ${output_dir})
+    # Generate .cpp file from template for each scalar type
+    foreach(scalar ${SCALAR_TYPES})
+      # Sanitize scalar name for filenames
+      sanitize_scalar_name("${scalar}" scalar_filename)
+      string(REPLACE ".cpp" "-${scalar_filename}.cpp" scalar_output_file
+                     "${output_file}")
+      set(SCALAR_TYPE ${scalar})
+      configure_file(${template_file} ${scalar_output_file} @ONLY)
+      list(APPEND generated_eti_files ${scalar_output_file})
+    endforeach()
+  endforeach()
+  # Add generated files to the target
+  target_sources(${PROJECT_NAME} PRIVATE ${generated_eti_files})
 
   install(
     TARGETS ${PROJECT_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,8 +106,8 @@ if(BUILD_PYTHON_INTERFACE)
   add_project_dependency(eigenpy 3.1.0 REQUIRED PKG_CONFIG_REQUIRES
                          "eigenpy >= 3.1.0")
 endif(BUILD_PYTHON_INTERFACE)
-add_project_dependency(pinocchio 3.4.0 REQUIRED PKG_CONFIG_REQUIRES
-                       "pinocchio >= 3.4.0")
+add_project_dependency(pinocchio 3.1.0 REQUIRED PKG_CONFIG_REQUIRES
+                       "pinocchio >= 3.1.0")
 if(BUILD_EXAMPLES
    OR BUILD_TESTING
    OR BUILD_BENCHMARK)

--- a/bindings/python/crocoddyl/core/optctrl/shooting.cpp
+++ b/bindings/python/crocoddyl/core/optctrl/shooting.cpp
@@ -12,7 +12,6 @@
 #include <memory>
 
 #include "python/crocoddyl/core/core.hpp"
-#include "python/crocoddyl/utils/deprecate.hpp"
 
 namespace crocoddyl {
 namespace python {
@@ -127,12 +126,6 @@ struct ShootingProblemVisitor
                       "dimension of state tuple")
         .add_property("ndx", bp::make_function(&Problem::get_ndx),
                       "dimension of the tangent space of the state manifold")
-        .add_property(
-            "nu_max",
-            bp::make_function(&Problem::get_nu_max,
-                              deprecated<>("Compute yourself the maximum "
-                                           "dimension of the control vector")),
-            "dimension of the maximum control vector")
         .add_property("is_updated", bp::make_function(&Problem::is_updated),
                       "Returns True if the shooting problem has been updated, "
                       "otherwise False");
@@ -165,14 +158,7 @@ struct ShootingProblemVisitor
       .def(CopyableVisitor<Problem>());
 
 void exposeShootingProblem() {
-// TODO: Remove once the deprecated update call has been removed in a future
-// release
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
   CROCODDYL_PYTHON_SCALARS(CROCODDYL_SHOOTING_PROBLEM_PYTHON_BINDINGS)
-
-#pragma GCC diagnostic pop
 }
 
 }  // namespace python

--- a/include/crocoddyl/core/action-base.hpp
+++ b/include/crocoddyl/core/action-base.hpp
@@ -441,4 +441,7 @@ struct ActionDataAbstractTpl {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/core/action-base.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::ActionModelAbstractTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::ActionDataAbstractTpl)
+
 #endif  // CROCODDYL_CORE_ACTION_BASE_HPP_

--- a/include/crocoddyl/core/actions/diff-lqr.hpp
+++ b/include/crocoddyl/core/actions/diff-lqr.hpp
@@ -367,4 +367,10 @@ struct DifferentialActionDataLQRTpl
 /* --- Details -------------------------------------------------------------- */
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/core/actions/diff-lqr.hxx"
+
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(
+    crocoddyl::DifferentialActionModelLQRTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::DifferentialActionDataLQRTpl)
+
 #endif  // CROCODDYL_CORE_ACTIONS_DIFF_LQR_HPP_

--- a/include/crocoddyl/core/actions/diff-lqr.hxx
+++ b/include/crocoddyl/core/actions/diff-lqr.hxx
@@ -448,7 +448,8 @@ void DifferentialActionModelLQRTpl<Scalar>::set_LQR(
   L_ = MatrixXs::Zero(2 * nq + nu_, 2 * nq + nu_);
   L_ << Q, N, N.transpose(), R;
   Eigen::SelfAdjointEigenSolver<MatrixXs> eig(L_);
-  if (eig.info() != Eigen::Success || eig.eigenvalues().minCoeff() < -1e-12) {
+  if (eig.info() != Eigen::Success ||
+      eig.eigenvalues().minCoeff() < ScaleNumerics<Scalar>(-1e-9)) {
     throw_pretty("Invalid argument "
                  << "[Q, N; N.T, R] is not positive semi-definite");
   }

--- a/include/crocoddyl/core/actions/lqr.hpp
+++ b/include/crocoddyl/core/actions/lqr.hpp
@@ -347,4 +347,7 @@ struct ActionDataLQRTpl : public ActionDataAbstractTpl<_Scalar> {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/core/actions/lqr.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::ActionModelLQRTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::ActionDataLQRTpl)
+
 #endif  // CROCODDYL_CORE_ACTIONS_LQR_HPP_

--- a/include/crocoddyl/core/actions/unicycle.hpp
+++ b/include/crocoddyl/core/actions/unicycle.hpp
@@ -115,4 +115,7 @@ struct ActionDataUnicycleTpl : public ActionDataAbstractTpl<_Scalar> {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/core/actions/unicycle.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::ActionModelUnicycleTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::ActionDataUnicycleTpl)
+
 #endif  // CROCODDYL_CORE_ACTIONS_UNICYCLE_HPP_

--- a/include/crocoddyl/core/activation-base.hpp
+++ b/include/crocoddyl/core/activation-base.hpp
@@ -109,4 +109,7 @@ struct ActivationDataAbstractTpl {
 
 }  // namespace crocoddyl
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::ActivationModelAbstractTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::ActivationDataAbstractTpl)
+
 #endif  // CROCODDYL_CORE_ACTIVATION_BASE_HPP_

--- a/include/crocoddyl/core/activations/2norm-barrier.hpp
+++ b/include/crocoddyl/core/activations/2norm-barrier.hpp
@@ -191,4 +191,9 @@ struct ActivationData2NormBarrierTpl
 
 }  // namespace crocoddyl
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(
+    crocoddyl::ActivationModel2NormBarrierTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::ActivationData2NormBarrierTpl)
+
 #endif  // CROCODDYL_CORE_ACTIVATIONS_2NORM_BARRIER_HPP_

--- a/include/crocoddyl/core/activations/quadratic-barrier.hpp
+++ b/include/crocoddyl/core/activations/quadratic-barrier.hpp
@@ -231,4 +231,10 @@ struct ActivationDataQuadraticBarrierTpl
 
 }  // namespace crocoddyl
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::ActivationBoundsTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(
+    crocoddyl::ActivationModelQuadraticBarrierTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::ActivationDataQuadraticBarrierTpl)
+
 #endif  // CROCODDYL_CORE_ACTIVATIONS_QUADRATIC_BARRIER_HPP_

--- a/include/crocoddyl/core/activations/quadratic-flat-exp.hpp
+++ b/include/crocoddyl/core/activations/quadratic-flat-exp.hpp
@@ -172,4 +172,9 @@ struct ActivationDataQuadFlatExpTpl
 
 }  // namespace crocoddyl
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(
+    crocoddyl::ActivationModelQuadFlatExpTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::ActivationDataQuadFlatExpTpl)
+
 #endif  // CROCODDYL_CORE_ACTIVATIONS_QUADRATIC_FLAT_EXP_HPP_

--- a/include/crocoddyl/core/activations/quadratic-flat-log.hpp
+++ b/include/crocoddyl/core/activations/quadratic-flat-log.hpp
@@ -170,4 +170,9 @@ struct ActivationDataQuadFlatLogTpl
 
 }  // namespace crocoddyl
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(
+    crocoddyl::ActivationModelQuadFlatLogTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::ActivationDataQuadFlatLogTpl)
+
 #endif  // CROCODDYL_CORE_ACTIVATIONS_QUADRATIC_FLAT_LOG_HPP_

--- a/include/crocoddyl/core/activations/quadratic.hpp
+++ b/include/crocoddyl/core/activations/quadratic.hpp
@@ -87,4 +87,9 @@ class ActivationModelQuadTpl : public ActivationModelAbstractTpl<_Scalar> {
 
 }  // namespace crocoddyl
 
+extern template class CROCODDYL_EXPLICIT_INSTANTIATION_DECLARATION_DLLAPI
+    crocoddyl::ActivationModelQuadTpl<double>;
+extern template class CROCODDYL_EXPLICIT_INSTANTIATION_DECLARATION_DLLAPI
+    crocoddyl::ActivationModelQuadTpl<float>;
+
 #endif  // CROCODDYL_CORE_ACTIVATIONS_QUADRATIC_HPP_

--- a/include/crocoddyl/core/activations/smooth-1norm.hpp
+++ b/include/crocoddyl/core/activations/smooth-1norm.hpp
@@ -165,4 +165,9 @@ struct ActivationDataSmooth1NormTpl
 
 }  // namespace crocoddyl
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(
+    crocoddyl::ActivationModelSmooth1NormTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::ActivationDataSmooth1NormTpl)
+
 #endif  // CROCODDYL_CORE_ACTIVATIONS_SMOOTH_1NORM_HPP_

--- a/include/crocoddyl/core/activations/smooth-2norm.hpp
+++ b/include/crocoddyl/core/activations/smooth-2norm.hpp
@@ -129,4 +129,9 @@ class ActivationModelSmooth2NormTpl
 
 }  // namespace crocoddyl
 
+extern template class CROCODDYL_EXPLICIT_INSTANTIATION_DECLARATION_DLLAPI
+    crocoddyl::ActivationModelSmooth2NormTpl<double>;
+extern template class CROCODDYL_EXPLICIT_INSTANTIATION_DECLARATION_DLLAPI
+    crocoddyl::ActivationModelSmooth2NormTpl<float>;
+
 #endif  // CROCODDYL_CORE_ACTIVATIONS_SMOOTH_2NORM_HPP_

--- a/include/crocoddyl/core/activations/smooth-abs.hpp
+++ b/include/crocoddyl/core/activations/smooth-abs.hpp
@@ -45,4 +45,7 @@ struct ActivationDataSmoothAbsTpl
 
 }  // namespace crocoddyl
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::ActivationModelSmoothAbsTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::ActivationDataSmoothAbsTpl)
+
 #endif  // CROCODDYL_CORE_ACTIVATIONS_SMOOTH_ABS_HPP_

--- a/include/crocoddyl/core/activations/weighted-quadratic-barrier.hpp
+++ b/include/crocoddyl/core/activations/weighted-quadratic-barrier.hpp
@@ -121,4 +121,9 @@ class ActivationModelWeightedQuadraticBarrierTpl
 
 }  // namespace crocoddyl
 
+extern template class CROCODDYL_EXPLICIT_INSTANTIATION_DECLARATION_DLLAPI
+    crocoddyl::ActivationModelWeightedQuadraticBarrierTpl<double>;
+extern template class CROCODDYL_EXPLICIT_INSTANTIATION_DECLARATION_DLLAPI
+    crocoddyl::ActivationModelWeightedQuadraticBarrierTpl<float>;
+
 #endif  // CROCODDYL_CORE_ACTIVATIONS_WEIGHTED_QUADRATIC_BARRIER_HPP_

--- a/include/crocoddyl/core/activations/weighted-quadratic.hpp
+++ b/include/crocoddyl/core/activations/weighted-quadratic.hpp
@@ -145,4 +145,9 @@ struct ActivationDataWeightedQuadTpl
 
 }  // namespace crocoddyl
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(
+    crocoddyl::ActivationModelWeightedQuadTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::ActivationDataWeightedQuadTpl)
+
 #endif  // CROCODDYL_CORE_ACTIVATIONS_WEIGHTED_QUADRATIC_HPP_

--- a/include/crocoddyl/core/actuation-base.hpp
+++ b/include/crocoddyl/core/actuation-base.hpp
@@ -222,4 +222,7 @@ struct ActuationDataAbstractTpl {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/core/actuation-base.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::ActuationModelAbstractTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::ActuationDataAbstractTpl)
+
 #endif  // CROCODDYL_CORE_ACTUATION_BASE_HPP_

--- a/include/crocoddyl/core/actuation/actuation-squashing.hpp
+++ b/include/crocoddyl/core/actuation/actuation-squashing.hpp
@@ -128,4 +128,7 @@ struct ActuationSquashingDataTpl : public ActuationDataAbstractTpl<_Scalar> {
 
 }  // namespace crocoddyl
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::ActuationSquashingModelTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::ActuationSquashingDataTpl)
+
 #endif  // CROCODDYL_CORE_ACTIVATION_SQUASH_BASE_HPP_

--- a/include/crocoddyl/core/actuation/squashing-base.hpp
+++ b/include/crocoddyl/core/actuation/squashing-base.hpp
@@ -117,4 +117,7 @@ std::ostream& operator<<(std::ostream& os,
 
 }  // namespace crocoddyl
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::SquashingModelAbstractTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::SquashingDataAbstractTpl)
+
 #endif  // CROCODDYL_CORE_SQUASHING_BASE_HPP_

--- a/include/crocoddyl/core/actuation/squashing/smooth-sat.hpp
+++ b/include/crocoddyl/core/actuation/squashing/smooth-sat.hpp
@@ -111,4 +111,6 @@ class SquashingModelSmoothSatTpl : public SquashingModelAbstractTpl<_Scalar> {
 
 }  // namespace crocoddyl
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::SquashingModelSmoothSatTpl)
+
 #endif  // CROCODDYL_CORE_SQUASHING_SMOOTH_SAT_HPP_

--- a/include/crocoddyl/core/codegen/action-base.hpp
+++ b/include/crocoddyl/core/codegen/action-base.hpp
@@ -652,4 +652,7 @@ struct ActionDataCodeGenTpl : public ActionDataAbstractTpl<_Scalar> {
 
 }  // namespace crocoddyl
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::ActionModelCodeGenTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::ActionDataCodeGenTpl)
+
 #endif  // CROCODDYL_CORE_CODEGEN_ACTION_BASE_HPP_

--- a/include/crocoddyl/core/constraint-base.hpp
+++ b/include/crocoddyl/core/constraint-base.hpp
@@ -318,4 +318,7 @@ struct ConstraintDataAbstractTpl {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/core/constraint-base.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::ConstraintModelAbstractTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::ConstraintDataAbstractTpl)
+
 #endif  // CROCODDYL_CORE_CONSTRAINT_BASE_HPP_

--- a/include/crocoddyl/core/constraints/constraint-manager.hpp
+++ b/include/crocoddyl/core/constraints/constraint-manager.hpp
@@ -483,4 +483,8 @@ struct ConstraintDataManagerTpl {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/core/constraints/constraint-manager.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::ConstraintItemTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::ConstraintModelManagerTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::ConstraintDataManagerTpl)
+
 #endif  // CROCODDYL_CORE_CONSTRAINTS_CONSTRAINT_MANAGER_HPP_

--- a/include/crocoddyl/core/constraints/residual.hpp
+++ b/include/crocoddyl/core/constraints/residual.hpp
@@ -208,4 +208,7 @@ struct ConstraintDataResidualTpl : public ConstraintDataAbstractTpl<_Scalar> {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/core/constraints/residual.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::ConstraintModelResidualTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::ConstraintDataResidualTpl)
+
 #endif  // CROCODDYL_CORE_CONSTRAINTS_RESIDUAL_CONSTRAINT_HPP_

--- a/include/crocoddyl/core/control-base.hpp
+++ b/include/crocoddyl/core/control-base.hpp
@@ -243,4 +243,9 @@ struct ControlParametrizationDataAbstractTpl {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/core/control-base.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(
+    crocoddyl::ControlParametrizationModelAbstractTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::ControlParametrizationDataAbstractTpl)
+
 #endif  // CROCODDYL_CORE_CONTROL_BASE_HPP_

--- a/include/crocoddyl/core/controls/poly-one.hpp
+++ b/include/crocoddyl/core/controls/poly-one.hpp
@@ -198,4 +198,9 @@ struct ControlParametrizationDataPolyOneTpl
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/core/controls/poly-one.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(
+    crocoddyl::ControlParametrizationModelPolyOneTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::ControlParametrizationDataPolyOneTpl)
+
 #endif  // CROCODDYL_CORE_CONTROLS_POLY_ONE_HPP_

--- a/include/crocoddyl/core/controls/poly-two-rk.hpp
+++ b/include/crocoddyl/core/controls/poly-two-rk.hpp
@@ -210,4 +210,9 @@ struct ControlParametrizationDataPolyTwoRKTpl
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/core/controls/poly-two-rk.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(
+    crocoddyl::ControlParametrizationModelPolyTwoRKTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::ControlParametrizationDataPolyTwoRKTpl)
+
 #endif  // CROCODDYL_CORE_CONTROLS_POLY_TWO_RK_HPP_

--- a/include/crocoddyl/core/controls/poly-zero.hpp
+++ b/include/crocoddyl/core/controls/poly-zero.hpp
@@ -169,4 +169,7 @@ class ControlParametrizationModelPolyZeroTpl
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/core/controls/poly-zero.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(
+    crocoddyl::ControlParametrizationModelPolyZeroTpl)
+
 #endif  // CROCODDYL_CORE_CONTROLS_POLY_ZERO_HPP_

--- a/include/crocoddyl/core/cost-base.hpp
+++ b/include/crocoddyl/core/cost-base.hpp
@@ -350,4 +350,7 @@ struct CostDataAbstractTpl {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/core/cost-base.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::CostModelAbstractTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::CostDataAbstractTpl)
+
 #endif  // CROCODDYL_CORE_COST_BASE_HPP_

--- a/include/crocoddyl/core/costs/cost-sum.hpp
+++ b/include/crocoddyl/core/costs/cost-sum.hpp
@@ -438,4 +438,8 @@ struct CostDataSumTpl {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/core/costs/cost-sum.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::CostItemTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::CostModelSumTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::CostDataSumTpl)
+
 #endif  // CROCODDYL_CORE_COSTS_COST_SUM_HPP_

--- a/include/crocoddyl/core/costs/residual.hpp
+++ b/include/crocoddyl/core/costs/residual.hpp
@@ -189,4 +189,7 @@ struct CostDataResidualTpl : public CostDataAbstractTpl<_Scalar> {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/core/costs/residual.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::CostModelResidualTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::CostDataResidualTpl)
+
 #endif  // CROCODDYL_CORE_COSTS_RESIDUAL_COST_HPP_

--- a/include/crocoddyl/core/data-collector-base.hpp
+++ b/include/crocoddyl/core/data-collector-base.hpp
@@ -25,4 +25,6 @@ struct DataCollectorAbstractTpl {
 
 }  // namespace crocoddyl
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::DataCollectorAbstractTpl)
+
 #endif  // CROCODDYL_CORE_DATA_COLLECTOR_BASE_HPP_

--- a/include/crocoddyl/core/data/actuation.hpp
+++ b/include/crocoddyl/core/data/actuation.hpp
@@ -31,4 +31,6 @@ struct DataCollectorActuationTpl : virtual DataCollectorAbstractTpl<Scalar> {
 
 }  // namespace crocoddyl
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::DataCollectorActuationTpl)
+
 #endif  // CROCODDYL_CORE_DATA_ACTUATION_HPP_

--- a/include/crocoddyl/core/data/joint.hpp
+++ b/include/crocoddyl/core/data/joint.hpp
@@ -99,4 +99,9 @@ struct DataCollectorJointActuationTpl : DataCollectorActuationTpl<Scalar> {
 
 }  // namespace crocoddyl
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::JointDataAbstractTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::DataCollectorJointTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::DataCollectorJointActuationTpl)
+
 #endif  // CROCODDYL_CORE_DATA_JOINT_HPP_

--- a/include/crocoddyl/core/diff-action-base.hpp
+++ b/include/crocoddyl/core/diff-action-base.hpp
@@ -476,4 +476,9 @@ struct DifferentialActionDataAbstractTpl {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/core/diff-action-base.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(
+    crocoddyl::DifferentialActionModelAbstractTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::DifferentialActionDataAbstractTpl)
+
 #endif  // CROCODDYL_CORE_DIFF_ACTION_BASE_HPP_

--- a/include/crocoddyl/core/fwd.hpp
+++ b/include/crocoddyl/core/fwd.hpp
@@ -10,6 +10,7 @@
 #ifndef CROCODDYL_CORE_FWD_HPP_
 #define CROCODDYL_CORE_FWD_HPP_
 
+#include "crocoddyl/config.hpp"
 #include "crocoddyl/core/macros.hpp"
 #include "crocoddyl/core/utils/conversions.hpp"
 #include "crocoddyl/core/utils/deprecate.hpp"

--- a/include/crocoddyl/core/integ-action-base.hpp
+++ b/include/crocoddyl/core/integ-action-base.hpp
@@ -212,4 +212,9 @@ struct IntegratedActionDataAbstractTpl : public ActionDataAbstractTpl<_Scalar> {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/core/integ-action-base.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(
+    crocoddyl::IntegratedActionModelAbstractTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::IntegratedActionDataAbstractTpl)
+
 #endif  // CROCODDYL_CORE_INTEGRATED_ACTION_BASE_HPP_

--- a/include/crocoddyl/core/integrator/euler.hpp
+++ b/include/crocoddyl/core/integrator/euler.hpp
@@ -253,4 +253,9 @@ struct IntegratedActionDataEulerTpl
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/core/integrator/euler.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(
+    crocoddyl::IntegratedActionModelEulerTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::IntegratedActionDataEulerTpl)
+
 #endif  // CROCODDYL_CORE_INTEGRATOR_EULER_HPP_

--- a/include/crocoddyl/core/integrator/rk.hpp
+++ b/include/crocoddyl/core/integrator/rk.hpp
@@ -372,4 +372,7 @@ struct IntegratedActionDataRKTpl
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/core/integrator/rk.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::IntegratedActionModelRKTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::IntegratedActionDataRKTpl)
+
 #endif  // CROCODDYL_CORE_INTEGRATOR_RK4_HPP_

--- a/include/crocoddyl/core/macros.hpp
+++ b/include/crocoddyl/core/macros.hpp
@@ -40,6 +40,37 @@ std::unique_ptr<T> make_unique(Args&&... args) {
 
 #ifdef CROCODDYL_WITH_CODEGEN_DISABLE  // TODO: Change to CROCODDYL_WITH_CODEGEN
                                        // when supporting codegen
+#define CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(class_name)                 \
+  extern template class CROCODDYL_EXPLICIT_INSTANTIATION_DECLARATION_DLLAPI \
+      class_name<double>;                                                   \
+  extern template class CROCODDYL_EXPLICIT_INSTANTIATION_DECLARATION_DLLAPI \
+      class_name<float>;                                                    \
+  extern template class CROCODDYL_EXPLICIT_INSTANTIATION_DECLARATION_DLLAPI \
+      class_name<ADFloat64>;
+
+#define CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(class_name)                 \
+  extern template struct CROCODDYL_EXPLICIT_INSTANTIATION_DECLARATION_DLLAPI \
+      class_name<double>;                                                    \
+  extern template struct CROCODDYL_EXPLICIT_INSTANTIATION_DECLARATION_DLLAPI \
+      class_name<float>;                                                     \
+  extern template struct CROCODDYL_EXPLICIT_INSTANTIATION_DECLARATION_DLLAPI \
+      class_name<ADFloat64>;
+#else
+#define CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(class_name)                 \
+  extern template class CROCODDYL_EXPLICIT_INSTANTIATION_DECLARATION_DLLAPI \
+      class_name<double>;                                                   \
+  extern template class CROCODDYL_EXPLICIT_INSTANTIATION_DECLARATION_DLLAPI \
+      class_name<float>;
+
+#define CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(class_name)                 \
+  extern template struct CROCODDYL_EXPLICIT_INSTANTIATION_DECLARATION_DLLAPI \
+      class_name<double>;                                                    \
+  extern template struct CROCODDYL_EXPLICIT_INSTANTIATION_DECLARATION_DLLAPI \
+      class_name<float>;
+#endif
+
+#ifdef CROCODDYL_WITH_CODEGEN_DISABLE  // TODO: Change to CROCODDYL_WITH_CODEGEN
+                                       // when supporting codegen
 #define CROCODDYL_BASE_CAST(base_class, class)                              \
   template <typename Scalar>                                                \
   std::shared_ptr<class<Scalar>> cast() const {                             \

--- a/include/crocoddyl/core/numdiff/action.hpp
+++ b/include/crocoddyl/core/numdiff/action.hpp
@@ -269,4 +269,7 @@ struct ActionDataNumDiffTpl : public ActionDataAbstractTpl<_Scalar> {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/core/numdiff/action.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::ActionModelNumDiffTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::ActionDataNumDiffTpl)
+
 #endif  // CROCODDYL_CORE_NUMDIFF_ACTION_HPP_

--- a/include/crocoddyl/core/numdiff/action.hxx
+++ b/include/crocoddyl/core/numdiff/action.hxx
@@ -357,7 +357,7 @@ void ActionModelNumDiffTpl<Scalar>::set_disturbance(const Scalar disturbance) {
     throw_pretty("Invalid argument: " << "Disturbance constant is positive");
   }
   e_jac_ = disturbance;
-  e_hess_ = sqrt(2.0 * e_jac_);
+  e_hess_ = Scalar(sqrt(2.0 * e_jac_));
 }
 
 template <typename Scalar>

--- a/include/crocoddyl/core/numdiff/activation.hpp
+++ b/include/crocoddyl/core/numdiff/activation.hpp
@@ -155,4 +155,7 @@ struct ActivationDataNumDiffTpl : public ActivationDataAbstractTpl<_Scalar> {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/core/numdiff/activation.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::ActivationModelNumDiffTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::ActivationDataNumDiffTpl)
+
 #endif  // CROCODDYL_CORE_NUMDIFF_ACTIVATION_HPP_

--- a/include/crocoddyl/core/numdiff/cost.hpp
+++ b/include/crocoddyl/core/numdiff/cost.hpp
@@ -247,4 +247,7 @@ struct CostDataNumDiffTpl : public CostDataAbstractTpl<_Scalar> {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/core/numdiff/cost.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::CostModelNumDiffTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::CostDataNumDiffTpl)
+
 #endif  // CROCODDYL_CORE_NUMDIFF_COST_HPP_

--- a/include/crocoddyl/core/numdiff/diff-action.hpp
+++ b/include/crocoddyl/core/numdiff/diff-action.hpp
@@ -268,4 +268,9 @@ struct DifferentialActionDataNumDiffTpl
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/core/numdiff/diff-action.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(
+    crocoddyl::DifferentialActionModelNumDiffTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::DifferentialActionDataNumDiffTpl)
+
 #endif  // CROCODDYL_CORE_NUMDIFF_DIFF_ACTION_HPP_

--- a/include/crocoddyl/core/numdiff/state.hpp
+++ b/include/crocoddyl/core/numdiff/state.hpp
@@ -125,4 +125,6 @@ class StateNumDiffTpl : public StateAbstractTpl<_Scalar> {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/core/numdiff/state.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::StateNumDiffTpl)
+
 #endif  // CROCODDYL_CORE_NUMDIFF_STATE_HPP_

--- a/include/crocoddyl/core/optctrl/shooting.hpp
+++ b/include/crocoddyl/core/optctrl/shooting.hpp
@@ -324,4 +324,9 @@ class ShootingProblemTpl {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/core/optctrl/shooting.hxx"
 
+extern template class CROCODDYL_EXPLICIT_INSTANTIATION_DECLARATION_DLLAPI
+    crocoddyl::ShootingProblemTpl<double>;
+extern template class CROCODDYL_EXPLICIT_INSTANTIATION_DECLARATION_DLLAPI
+    crocoddyl::ShootingProblemTpl<float>;
+
 #endif  // CROCODDYL_CORE_OPTCTRL_SHOOTING_HPP_

--- a/include/crocoddyl/core/optctrl/shooting.hpp
+++ b/include/crocoddyl/core/optctrl/shooting.hpp
@@ -272,12 +272,6 @@ class ShootingProblemTpl {
   std::size_t get_ndx() const;
 
   /**
-   * @brief Return the maximum dimension of the control vector
-   */
-  DEPRECATED("Compute yourself the maximum dimension of the control vector",
-             std::size_t get_nu_max() const;)
-
-  /**
    * @brief Return the number of threads
    */
   std::size_t get_nthreads() const;
@@ -308,7 +302,6 @@ class ShootingProblemTpl {
       running_datas_;     //!< Running action data
   std::size_t nx_;        //!< State dimension
   std::size_t ndx_;       //!< State rate dimension
-  std::size_t nu_max_;    //!< Maximum control dimension
   std::size_t nthreads_;  //!< Number of threads launch by the multi-threading
                           //!< application
   bool is_updated_;

--- a/include/crocoddyl/core/optctrl/shooting.hxx
+++ b/include/crocoddyl/core/optctrl/shooting.hxx
@@ -27,16 +27,8 @@ ShootingProblemTpl<Scalar>::ShootingProblemTpl(
       running_models_(running_models),
       nx_(running_models[0]->get_state()->get_nx()),
       ndx_(running_models[0]->get_state()->get_ndx()),
-      nu_max_(running_models[0]->get_nu()),
       nthreads_(1),
       is_updated_(false) {
-  for (std::size_t i = 1; i < T_; ++i) {
-    const std::shared_ptr<ActionModelAbstract>& model = running_models_[i];
-    const std::size_t nu = model->get_nu();
-    if (nu_max_ < nu) {
-      nu_max_ = nu;
-    }
-  }
   if (static_cast<std::size_t>(x0.size()) != nx_) {
     throw_pretty(
         "Invalid argument: " << "x0 has wrong dimension (it should be " +
@@ -90,15 +82,7 @@ ShootingProblemTpl<Scalar>::ShootingProblemTpl(
       running_datas_(running_datas),
       nx_(running_models[0]->get_state()->get_nx()),
       ndx_(running_models[0]->get_state()->get_ndx()),
-      nu_max_(running_models[0]->get_nu()),
       nthreads_(1) {
-  for (std::size_t i = 1; i < T_; ++i) {
-    const std::shared_ptr<ActionModelAbstract>& model = running_models_[i];
-    const std::size_t nu = model->get_nu();
-    if (nu_max_ < nu) {
-      nu_max_ = nu;
-    }
-  }
   if (static_cast<std::size_t>(x0.size()) != nx_) {
     throw_pretty(
         "Invalid argument: " << "x0 has wrong dimension (it should be " +
@@ -154,8 +138,7 @@ ShootingProblemTpl<Scalar>::ShootingProblemTpl(
       running_models_(problem.get_runningModels()),
       running_datas_(problem.get_runningDatas()),
       nx_(problem.get_nx()),
-      ndx_(problem.get_ndx()),
-      nu_max_(problem.get_nu_max()) {}
+      ndx_(problem.get_ndx()) {}
 
 template <typename Scalar>
 ShootingProblemTpl<Scalar>::~ShootingProblemTpl() {}
@@ -543,11 +526,6 @@ std::size_t ShootingProblemTpl<Scalar>::get_nx() const {
 template <typename Scalar>
 std::size_t ShootingProblemTpl<Scalar>::get_ndx() const {
   return ndx_;
-}
-
-template <typename Scalar>
-std::size_t ShootingProblemTpl<Scalar>::get_nu_max() const {
-  return nu_max_;
 }
 
 template <typename Scalar>

--- a/include/crocoddyl/core/residual-base.hpp
+++ b/include/crocoddyl/core/residual-base.hpp
@@ -290,4 +290,7 @@ struct ResidualDataAbstractTpl {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/core/residual-base.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::ResidualModelAbstractTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::ResidualDataAbstractTpl)
+
 #endif  // CROCODDYL_CORE_RESIDUAL_BASE_HPP_

--- a/include/crocoddyl/core/residuals/control.hpp
+++ b/include/crocoddyl/core/residuals/control.hpp
@@ -178,4 +178,6 @@ class ResidualModelControlTpl : public ResidualModelAbstractTpl<_Scalar> {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/core/residuals/control.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::ResidualModelControlTpl)
+
 #endif  // CROCODDYL_CORE_RESIDUALS_CONTROL_HPP_

--- a/include/crocoddyl/core/residuals/joint-acceleration.hpp
+++ b/include/crocoddyl/core/residuals/joint-acceleration.hpp
@@ -211,4 +211,9 @@ struct ResidualDataJointAccelerationTpl
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/core/residuals/joint-acceleration.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(
+    crocoddyl::ResidualModelJointAccelerationTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::ResidualDataJointAccelerationTpl)
+
 #endif  // CROCODDYL_CORE_RESIDUALS_JOINT_ACCELERATION_HPP_

--- a/include/crocoddyl/core/residuals/joint-effort.hpp
+++ b/include/crocoddyl/core/residuals/joint-effort.hpp
@@ -231,4 +231,7 @@ struct ResidualDataJointEffortTpl : public ResidualDataAbstractTpl<_Scalar> {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/core/residuals/joint-effort.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::ResidualModelJointEffortTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::ResidualDataJointEffortTpl)
+
 #endif  // CROCODDYL_CORE_RESIDUALS_JOINT_TORQUE_HPP_

--- a/include/crocoddyl/core/state-base.hpp
+++ b/include/crocoddyl/core/state-base.hpp
@@ -352,4 +352,6 @@ class StateAbstractTpl : public StateBase {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/core/state-base.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::StateAbstractTpl)
+
 #endif  // CROCODDYL_CORE_STATE_BASE_HPP_

--- a/include/crocoddyl/core/states/euclidean.hpp
+++ b/include/crocoddyl/core/states/euclidean.hpp
@@ -78,4 +78,6 @@ class StateVectorTpl : public StateAbstractTpl<_Scalar> {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/core/states/euclidean.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::StateVectorTpl)
+
 #endif  // CROCODDYL_CORE_STATES_EUCLIDEAN_HPP_

--- a/include/crocoddyl/multibody/actions/contact-fwddyn.hpp
+++ b/include/crocoddyl/multibody/actions/contact-fwddyn.hpp
@@ -415,4 +415,9 @@ struct DifferentialActionDataContactFwdDynamicsTpl
 /* --- Details -------------------------------------------------------------- */
 #include <crocoddyl/multibody/actions/contact-fwddyn.hxx>
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(
+    crocoddyl::DifferentialActionModelContactFwdDynamicsTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::DifferentialActionDataContactFwdDynamicsTpl)
+
 #endif  // CROCODDYL_MULTIBODY_ACTIONS_CONTACT_FWDDYN_HPP_

--- a/include/crocoddyl/multibody/actions/contact-invdyn.hpp
+++ b/include/crocoddyl/multibody/actions/contact-invdyn.hpp
@@ -792,4 +792,9 @@ struct DifferentialActionDataContactInvDynamicsTpl
 /* --- Details -------------------------------------------------------------- */
 #include <crocoddyl/multibody/actions/contact-invdyn.hxx>
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(
+    crocoddyl::DifferentialActionModelContactInvDynamicsTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::DifferentialActionDataContactInvDynamicsTpl)
+
 #endif  // CROCODDYL_MULTIBODY_ACTIONS_CONTACT_INVDYN_HPP_

--- a/include/crocoddyl/multibody/actions/free-fwddyn.hpp
+++ b/include/crocoddyl/multibody/actions/free-fwddyn.hpp
@@ -307,4 +307,9 @@ struct DifferentialActionDataFreeFwdDynamicsTpl
 /* --- Details -------------------------------------------------------------- */
 #include <crocoddyl/multibody/actions/free-fwddyn.hxx>
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(
+    crocoddyl::DifferentialActionModelFreeFwdDynamicsTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::DifferentialActionDataFreeFwdDynamicsTpl)
+
 #endif  // CROCODDYL_MULTIBODY_ACTIONS_FREE_FWDDYN_HPP_

--- a/include/crocoddyl/multibody/actions/free-invdyn.hpp
+++ b/include/crocoddyl/multibody/actions/free-invdyn.hpp
@@ -519,4 +519,9 @@ struct DifferentialActionDataFreeInvDynamicsTpl
 /* --- Details -------------------------------------------------------------- */
 #include <crocoddyl/multibody/actions/free-invdyn.hxx>
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(
+    crocoddyl::DifferentialActionModelFreeInvDynamicsTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::DifferentialActionDataFreeInvDynamicsTpl)
+
 #endif  // CROCODDYL_MULTIBODY_ACTIONS_FREE_INVDYN_HPP_

--- a/include/crocoddyl/multibody/actions/impulse-fwddyn.hpp
+++ b/include/crocoddyl/multibody/actions/impulse-fwddyn.hpp
@@ -386,4 +386,9 @@ struct ActionDataImpulseFwdDynamicsTpl : public ActionDataAbstractTpl<_Scalar> {
 /* --- Details -------------------------------------------------------------- */
 #include <crocoddyl/multibody/actions/impulse-fwddyn.hxx>
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(
+    crocoddyl::ActionModelImpulseFwdDynamicsTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::ActionDataImpulseFwdDynamicsTpl)
+
 #endif  // CROCODDYL_MULTIBODY_ACTIONS_IMPULSE_FWDDYN_HPP_

--- a/include/crocoddyl/multibody/actuations/floating-base-thrusters.hpp
+++ b/include/crocoddyl/multibody/actuations/floating-base-thrusters.hpp
@@ -372,4 +372,9 @@ class ActuationModelFloatingBaseThrustersTpl
 
 }  // namespace crocoddyl
 
+extern template class CROCODDYL_EXPLICIT_INSTANTIATION_DECLARATION_DLLAPI
+    crocoddyl::ActuationModelFloatingBaseThrustersTpl<double>;
+extern template class CROCODDYL_EXPLICIT_INSTANTIATION_DECLARATION_DLLAPI
+    crocoddyl::ActuationModelFloatingBaseThrustersTpl<float>;
+
 #endif  // CROCODDYL_MULTIBODY_ACTUATIONS_PROPELLERS_HPP_

--- a/include/crocoddyl/multibody/actuations/floating-base.hpp
+++ b/include/crocoddyl/multibody/actuations/floating-base.hpp
@@ -188,4 +188,9 @@ class ActuationModelFloatingBaseTpl
 
 }  // namespace crocoddyl
 
+extern template class CROCODDYL_EXPLICIT_INSTANTIATION_DECLARATION_DLLAPI
+    crocoddyl::ActuationModelFloatingBaseTpl<double>;
+extern template class CROCODDYL_EXPLICIT_INSTANTIATION_DECLARATION_DLLAPI
+    crocoddyl::ActuationModelFloatingBaseTpl<float>;
+
 #endif  // CROCODDYL_MULTIBODY_ACTUATIONS_FLOATING_BASE_HPP_

--- a/include/crocoddyl/multibody/actuations/full.hpp
+++ b/include/crocoddyl/multibody/actuations/full.hpp
@@ -154,4 +154,9 @@ class ActuationModelFullTpl : public ActuationModelAbstractTpl<_Scalar> {
 
 }  // namespace crocoddyl
 
+extern template class CROCODDYL_EXPLICIT_INSTANTIATION_DECLARATION_DLLAPI
+    crocoddyl::ActuationModelFullTpl<double>;
+extern template class CROCODDYL_EXPLICIT_INSTANTIATION_DECLARATION_DLLAPI
+    crocoddyl::ActuationModelFullTpl<float>;
+
 #endif  // CROCODDYL_MULTIBODY_ACTUATIONS_FULL_HPP_

--- a/include/crocoddyl/multibody/contact-base.hpp
+++ b/include/crocoddyl/multibody/contact-base.hpp
@@ -228,4 +228,7 @@ struct ContactDataAbstractTpl : public ForceDataAbstractTpl<_Scalar> {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/multibody/contact-base.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::ContactModelAbstractTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::ContactDataAbstractTpl)
+
 #endif  // CROCODDYL_MULTIBODY_CONTACT_BASE_HPP_

--- a/include/crocoddyl/multibody/contacts/contact-1d.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-1d.hpp
@@ -285,4 +285,7 @@ struct ContactData1DTpl : public ContactDataAbstractTpl<_Scalar> {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/multibody/contacts/contact-1d.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::ContactModel1DTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::ContactData1DTpl)
+
 #endif  // CROCODDYL_MULTIBODY_CONTACTS_CONTACT_1D_HPP_

--- a/include/crocoddyl/multibody/contacts/contact-2d.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-2d.hpp
@@ -224,4 +224,7 @@ struct ContactData2DTpl : public ContactDataAbstractTpl<_Scalar> {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/multibody/contacts/contact-2d.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::ContactModel2DTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::ContactData2DTpl)
+
 #endif  // CROCODDYL_MULTIBODY_CONTACTS_CONTACT_2D_HPP_

--- a/include/crocoddyl/multibody/contacts/contact-3d.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-3d.hpp
@@ -270,4 +270,7 @@ struct ContactData3DTpl : public ContactDataAbstractTpl<_Scalar> {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/multibody/contacts/contact-3d.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::ContactModel3DTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::ContactData3DTpl)
+
 #endif  // CROCODDYL_MULTIBODY_CONTACTS_CONTACT_3D_HPP_

--- a/include/crocoddyl/multibody/contacts/contact-6d.hpp
+++ b/include/crocoddyl/multibody/contacts/contact-6d.hpp
@@ -262,4 +262,7 @@ struct ContactData6DTpl : public ContactDataAbstractTpl<_Scalar> {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/multibody/contacts/contact-6d.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::ContactModel6DTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::ContactData6DTpl)
+
 #endif  // CROCODDYL_MULTIBODY_CONTACTS_CONTACT_6D_HPP_

--- a/include/crocoddyl/multibody/contacts/multiple-contacts.hpp
+++ b/include/crocoddyl/multibody/contacts/multiple-contacts.hpp
@@ -381,4 +381,8 @@ struct ContactDataMultipleTpl {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/multibody/contacts/multiple-contacts.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::ContactItemTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::ContactModelMultipleTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::ContactDataMultipleTpl)
+
 #endif  // CROCODDYL_MULTIBODY_CONTACTS_MULTIPLE_CONTACTS_HPP_

--- a/include/crocoddyl/multibody/cop-support.hpp
+++ b/include/crocoddyl/multibody/cop-support.hpp
@@ -12,6 +12,7 @@
 
 #include "crocoddyl/core/mathbase.hpp"
 #include "crocoddyl/multibody/fwd.hpp"
+#include "crocoddyl/multibody/wrench-cone.hpp"
 
 namespace crocoddyl {
 
@@ -150,5 +151,7 @@ class CoPSupportTpl {
 }  // namespace crocoddyl
 
 #include "crocoddyl/multibody/cop-support.hxx"
+
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::CoPSupportTpl)
 
 #endif  // CROCODDYL_MULTIBODY_COP_SUPPORT_HPP_

--- a/include/crocoddyl/multibody/data/contacts.hpp
+++ b/include/crocoddyl/multibody/data/contacts.hpp
@@ -76,4 +76,12 @@ struct DataCollectorJointActMultibodyInContactTpl
 
 }  // namespace crocoddyl
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::DataCollectorContactTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::DataCollectorMultibodyInContactTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::DataCollectorActMultibodyInContactTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::DataCollectorJointActMultibodyInContactTpl)
+
 #endif  // CROCODDYL_CORE_DATA_MULTIBODY_IN_CONTACT_HPP_

--- a/include/crocoddyl/multibody/data/impulses.hpp
+++ b/include/crocoddyl/multibody/data/impulses.hpp
@@ -44,4 +44,8 @@ struct DataCollectorMultibodyInImpulseTpl : DataCollectorMultibodyTpl<Scalar>,
 
 }  // namespace crocoddyl
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::DataCollectorImpulseTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::DataCollectorMultibodyInImpulseTpl)
+
 #endif  // CROCODDYL_CORE_DATA_MULTIBODY_IN_IMPULSE_HPP_

--- a/include/crocoddyl/multibody/data/multibody.hpp
+++ b/include/crocoddyl/multibody/data/multibody.hpp
@@ -58,4 +58,10 @@ struct DataCollectorJointActMultibodyTpl : DataCollectorActMultibodyTpl<Scalar>,
 
 }  // namespace crocoddyl
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::DataCollectorMultibodyTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::DataCollectorActMultibodyTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::DataCollectorJointActMultibodyTpl)
+
 #endif  // CROCODDYL_CORE_DATA_MULTIBODY_HPP_

--- a/include/crocoddyl/multibody/force-base.hpp
+++ b/include/crocoddyl/multibody/force-base.hpp
@@ -61,4 +61,6 @@ struct ForceDataAbstractTpl {
 
 }  // namespace crocoddyl
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::ForceDataAbstractTpl)
+
 #endif  // CROCODDYL_MULTIBODY_FORCE_BASE_HPP_

--- a/include/crocoddyl/multibody/friction-cone.hpp
+++ b/include/crocoddyl/multibody/friction-cone.hpp
@@ -215,4 +215,6 @@ class FrictionConeTpl {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/multibody/friction-cone.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::FrictionConeTpl)
+
 #endif  // CROCODDYL_MULTIBODY_FRICTION_CONE_HPP_

--- a/include/crocoddyl/multibody/friction-cone.hxx
+++ b/include/crocoddyl/multibody/friction-cone.hxx
@@ -216,7 +216,7 @@ void FrictionConeTpl<Scalar>::set_R(const Matrix3s& R) {
 
 template <typename Scalar>
 void FrictionConeTpl<Scalar>::set_nsurf(const Vector3s& nsurf) {
-  Eigen::Vector3d normal = nsurf;
+  Vector3s normal = nsurf;
   // Sanity checks
   if (!nsurf.isUnitary()) {
     normal /= nsurf.norm();

--- a/include/crocoddyl/multibody/impulse-base.hpp
+++ b/include/crocoddyl/multibody/impulse-base.hpp
@@ -150,4 +150,7 @@ struct ImpulseDataAbstractTpl : public ForceDataAbstractTpl<_Scalar> {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/multibody/impulse-base.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::ImpulseModelAbstractTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::ImpulseDataAbstractTpl)
+
 #endif  // CROCODDYL_MULTIBODY_IMPULSE_BASE_HPP_

--- a/include/crocoddyl/multibody/impulses/impulse-3d.hpp
+++ b/include/crocoddyl/multibody/impulses/impulse-3d.hpp
@@ -173,4 +173,7 @@ struct ImpulseData3DTpl : public ImpulseDataAbstractTpl<_Scalar> {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/multibody/impulses/impulse-3d.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::ImpulseModel3DTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::ImpulseData3DTpl)
+
 #endif  // CROCODDYL_MULTIBODY_IMPULSES_IMPULSE_3D_HPP_

--- a/include/crocoddyl/multibody/impulses/impulse-6d.hpp
+++ b/include/crocoddyl/multibody/impulses/impulse-6d.hpp
@@ -180,4 +180,7 @@ struct ImpulseData6DTpl : public ImpulseDataAbstractTpl<_Scalar> {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/multibody/impulses/impulse-6d.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::ImpulseModel6DTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::ImpulseData6DTpl)
+
 #endif  // CROCODDYL_MULTIBODY_IMPULSES_IMPULSE_6D_HPP_

--- a/include/crocoddyl/multibody/impulses/multiple-impulses.hpp
+++ b/include/crocoddyl/multibody/impulses/multiple-impulses.hpp
@@ -341,4 +341,8 @@ struct ImpulseDataMultipleTpl {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/multibody/impulses/multiple-impulses.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::ImpulseItemTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::ImpulseModelMultipleTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::ImpulseDataMultipleTpl)
+
 #endif  // CROCODDYL_MULTIBODY_IMPULSES_MULTIPLE_IMPULSES_HPP_

--- a/include/crocoddyl/multibody/residuals/centroidal-momentum.hpp
+++ b/include/crocoddyl/multibody/residuals/centroidal-momentum.hpp
@@ -193,4 +193,9 @@ struct ResidualDataCentroidalMomentumTpl
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/multibody/residuals/centroidal-momentum.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(
+    crocoddyl::ResidualModelCentroidalMomentumTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::ResidualDataCentroidalMomentumTpl)
+
 #endif  // CROCODDYL_MULTIBODY_RESIDUALS_MOMENTUM_HPP_

--- a/include/crocoddyl/multibody/residuals/com-position.hpp
+++ b/include/crocoddyl/multibody/residuals/com-position.hpp
@@ -175,4 +175,7 @@ struct ResidualDataCoMPositionTpl : public ResidualDataAbstractTpl<_Scalar> {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/multibody/residuals/com-position.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::ResidualModelCoMPositionTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::ResidualDataCoMPositionTpl)
+
 #endif  // CROCODDYL_MULTIBODY_RESIDUALS_COM_POSITION_HPP_

--- a/include/crocoddyl/multibody/residuals/contact-control-gravity.hpp
+++ b/include/crocoddyl/multibody/residuals/contact-control-gravity.hpp
@@ -210,4 +210,9 @@ struct ResidualDataContactControlGravTpl
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/multibody/residuals/contact-control-gravity.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(
+    crocoddyl::ResidualModelContactControlGravTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::ResidualDataContactControlGravTpl)
+
 #endif  // CROCODDYL_MULTIBODY_RESIDUALS_CONTACT_CONTROL_GRAVITY_HPP_

--- a/include/crocoddyl/multibody/residuals/contact-cop-position.hpp
+++ b/include/crocoddyl/multibody/residuals/contact-cop-position.hpp
@@ -372,4 +372,9 @@ struct ResidualDataContactCoPPositionTpl
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/multibody/residuals/contact-cop-position.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(
+    crocoddyl::ResidualModelContactCoPPositionTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::ResidualDataContactCoPPositionTpl)
+
 #endif  // CROCODDYL_MULTIBODY_RESIDUALS_CONTACT_COP_POSITION_HPP_

--- a/include/crocoddyl/multibody/residuals/contact-force.hpp
+++ b/include/crocoddyl/multibody/residuals/contact-force.hpp
@@ -371,4 +371,7 @@ struct ResidualDataContactForceTpl : public ResidualDataAbstractTpl<_Scalar> {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/multibody/residuals/contact-force.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::ResidualModelContactForceTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::ResidualDataContactForceTpl)
+
 #endif  // CROCODDYL_MULTIBODY_RESIDUALS_CONTACT_FORCE_HPP_

--- a/include/crocoddyl/multibody/residuals/contact-friction-cone.hpp
+++ b/include/crocoddyl/multibody/residuals/contact-friction-cone.hpp
@@ -356,4 +356,9 @@ struct ResidualDataContactFrictionConeTpl
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/multibody/residuals/contact-friction-cone.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(
+    crocoddyl::ResidualModelContactFrictionConeTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::ResidualDataContactFrictionConeTpl)
+
 #endif  // CROCODDYL_MULTIBODY_RESIDUALS_CONTACT_FRICTION_CONE_HPP_

--- a/include/crocoddyl/multibody/residuals/contact-wrench-cone.hpp
+++ b/include/crocoddyl/multibody/residuals/contact-wrench-cone.hpp
@@ -356,4 +356,9 @@ struct ResidualDataContactWrenchConeTpl
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/multibody/residuals/contact-wrench-cone.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(
+    crocoddyl::ResidualModelContactWrenchConeTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::ResidualDataContactWrenchConeTpl)
+
 #endif  // CROCODDYL_MULTIBODY_RESIDUALS_CONTACT_WRENCH_CONE_HPP_

--- a/include/crocoddyl/multibody/residuals/control-gravity.hpp
+++ b/include/crocoddyl/multibody/residuals/control-gravity.hpp
@@ -183,4 +183,7 @@ struct ResidualDataControlGravTpl : public ResidualDataAbstractTpl<_Scalar> {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/multibody/residuals/control-gravity.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::ResidualModelControlGravTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::ResidualDataControlGravTpl)
+
 #endif  // CROCODDYL_MULTIBODY_RESIDUALS_CONTROL_GRAVITY_HPP_

--- a/include/crocoddyl/multibody/residuals/frame-placement.hpp
+++ b/include/crocoddyl/multibody/residuals/frame-placement.hpp
@@ -210,4 +210,9 @@ struct ResidualDataFramePlacementTpl : public ResidualDataAbstractTpl<_Scalar> {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/multibody/residuals/frame-placement.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(
+    crocoddyl::ResidualModelFramePlacementTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::ResidualDataFramePlacementTpl)
+
 #endif  // CROCODDYL_MULTIBODY_RESIDUALS_FRAME_PLACEMENT_HPP_

--- a/include/crocoddyl/multibody/residuals/frame-rotation.hpp
+++ b/include/crocoddyl/multibody/residuals/frame-rotation.hpp
@@ -210,4 +210,9 @@ struct ResidualDataFrameRotationTpl : public ResidualDataAbstractTpl<_Scalar> {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/multibody/residuals/frame-rotation.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(
+    crocoddyl::ResidualModelFrameRotationTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::ResidualDataFrameRotationTpl)
+
 #endif  // CROCODDYL_MULTIBODY_RESIDUALS_FRAME_ROTATION_HPP_

--- a/include/crocoddyl/multibody/residuals/frame-translation.hpp
+++ b/include/crocoddyl/multibody/residuals/frame-translation.hpp
@@ -205,4 +205,9 @@ struct ResidualDataFrameTranslationTpl
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/multibody/residuals/frame-translation.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(
+    crocoddyl::ResidualModelFrameTranslationTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::ResidualDataFrameTranslationTpl)
+
 #endif  // CROCODDYL_MULTIBODY_RESIDUALS_FRAME_TRANSLATION_HPP_

--- a/include/crocoddyl/multibody/residuals/frame-velocity.hpp
+++ b/include/crocoddyl/multibody/residuals/frame-velocity.hpp
@@ -218,4 +218,9 @@ struct ResidualDataFrameVelocityTpl : public ResidualDataAbstractTpl<_Scalar> {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/multibody/residuals/frame-velocity.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(
+    crocoddyl::ResidualModelFrameVelocityTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::ResidualDataFrameVelocityTpl)
+
 #endif  // CROCODDYL_MULTIBODY_RESIDUALS_FRAME_VELOCITY_HPP_

--- a/include/crocoddyl/multibody/residuals/impulse-com.hpp
+++ b/include/crocoddyl/multibody/residuals/impulse-com.hpp
@@ -171,4 +171,7 @@ struct ResidualDataImpulseCoMTpl : public ResidualDataAbstractTpl<_Scalar> {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/multibody/residuals/impulse-com.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::ResidualModelImpulseCoMTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(crocoddyl::ResidualDataImpulseCoMTpl)
+
 #endif  // CROCODDYL_MULTIBODY_RESIDUALS_IMPULSE_COM_HPP_

--- a/include/crocoddyl/multibody/residuals/state.hpp
+++ b/include/crocoddyl/multibody/residuals/state.hpp
@@ -184,4 +184,9 @@ class ResidualModelStateTpl : public ResidualModelAbstractTpl<_Scalar> {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/multibody/residuals/state.hxx"
 
+extern template class CROCODDYL_EXPLICIT_INSTANTIATION_DECLARATION_DLLAPI
+    crocoddyl::ResidualModelStateTpl<double>;
+extern template class CROCODDYL_EXPLICIT_INSTANTIATION_DECLARATION_DLLAPI
+    crocoddyl::ResidualModelStateTpl<float>;
+
 #endif  // CROCODDYL_MULTIBODY_RESIDUALS_STATE_HPP_

--- a/include/crocoddyl/multibody/states/multibody.hpp
+++ b/include/crocoddyl/multibody/states/multibody.hpp
@@ -127,4 +127,9 @@ class StateMultibodyTpl : public StateAbstractTpl<_Scalar> {
 /* --- Details -------------------------------------------------------------- */
 #include "crocoddyl/multibody/states/multibody.hxx"
 
+extern template class CROCODDYL_EXPLICIT_INSTANTIATION_DECLARATION_DLLAPI
+    crocoddyl::StateMultibodyTpl<double>;
+extern template class CROCODDYL_EXPLICIT_INSTANTIATION_DECLARATION_DLLAPI
+    crocoddyl::StateMultibodyTpl<float>;
+
 #endif  // CROCODDYL_MULTIBODY_STATES_MULTIBODY_HPP_

--- a/include/crocoddyl/multibody/wrench-cone.hpp
+++ b/include/crocoddyl/multibody/wrench-cone.hpp
@@ -238,4 +238,6 @@ class WrenchConeTpl {
 
 #include "crocoddyl/multibody/wrench-cone.hxx"
 
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(crocoddyl::WrenchConeTpl)
+
 #endif  // CROCODDYL_MULTIBODY_WRENCH_CONE_HPP_

--- a/include/crocoddyl/multibody/wrench-cone.hxx
+++ b/include/crocoddyl/multibody/wrench-cone.hxx
@@ -84,7 +84,7 @@ WrenchConeTpl<Scalar>::WrenchConeTpl(const Matrix3s& R, const Scalar mu,
                  "infinity value"
               << std::endl;
   }
-  A_ = MatrixX3s::Zero(nf_ + 13, 6);
+  A_ = MatrixX6s::Zero(nf_ + 13, 6);
   ub_ = VectorXs::Zero(nf_ + 13);
   lb_ = VectorXs::Zero(nf_ + 13);
 

--- a/src/core/action-base.cpp.in
+++ b/src/core/action-base.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/action-base.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActionModelAbstractTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActionDataAbstractTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/actions/diff-lqr.cpp.in
+++ b/src/core/actions/diff-lqr.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/actions/diff-lqr.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    DifferentialActionModelLQRTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    DifferentialActionDataLQRTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/actions/lqr.cpp.in
+++ b/src/core/actions/lqr.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/actions/lqr.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActionModelLQRTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActionDataLQRTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/actions/unicycle.cpp.in
+++ b/src/core/actions/unicycle.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/actions/unicycle.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActionModelUnicycleTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActionDataUnicycleTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/activation-base.cpp.in
+++ b/src/core/activation-base.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/activation-base.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActivationModelAbstractTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActivationDataAbstractTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/activations/2norm-barrier.cpp.in
+++ b/src/core/activations/2norm-barrier.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/activations/2norm-barrier.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActivationModel2NormBarrierTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActivationData2NormBarrierTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/activations/quadratic-barrier.cpp.in
+++ b/src/core/activations/quadratic-barrier.cpp.in
@@ -1,0 +1,21 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/activations/quadratic-barrier.hpp"
+
+namespace crocoddyl {
+
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActivationBoundsTpl<@SCALAR_TYPE@>;
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActivationModelQuadraticBarrierTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActivationDataQuadraticBarrierTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/activations/quadratic-flat-exp.cpp.in
+++ b/src/core/activations/quadratic-flat-exp.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/activations/quadratic-flat-exp.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActivationModelQuadFlatExpTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActivationDataQuadFlatExpTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/activations/quadratic-flat-log.cpp.in
+++ b/src/core/activations/quadratic-flat-log.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/activations/quadratic-flat-log.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActivationModelQuadFlatLogTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActivationDataQuadFlatLogTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/activations/quadratic.cpp.in
+++ b/src/core/activations/quadratic.cpp.in
@@ -1,0 +1,17 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/activations/quadratic.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActivationModelQuadTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/activations/smooth-1norm.cpp.in
+++ b/src/core/activations/smooth-1norm.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/activations/smooth-1norm.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActivationModelSmooth1NormTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActivationDataSmooth1NormTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/activations/smooth-2norm.cpp.in
+++ b/src/core/activations/smooth-2norm.cpp.in
@@ -1,0 +1,17 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/activations/smooth-2norm.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActivationModelSmooth2NormTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/activations/smooth-abs.cpp.in
+++ b/src/core/activations/smooth-abs.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/activations/smooth-abs.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActivationModelSmoothAbsTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActivationDataSmoothAbsTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/activations/weighted-quadratic-barrier.cpp.in
+++ b/src/core/activations/weighted-quadratic-barrier.cpp.in
@@ -1,0 +1,17 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/activations/weighted-quadratic-barrier.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActivationModelWeightedQuadraticBarrierTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/activations/weighted-quadratic.cpp.in
+++ b/src/core/activations/weighted-quadratic.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/activations/weighted-quadratic.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActivationModelWeightedQuadTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActivationDataWeightedQuadTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/actuation-base.cpp.in
+++ b/src/core/actuation-base.cpp.in
@@ -1,0 +1,23 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/actuation-base.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActuationModelAbstractTpl<double>;
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActuationModelAbstractTpl<float>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActuationDataAbstractTpl<double>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActuationDataAbstractTpl<float>;
+
+}  // namespace crocoddyl

--- a/src/core/actuation/actuation-squashing.cpp.in
+++ b/src/core/actuation/actuation-squashing.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/actuation/actuation-squashing.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActuationSquashingModelTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActuationSquashingDataTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/actuation/squashing-base.cpp.in
+++ b/src/core/actuation/squashing-base.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/actuation/squashing-base.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    SquashingModelAbstractTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    SquashingDataAbstractTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/actuation/squashing/smooth-sat.cpp.in
+++ b/src/core/actuation/squashing/smooth-sat.cpp.in
@@ -1,0 +1,17 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/actuation/squashing/smooth-sat.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    SquashingModelSmoothSatTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/codegen/action-base.cpp.in
+++ b/src/core/codegen/action-base.cpp.in
@@ -1,0 +1,23 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#ifdef CROCODDYL_WITH_CODEGEN
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/codegen/action-base.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActionModelCodeGenTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActionDataCodeGenTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl
+
+#endif

--- a/src/core/constraint-base.cpp.in
+++ b/src/core/constraint-base.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/constraint-base.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ConstraintModelAbstractTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ConstraintDataAbstractTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/constraints/constraint-manager.cpp.in
+++ b/src/core/constraints/constraint-manager.cpp.in
@@ -1,0 +1,21 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/constraints/constraint-manager.hpp"
+
+namespace crocoddyl {
+
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ConstraintItemTpl<@SCALAR_TYPE@>;
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ConstraintModelManagerTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ConstraintDataManagerTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/constraints/residual.cpp.in
+++ b/src/core/constraints/residual.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/constraints/residual.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ConstraintModelResidualTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ConstraintDataResidualTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/control-base.cpp.in
+++ b/src/core/control-base.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/control-base.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ControlParametrizationModelAbstractTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ControlParametrizationDataAbstractTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/controls/poly-one.cpp.in
+++ b/src/core/controls/poly-one.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/controls/poly-one.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ControlParametrizationModelPolyOneTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ControlParametrizationDataPolyOneTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/controls/poly-two-rk.cpp.in
+++ b/src/core/controls/poly-two-rk.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/controls/poly-two-rk.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ControlParametrizationModelPolyTwoRKTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ControlParametrizationDataPolyTwoRKTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/controls/poly-zero.cpp.in
+++ b/src/core/controls/poly-zero.cpp.in
@@ -1,0 +1,17 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/controls/poly-zero.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ControlParametrizationModelPolyZeroTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/cost-base.cpp.in
+++ b/src/core/cost-base.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/cost-base.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    CostModelAbstractTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    CostDataAbstractTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/costs/cost-sum.cpp.in
+++ b/src/core/costs/cost-sum.cpp.in
@@ -1,0 +1,21 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/costs/cost-sum.hpp"
+
+namespace crocoddyl {
+
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    crocoddyl::CostItemTpl<@SCALAR_TYPE@>;
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    CostModelSumTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    CostDataSumTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/costs/residual.cpp.in
+++ b/src/core/costs/residual.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/costs/residual.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    CostModelResidualTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    CostDataResidualTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/data-collector-base.cpp.in
+++ b/src/core/data-collector-base.cpp.in
@@ -1,0 +1,17 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/data-collector-base.hpp"
+
+namespace crocoddyl {
+
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    DataCollectorAbstractTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/data/actuation.cpp.in
+++ b/src/core/data/actuation.cpp.in
@@ -1,0 +1,17 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/data/actuation.hpp"
+
+namespace crocoddyl {
+
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    DataCollectorActuationTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/data/joint.cpp.in
+++ b/src/core/data/joint.cpp.in
@@ -1,0 +1,21 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/data/joint.hpp"
+
+namespace crocoddyl {
+
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    JointDataAbstractTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    DataCollectorJointTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    DataCollectorJointActuationTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/diff-action-base.cpp.in
+++ b/src/core/diff-action-base.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/diff-action-base.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    DifferentialActionModelAbstractTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    DifferentialActionDataAbstractTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/integ-action-base.cpp.in
+++ b/src/core/integ-action-base.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/integ-action-base.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    IntegratedActionModelAbstractTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    IntegratedActionDataAbstractTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/integrator/euler.cpp.in
+++ b/src/core/integrator/euler.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/integrator/euler.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    IntegratedActionModelEulerTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    IntegratedActionDataEulerTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/integrator/rk.cpp.in
+++ b/src/core/integrator/rk.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/integrator/rk.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    IntegratedActionModelRKTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    IntegratedActionDataRKTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/numdiff/action.cpp.in
+++ b/src/core/numdiff/action.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/numdiff/action.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActionModelNumDiffTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActionDataNumDiffTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/numdiff/activation.cpp.in
+++ b/src/core/numdiff/activation.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/numdiff/activation.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActivationModelNumDiffTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActivationDataNumDiffTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/numdiff/cost.cpp.in
+++ b/src/core/numdiff/cost.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/numdiff/cost.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    CostModelNumDiffTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    CostDataNumDiffTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/numdiff/diff-action.cpp.in
+++ b/src/core/numdiff/diff-action.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/numdiff/diff-action.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    DifferentialActionModelNumDiffTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    DifferentialActionDataNumDiffTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/numdiff/state.cpp.in
+++ b/src/core/numdiff/state.cpp.in
@@ -1,0 +1,17 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/numdiff/state.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    StateNumDiffTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/optctrl/shooting.cpp.in
+++ b/src/core/optctrl/shooting.cpp.in
@@ -1,0 +1,17 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/optctrl/shooting.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ShootingProblemTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/residual-base.cpp.in
+++ b/src/core/residual-base.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/residual-base.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ResidualModelAbstractTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ResidualDataAbstractTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/residuals/control.cpp.in
+++ b/src/core/residuals/control.cpp.in
@@ -1,0 +1,17 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/residuals/control.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ResidualModelControlTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/residuals/joint-acceleration.cpp.in
+++ b/src/core/residuals/joint-acceleration.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/residuals/joint-acceleration.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ResidualModelJointAccelerationTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ResidualDataJointAccelerationTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/residuals/joint-effort.cpp.in
+++ b/src/core/residuals/joint-effort.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/residuals/joint-effort.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ResidualModelJointEffortTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ResidualDataJointEffortTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/state-base.cpp.in
+++ b/src/core/state-base.cpp.in
@@ -1,0 +1,17 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/state-base.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    StateAbstractTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/core/states/euclidean.cpp.in
+++ b/src/core/states/euclidean.cpp.in
@@ -1,0 +1,17 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/states/euclidean.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    StateVectorTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/actions/contact-fwddyn.cpp.in
+++ b/src/multibody/actions/contact-fwddyn.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/actions/contact-fwddyn.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    DifferentialActionModelContactFwdDynamicsTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    DifferentialActionDataContactFwdDynamicsTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/actions/contact-invdyn.cpp.in
+++ b/src/multibody/actions/contact-invdyn.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/actions/contact-invdyn.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    DifferentialActionModelContactInvDynamicsTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    DifferentialActionDataContactInvDynamicsTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/actions/free-fwddyn.cpp.in
+++ b/src/multibody/actions/free-fwddyn.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/actions/free-fwddyn.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    DifferentialActionModelFreeFwdDynamicsTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    DifferentialActionDataFreeFwdDynamicsTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/actions/free-invdyn.cpp.in
+++ b/src/multibody/actions/free-invdyn.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/actions/free-invdyn.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    DifferentialActionModelFreeInvDynamicsTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    DifferentialActionDataFreeInvDynamicsTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/actions/impulse-fwddyn.cpp.in
+++ b/src/multibody/actions/impulse-fwddyn.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/actions/impulse-fwddyn.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActionModelImpulseFwdDynamicsTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActionDataImpulseFwdDynamicsTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/actuations/floating-base-thrusters.cpp.in
+++ b/src/multibody/actuations/floating-base-thrusters.cpp.in
@@ -1,0 +1,17 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/actuations/floating-base-thrusters.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActuationModelFloatingBaseThrustersTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/actuations/floating-base.cpp.in
+++ b/src/multibody/actuations/floating-base.cpp.in
@@ -1,0 +1,17 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/actuations/floating-base.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActuationModelFloatingBaseTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/actuations/full.cpp.in
+++ b/src/multibody/actuations/full.cpp.in
@@ -1,0 +1,17 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/actuations/full.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActuationModelFullTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/contact-base.cpp.in
+++ b/src/multibody/contact-base.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/contact-base.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ContactModelAbstractTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ContactDataAbstractTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/contacts/contact-1d.cpp.in
+++ b/src/multibody/contacts/contact-1d.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/contacts/contact-1d.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ContactModel1DTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ContactData1DTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/contacts/contact-2d.cpp.in
+++ b/src/multibody/contacts/contact-2d.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/contacts/contact-2d.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ContactModel2DTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ContactData2DTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/contacts/contact-3d.cpp.in
+++ b/src/multibody/contacts/contact-3d.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/contacts/contact-3d.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ContactModel3DTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ContactData3DTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/contacts/contact-6d.cpp.in
+++ b/src/multibody/contacts/contact-6d.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/contacts/contact-6d.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ContactModel6DTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ContactData6DTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/contacts/multiple-contacts.cpp.in
+++ b/src/multibody/contacts/multiple-contacts.cpp.in
@@ -1,0 +1,21 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/contacts/multiple-contacts.hpp"
+
+namespace crocoddyl {
+
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ContactItemTpl<@SCALAR_TYPE@>;
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ContactModelMultipleTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ContactDataMultipleTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/cop-support.cpp.in
+++ b/src/multibody/cop-support.cpp.in
@@ -1,0 +1,17 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/cop-support.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    CoPSupportTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/data/contacts.cpp.in
+++ b/src/multibody/data/contacts.cpp.in
@@ -1,0 +1,23 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/data/contacts.hpp"
+
+namespace crocoddyl {
+
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    DataCollectorContactTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    DataCollectorMultibodyInContactTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    DataCollectorActMultibodyInContactTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    DataCollectorJointActMultibodyInContactTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/data/impulses.cpp.in
+++ b/src/multibody/data/impulses.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/data/impulses.hpp"
+
+namespace crocoddyl {
+
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    DataCollectorImpulseTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    DataCollectorMultibodyInImpulseTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/data/multibody.cpp.in
+++ b/src/multibody/data/multibody.cpp.in
@@ -1,0 +1,21 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/data/multibody.hpp"
+
+namespace crocoddyl {
+
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    DataCollectorMultibodyTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    DataCollectorActMultibodyTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    DataCollectorJointActMultibodyTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/force-base.cpp.in
+++ b/src/multibody/force-base.cpp.in
@@ -1,0 +1,17 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/force-base.hpp"
+
+namespace crocoddyl {
+
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ForceDataAbstractTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/friction-cone.cpp.in
+++ b/src/multibody/friction-cone.cpp.in
@@ -1,0 +1,17 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/friction-cone.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    FrictionConeTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/impulse-base.cpp.in
+++ b/src/multibody/impulse-base.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/impulse-base.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ImpulseModelAbstractTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ImpulseDataAbstractTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/impulses/impulse-3d.cpp.in
+++ b/src/multibody/impulses/impulse-3d.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/impulses/impulse-3d.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ImpulseModel3DTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ImpulseData3DTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/impulses/impulse-6d.cpp.in
+++ b/src/multibody/impulses/impulse-6d.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/impulses/impulse-6d.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ImpulseModel6DTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ImpulseData6DTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/impulses/multiple-impulses.cpp.in
+++ b/src/multibody/impulses/multiple-impulses.cpp.in
@@ -1,0 +1,21 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/impulses/multiple-impulses.hpp"
+
+namespace crocoddyl {
+
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ImpulseItemTpl<@SCALAR_TYPE@>;
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ImpulseModelMultipleTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ImpulseDataMultipleTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/residuals/centroidal-momentum.cpp.in
+++ b/src/multibody/residuals/centroidal-momentum.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/residuals/centroidal-momentum.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ResidualModelCentroidalMomentumTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ResidualDataCentroidalMomentumTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/residuals/com-position.cpp.in
+++ b/src/multibody/residuals/com-position.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/residuals/com-position.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ResidualModelCoMPositionTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ResidualDataCoMPositionTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/residuals/contact-control-gravity.cpp.in
+++ b/src/multibody/residuals/contact-control-gravity.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/residuals/contact-control-gravity.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ResidualModelContactControlGravTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ResidualDataContactControlGravTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/residuals/contact-cop-position.cpp.in
+++ b/src/multibody/residuals/contact-cop-position.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/residuals/contact-cop-position.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ResidualModelContactCoPPositionTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ResidualDataContactCoPPositionTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/residuals/contact-force.cpp.in
+++ b/src/multibody/residuals/contact-force.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/residuals/contact-force.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ResidualModelContactForceTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ResidualDataContactForceTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/residuals/contact-friction-cone.cpp.in
+++ b/src/multibody/residuals/contact-friction-cone.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/residuals/contact-friction-cone.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ResidualModelContactFrictionConeTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ResidualDataContactFrictionConeTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/residuals/contact-wrench-cone.cpp.in
+++ b/src/multibody/residuals/contact-wrench-cone.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/residuals/contact-wrench-cone.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ResidualModelContactWrenchConeTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ResidualDataContactWrenchConeTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/residuals/control-gravity.cpp.in
+++ b/src/multibody/residuals/control-gravity.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/residuals/control-gravity.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ResidualModelControlGravTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ResidualDataControlGravTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/residuals/frame-placement.cpp.in
+++ b/src/multibody/residuals/frame-placement.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/residuals/frame-placement.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ResidualModelFramePlacementTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ResidualDataFramePlacementTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/residuals/frame-rotation.cpp.in
+++ b/src/multibody/residuals/frame-rotation.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/residuals/frame-rotation.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ResidualModelFrameRotationTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ResidualDataFrameRotationTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/residuals/frame-translation.cpp.in
+++ b/src/multibody/residuals/frame-translation.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/residuals/frame-translation.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ResidualModelFrameTranslationTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ResidualDataFrameTranslationTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/residuals/frame-velocity.cpp.in
+++ b/src/multibody/residuals/frame-velocity.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/residuals/frame-velocity.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ResidualModelFrameVelocityTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ResidualDataFrameVelocityTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/residuals/impulse-com.cpp.in
+++ b/src/multibody/residuals/impulse-com.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/residuals/impulse-com.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ResidualModelImpulseCoMTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ResidualDataImpulseCoMTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/residuals/state.cpp.in
+++ b/src/multibody/residuals/state.cpp.in
@@ -1,0 +1,17 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/residuals/state.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ResidualModelStateTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/states/multibody.cpp.in
+++ b/src/multibody/states/multibody.cpp.in
@@ -1,0 +1,17 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/states/multibody.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    StateMultibodyTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/src/multibody/wrench-cone.cpp.in
+++ b/src/multibody/wrench-cone.cpp.in
@@ -1,0 +1,17 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/multibody/wrench-cone.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    WrenchConeTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/unittest/test_contacts.cpp
+++ b/unittest/test_contacts.cpp
@@ -357,6 +357,7 @@ void test_partial_derivatives_against_numdiff(
   casted_model_num_diff.calcDiff(casted_data_num_diff, x_f);
   float tol_f = std::sqrt(2.0f * std::numeric_limits<float>::epsilon());
   BOOST_CHECK((data->da0_dx.cast<float>() - casted_data->da0_dx).isZero(tol_f));
+  tol_f = 80.0f * sqrt(casted_model_num_diff.get_disturbance());
   BOOST_CHECK((casted_data->da0_dx - casted_data_num_diff->da0_dx)
                   .isZero(30.f * tol_f));
 #endif

--- a/unittest/test_contacts.cpp
+++ b/unittest/test_contacts.cpp
@@ -158,10 +158,13 @@ void test_calc_diff_fetch_derivatives(ContactModelTypes::Type contact_type,
   if (model_type !=
       PinocchioModelTypes::Hector) {  // this is due to Hector is a single rigid
                                       // body system.
+    float tol_f =
+        80.f * std::sqrt(2.0f * std::numeric_limits<float>::epsilon());
     BOOST_CHECK(!casted_data->a0.isZero());
     BOOST_CHECK(!casted_data->da0_dx.isZero());
     BOOST_CHECK((data->a0.cast<float>() - casted_data->a0).isZero());
-    BOOST_CHECK((data->da0_dx.cast<float>() - casted_data->da0_dx).isZero());
+    BOOST_CHECK(
+        (data->da0_dx.cast<float>() - casted_data->da0_dx).isZero(tol_f));
   }
   BOOST_CHECK(casted_data->f.toVector().isZero());
   BOOST_CHECK(casted_data->df_dx.isZero());
@@ -355,9 +358,8 @@ void test_partial_derivatives_against_numdiff(
   casted_model->calcDiff(casted_data, x_f);
   casted_model_num_diff.calc(casted_data_num_diff, x_f);
   casted_model_num_diff.calcDiff(casted_data_num_diff, x_f);
-  float tol_f = std::sqrt(2.0f * std::numeric_limits<float>::epsilon());
+  float tol_f = 80.f * std::sqrt(2.0f * std::numeric_limits<float>::epsilon());
   BOOST_CHECK((data->da0_dx.cast<float>() - casted_data->da0_dx).isZero(tol_f));
-  tol_f = 80.0f * sqrt(casted_model_num_diff.get_disturbance());
   BOOST_CHECK((casted_data->da0_dx - casted_data_num_diff->da0_dx)
                   .isZero(30.f * tol_f));
 #endif


### PR DESCRIPTION
This PR introduces template instantiation for almost all the classes in Crocoddyl. Exceptions are numdiff's classes not widely used such as state's numdiff. Additionally, it brings a mechanism to generate cpp files for each type of supported scalar.

This PR reduces substantially the compilation time and memory footprint. Early benchmarks show a 
  1. compilation time reduction of over 37% for a single core and over 62% for multiple cores compilation
  2. memory footprint reduction of over 31 %
  3. reduction of fetching memory from RAM of over 200%

These statistics are not updated, as I did when instantiating around half of what is proposed in this PR. Additionally, they were generated when using a single cpp for compiling double and floats. Therefore, the current figures should be much better, but in the interest of time, I have skipped this benchmark.

[abussy-aldebaran](https://github.com/abussy-aldebaran) -- please have a look at this PR.