### PR TITLE
Feature/offset center

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-* Updated the rotation transpose in contact wrench cone to re-use the same object to avoid additional transpose operations.
-* Switched to a multiply operation instead of divide for efficiency.
+* Updated the rotation transpose in contact wrench cone to re-use the same object to avoid additional transpose operations. https://github.com/loco-3d/crocoddyl/pull/1343
+* Switched to a multiply operation instead of divide for efficiency. https://github.com/loco-3d/crocoddyl/pull/1343
 * Fix Python bindings of action getters in https://github.com/loco-3d/crocoddyl/pull/1374
 * Created independent Python modules associated to each scalar in https://github.com/loco-3d/crocoddyl/pull/1372
 * Introduced CodeGen and AutoDiff in Python + pre-compiled headers in https://github.com/loco-3d/crocoddyl/pull/1370

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+* Updated the rotation transpose in contact wrench cone to re-use the same object to avoid additional transpose operations.
+* Switched to a multiply operation instead of divide for efficiency.
 * Fix Python bindings of action getters in https://github.com/loco-3d/crocoddyl/pull/1374
 * Created independent Python modules associated to each scalar in https://github.com/loco-3d/crocoddyl/pull/1372
 * Introduced CodeGen and AutoDiff in Python + pre-compiled headers in https://github.com/loco-3d/crocoddyl/pull/1370

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+* Added the ability to move the origin of the wrench cone with respect to the contact frame. https://github.com/loco-3d/crocoddyl/pull/1385
 * Updated the rotation transpose in contact wrench cone to re-use the same object to avoid additional transpose operations. https://github.com/loco-3d/crocoddyl/pull/1343
 * Switched to a multiply operation instead of divide for efficiency. https://github.com/loco-3d/crocoddyl/pull/1343
 * Fix Python bindings of action getters in https://github.com/loco-3d/crocoddyl/pull/1374

--- a/bindings/python/crocoddyl/core/costs/cost-sum.cpp.in
+++ b/bindings/python/crocoddyl/core/costs/cost-sum.cpp.in
@@ -40,6 +40,7 @@ struct CostModelSumVisitor
   BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(CostModelSum_addCost_wrap,
                                          Model::addCost, 3, 4)
   typedef typename Model::CostDataSum Data;
+  typedef typename Model::CostItem CostItem;
   typedef typename Model::StateAbstract State;
   typedef typename Model::VectorXs VectorXs;
   template <class PyClass>
@@ -63,6 +64,12 @@ struct CostModelSumVisitor
                  ":param cost: cost model\n"
                  ":param weight: cost weight\n"
                  ":param active: True if the cost is activated (default true)"))
+        .def("addCost",
+                    static_cast<void (Model::*)(
+                        const std::shared_ptr<CostItem>&)>(&Model::calc),
+                    bp::args("self", "cost_item"),
+                    "Add a cost item.\n\n"
+                    ":param cost_item: cost item")
         .def("removeCost", &Model::removeCost, bp::args("self", "name"),
              "Remove a cost item.\n\n"
              ":param name: cost name")

--- a/include/crocoddyl/core/costs/cost-sum.hpp
+++ b/include/crocoddyl/core/costs/cost-sum.hpp
@@ -125,7 +125,7 @@ class CostModelSumTpl {
    *
    * @param[in] cost_item Cost item
    */
-  void addCost(const boost::shared_ptr<CostItem>& cost_item);
+  void addCost(const std::shared_ptr<CostItem>& cost_item);
 
   /**
    * @brief Remove a cost item

--- a/include/crocoddyl/core/costs/cost-sum.hpp
+++ b/include/crocoddyl/core/costs/cost-sum.hpp
@@ -121,6 +121,13 @@ class CostModelSumTpl {
                const Scalar weight, const bool active = true);
 
   /**
+   * @brief Add a cost item
+   *
+   * @param[in] cost_item Cost item
+   */
+  void addCost(const boost::shared_ptr<CostItem>& cost_item);
+
+  /**
    * @brief Remove a cost item
    *
    * @param[in] name    Cost name

--- a/include/crocoddyl/core/costs/cost-sum.hxx
+++ b/include/crocoddyl/core/costs/cost-sum.hxx
@@ -48,8 +48,7 @@ void CostModelSumTpl<Scalar>::addCost(const std::string& name,
 }
 
 template <typename Scalar>
-void CostModelSumTpl<Scalar>::addCost(const boost::shared_ptr<CostItem>& cost_item)
-{
+void CostModelSumTpl<Scalar>::addCost(const std::shared_ptr<CostItem>& cost_item) {
   if (cost_item->cost->get_nu() != nu_) {
     throw_pretty(
         cost_item->name

--- a/include/crocoddyl/core/costs/cost-sum.hxx
+++ b/include/crocoddyl/core/costs/cost-sum.hxx
@@ -58,11 +58,11 @@ void CostModelSumTpl<Scalar>::addCost(const boost::shared_ptr<CostItem>& cost_it
   }
   costs_.insert(std::make_pair(cost_item->name, cost_item));
   if (cost_item->active) {
-    nr_ += cost_item->get_activation()->get_nr();
-    nr_total_ += cost_item->get_activation()->get_nr();
+    nr_ += cost_item->cost->get_activation()->get_nr();
+    nr_total_ += cost_item->cost->get_activation()->get_nr();
     active_set_.insert(cost_item->name);
   } else {
-    nr_total_ += cost_item->get_activation()->get_nr();
+    nr_total_ += cost_item->cost->get_activation()->get_nr();
     inactive_set_.insert(cost_item->name);
   }
 }

--- a/include/crocoddyl/core/costs/cost-sum.hxx
+++ b/include/crocoddyl/core/costs/cost-sum.hxx
@@ -48,6 +48,26 @@ void CostModelSumTpl<Scalar>::addCost(const std::string& name,
 }
 
 template <typename Scalar>
+void CostModelSumTpl<Scalar>::addCost(const boost::shared_ptr<CostItem>& cost_item)
+{
+  if (cost_item->cost->get_nu() != nu_) {
+    throw_pretty(
+        cost_item->name
+        << " cost item doesn't have the same control dimension (it should be " +
+               std::to_string(nu_) + ")");
+  }
+  costs_.insert(std::make_pair(cost_item->name, cost_item));
+  if (cost_item->active) {
+    nr_ += cost_item->get_activation()->get_nr();
+    nr_total_ += cost_item->get_activation()->get_nr();
+    active_set_.insert(cost_item->name);
+  } else {
+    nr_total_ += cost_item->get_activation()->get_nr();
+    inactive_set_.insert(cost_item->name);
+  }
+}
+
+template <typename Scalar>
 void CostModelSumTpl<Scalar>::removeCost(const std::string& name) {
   typename CostModelContainer::iterator it = costs_.find(name);
   if (it != costs_.end()) {

--- a/include/crocoddyl/multibody/wrench-cone.hpp
+++ b/include/crocoddyl/multibody/wrench-cone.hpp
@@ -143,6 +143,11 @@ class WrenchConeTpl {
   const Vector2s& get_box() const;
 
   /**
+    * @brief Return center of the constraint box in the contact frame (x, y)
+    */
+  const Vector2s& get_box() const;
+
+  /**
    * @brief Return friction coefficient
    */
   const Scalar get_mu() const;
@@ -179,6 +184,14 @@ class WrenchConeTpl {
    * bounds.
    */
   void set_box(const Vector2s& box);
+
+  /**
+    * @brief Modify the center of the foot constraint box in the contact frame (x, y)
+    *
+    * Note that you need to run `update` for updating the inequality matrix and
+    * bounds.
+    */
+  void set_center(const Vector2s& center);
 
   /**
    * @brief Modify friction coefficient
@@ -226,6 +239,7 @@ class WrenchConeTpl {
   VectorXs lb_;      //!< Lower bound of the wrench cone
   Matrix3s R_;       //!< Rotation of the wrench cone w.r.t. the inertial frame
   Vector2s box_;     //!< Dimension of the foot surface (length, width)
+  Vector2s center_;     //!< Center of the foot surface w.r.t. the contact frame (x, y)
   Scalar mu_;        //!< Friction coefficient
   bool inner_appr_;  //!< Label that describes the type of friction cone
                      //!< approximation (inner/outer)

--- a/include/crocoddyl/multibody/wrench-cone.hxx
+++ b/include/crocoddyl/multibody/wrench-cone.hxx
@@ -140,8 +140,11 @@ void WrenchConeTpl<Scalar>::update() {
   Scalar theta =
       static_cast<Scalar>(2.0) * pi<Scalar>() / static_cast<Scalar>(nf_);
   if (inner_appr_) {
-    mu *= cos(theta / Scalar(2.));
+    mu *= cos(theta * Scalar(0.5));
   }
+
+  // Create a temporary object for computation
+  Matrix3s R_transpose = R_.transpose();
 
   // Friction cone information
   // This segment of matrix is defined as
@@ -155,26 +158,26 @@ void WrenchConeTpl<Scalar>::update() {
     Vector3s tsurf_i = Vector3s(cos(theta_i), sin(theta_i), Scalar(0.));
     Vector3s mu_nsurf = -mu * Vector3s::UnitZ();
     A_.row(2 * i).template head<3>() =
-        (mu_nsurf + tsurf_i).transpose() * R_.transpose();
+        (mu_nsurf + tsurf_i).transpose() * R_transpose;
     A_.row(2 * i + 1).template head<3>() =
-        (mu_nsurf - tsurf_i).transpose() * R_.transpose();
+        (mu_nsurf - tsurf_i).transpose() * R_transpose;
   }
-  A_.row(nf_).template head<3>() = R_.col(2).transpose();
+  A_.row(nf_).template head<3>() = R_transpose.row(2);
   lb_(nf_) = min_nforce_;
   ub_(nf_) = max_nforce_;
 
   // CoP information
-  const Scalar L = box_(0) / Scalar(2.);
-  const Scalar W = box_(1) / Scalar(2.);
+  const Scalar L = box_(0) * Scalar(0.5);
+  const Scalar W = box_(1) * Scalar(0.5);
   // This segment of matrix is defined as
   // [0  0 -W  1  0  0;
   //  0  0 -W -1  0  0;
   //  0  0 -L  0  1  0;
   //  0  0 -L  0 -1  0]
-  A_.row(nf_ + 1) << -W * R_.col(2).transpose(), R_.col(0).transpose();
-  A_.row(nf_ + 2) << -W * R_.col(2).transpose(), -R_.col(0).transpose();
-  A_.row(nf_ + 3) << -L * R_.col(2).transpose(), R_.col(1).transpose();
-  A_.row(nf_ + 4) << -L * R_.col(2).transpose(), -R_.col(1).transpose();
+  A_.row(nf_ + 1) << -W * R_transpose.row(2), R_transpose.row(0);
+  A_.row(nf_ + 2) << -W * R_transpose.row(2), -R_transpose.row(0);
+  A_.row(nf_ + 3) << -L * R_transpose.row(2), R_transpose.row(1);
+  A_.row(nf_ + 4) << -L * R_transpose.row(2), -R_transpose.row(1);
 
   // Yaw-tau information
   const Scalar mu_LW = -mu * (L + W);
@@ -183,27 +186,27 @@ void WrenchConeTpl<Scalar>::update() {
   //   W -L -mu*(L+W) -mu  mu -1;
   //  -W  L -mu*(L+W)  mu -mu -1;
   //  -W -L -mu*(L+W)  mu  mu -1]
-  A_.row(nf_ + 5) << Vector3s(W, L, mu_LW).transpose() * R_.transpose(),
-      Vector3s(-mu, -mu, Scalar(-1.)).transpose() * R_.transpose();
-  A_.row(nf_ + 6) << Vector3s(W, -L, mu_LW).transpose() * R_.transpose(),
-      Vector3s(-mu, mu, Scalar(-1.)).transpose() * R_.transpose();
-  A_.row(nf_ + 7) << Vector3s(-W, L, mu_LW).transpose() * R_.transpose(),
-      Vector3s(mu, -mu, Scalar(-1.)).transpose() * R_.transpose();
-  A_.row(nf_ + 8) << Vector3s(-W, -L, mu_LW).transpose() * R_.transpose(),
-      Vector3s(mu, mu, Scalar(-1.)).transpose() * R_.transpose();
+  A_.row(nf_ + 5) << Vector3s(W, L, mu_LW).transpose() * R_transpose,
+      Vector3s(-mu, -mu, Scalar(-1.)).transpose() * R_transpose;
+  A_.row(nf_ + 6) << Vector3s(W, -L, mu_LW).transpose() * R_transpose,
+      Vector3s(-mu, mu, Scalar(-1.)).transpose() * R_transpose;
+  A_.row(nf_ + 7) << Vector3s(-W, L, mu_LW).transpose() * R_transpose,
+      Vector3s(mu, -mu, Scalar(-1.)).transpose() * R_transpose;
+  A_.row(nf_ + 8) << Vector3s(-W, -L, mu_LW).transpose() * R_transpose,
+      Vector3s(mu, mu, Scalar(-1.)).transpose() * R_transpose;
   // The segment of the matrix that encodes the infinity torque is defined as
   // [ W  L -mu*(L+W)  mu  mu 1;
   //   W -L -mu*(L+W)  mu -mu 1;
   //  -W  L -mu*(L+W) -mu  mu 1;
   //  -W -L -mu*(L+W) -mu -mu 1]
-  A_.row(nf_ + 9) << Vector3s(W, L, mu_LW).transpose() * R_.transpose(),
-      Vector3s(mu, mu, Scalar(1.)).transpose() * R_.transpose();
-  A_.row(nf_ + 10) << Vector3s(W, -L, mu_LW).transpose() * R_.transpose(),
-      Vector3s(mu, -mu, Scalar(1.)).transpose() * R_.transpose();
-  A_.row(nf_ + 11) << Vector3s(-W, L, mu_LW).transpose() * R_.transpose(),
-      Vector3s(-mu, mu, Scalar(1.)).transpose() * R_.transpose();
-  A_.row(nf_ + 12) << Vector3s(-W, -L, mu_LW).transpose() * R_.transpose(),
-      Vector3s(-mu, -mu, Scalar(1.)).transpose() * R_.transpose();
+  A_.row(nf_ + 9) << Vector3s(W, L, mu_LW).transpose() * R_transpose,
+      Vector3s(mu, mu, Scalar(1.)).transpose() * R_transpose;
+  A_.row(nf_ + 10) << Vector3s(W, -L, mu_LW).transpose() * R_transpose,
+      Vector3s(mu, -mu, Scalar(1.)).transpose() * R_transpose;
+  A_.row(nf_ + 11) << Vector3s(-W, L, mu_LW).transpose() * R_transpose,
+      Vector3s(-mu, mu, Scalar(1.)).transpose() * R_transpose;
+  A_.row(nf_ + 12) << Vector3s(-W, -L, mu_LW).transpose() * R_transpose,
+      Vector3s(-mu, -mu, Scalar(1.)).transpose() * R_transpose;
 }
 
 template <typename Scalar>

--- a/include/crocoddyl/multibody/wrench-cone.hxx
+++ b/include/crocoddyl/multibody/wrench-cone.hxx
@@ -45,6 +45,50 @@ WrenchConeTpl<Scalar>::WrenchConeTpl(const Matrix3s& R, const Scalar mu,
   A_ = MatrixX6s::Zero(nf_ + 13, 6);
   ub_ = VectorXs::Zero(nf_ + 13);
   lb_ = VectorXs::Zero(nf_ + 13);
+  center_ = Vector2s::Zero();
+
+  // Update the inequality matrix and bounds
+  update();
+}
+
+  template <typename Scalar>
+  WrenchConeTpl<Scalar>::WrenchConeTpl(const Matrix3s& R, const Scalar mu,
+                                       const Vector2s& box, const Vector2s& center,
+                                       const std::size_t nf,
+                                       const bool inner_appr,
+                                       const Scalar min_nforce,
+                                       const Scalar max_nforce)
+      : nf_(nf),
+        R_(R),
+        box_(box),
+        center_(center),
+        mu_(mu),
+        inner_appr_(inner_appr),
+        min_nforce_(min_nforce),
+        max_nforce_(max_nforce) {
+  if (nf_ % 2 != 0) {
+    nf_ = 4;
+    std::cerr << "Warning: nf has to be an even number, set to 4" << std::endl;
+  }
+  if (mu < Scalar(0.)) {
+    mu_ = Scalar(1.);
+    std::cerr << "Warning: mu has to be a positive value, set to 1."
+              << std::endl;
+  }
+  if (min_nforce < Scalar(0.)) {
+    min_nforce_ = Scalar(0.);
+    std::cerr << "Warning: min_nforce has to be a positive value, set to 0"
+              << std::endl;
+  }
+  if (max_nforce < Scalar(0.)) {
+    max_nforce_ = std::numeric_limits<Scalar>::infinity();
+    std::cerr << "Warning: max_nforce has to be a positive value, set to "
+                 "infinity value"
+              << std::endl;
+  }
+  A_ = MatrixX6s::Zero(nf_ + 13, 6);
+  ub_ = VectorXs::Zero(nf_ + 13);
+  lb_ = VectorXs::Zero(nf_ + 13);
 
   // Update the inequality matrix and bounds
   update();
@@ -85,6 +129,7 @@ WrenchConeTpl<Scalar>::WrenchConeTpl(const Matrix3s& R, const Scalar mu,
   A_ = MatrixX6s::Zero(nf_ + 13, 6);
   ub_ = VectorXs::Zero(nf_ + 13);
   lb_ = VectorXs::Zero(nf_ + 13);
+  center_ = Vector2s::Zero();
 
   // Update the inequality matrix and bounds
   update();
@@ -98,6 +143,7 @@ WrenchConeTpl<Scalar>::WrenchConeTpl(const WrenchConeTpl<Scalar>& cone)
       lb_(cone.get_lb()),
       R_(cone.get_R()),
       box_(cone.get_box()),
+      center_(cone.get_center()),
       mu_(cone.get_mu()),
       inner_appr_(cone.get_inner_appr()),
       min_nforce_(cone.get_min_nforce()),
@@ -112,6 +158,7 @@ WrenchConeTpl<Scalar>::WrenchConeTpl()
       R_(Matrix3s::Identity()),
       box_(std::numeric_limits<Scalar>::infinity(),
            std::numeric_limits<Scalar>::infinity()),
+      center_(Vector2s::Zero()),
       mu_(Scalar(0.7)),
       inner_appr_(true),
       min_nforce_(Scalar(0.)),
@@ -147,16 +194,16 @@ void WrenchConeTpl<Scalar>::update() {
   Matrix3s R_transpose = R_.transpose();
   // There are blocks of the A matrix that are repeated. By separating it this way, we can
   // reduced computation.
-  MatrixX3s A_left = A_.leftCols(nf_);
-  MatrixX3s A_right = A_.rightCols(nf_);
+  MatrixX3s A_left = A_.template leftCols<nf_>();
+  MatrixX3s A_right = A_.template rightCols<nf_>() ;
 
   // Friction cone information
   // This segment of matrix is defined as
-  // [ 1  0 -mu  0  0  0;
-  //  -1  0 -mu  0  0  0;
-  //   0  1 -mu  0  0  0;
-  //   0 -1 -mu  0  0  0;
-  //   0  0   1  0  0  0]
+  // [ 1  0 -mu  0  0  0;     fx <= mu fz  = fx_max
+  //  -1  0 -mu  0  0  0;     fx >= -mu fz = fx_min
+  //   0  1 -mu  0  0  0;     fy <= mu fz  = fy_max
+  //   0 -1 -mu  0  0  0;     fy >= -mu fz = fy_min
+  //   0  0   1  0  0  0]     fz >= 0      = fz_min
   Vector3s mu_nsurf = -mu * Vector3s::UnitZ(); // We can pull this out because it's reused.
   std::size_t row = 0;
   for (std::size_t i = 0; i < nf_ / 2; ++i) {
@@ -171,35 +218,39 @@ void WrenchConeTpl<Scalar>::update() {
   lb_(nf_) = min_nforce_;
   ub_(nf_) = max_nforce_;
 
-  // CoP information
+  // Box dimensions
   const Scalar L = box_(0) * Scalar(0.5);
   const Scalar W = box_(1) * Scalar(0.5);
+  const Scalar left_bound = W + center_(1);
+  const Scalar right_bound = -W + center_(1);
+  const Scalar front_bound = L + center_(0);
+  const Scalar back_bound = -L + center_(0);
+
+  // CoP information
   // This segment of matrix is defined as
-  // [0  0 -W  1  0  0;
-  //  0  0 -W -1  0  0;
-  //  0  0 -L  0  1  0;
-  //  0  0 -L  0 -1  0]
-  A_.row(nf_ + 1) << -W * R_transpose.row(2), R_transpose.row(0);
-  A_left.row(nf_ + 2) = A_left.row(nf_ + 1);
-  A_right.row(nf_ + 2) = -R_transepose.row(0);
-  A_.row(nf_ + 3) << -L * R_transpose.row(2), R_transpose.row(1);
-  A_left.row(nf_ + 4) = A_left.row(nf_ + 3);
-  A_right.row(nf_ + 4) = -R_transpose.row(1);
+  // [0  0 -W  1  0  0;   -W fz + tau_x <= 0 ->  tau_x <= W fz,                   = tau_x_max, so W is the left_bound
+  //  0  0 -W -1  0  0;   -W fz - tau_x <= 0 -> -tau_x <= W fz -> tau_x >= -W fz, = tau_x_min, so -W is the right_bound
+  //  0  0 -L  0  1  0;   -L fz + tau_y <= 0 ->  tau_y <= L fz,                   = tau_y_max, so L is -back_bound
+  //  0  0 -L  0 -1  0]   -L fz - tau_y <= 0 -> -tau_y <= L fz -> tau_y >= -L fz, = tau_y_min, so L is front_bound
+  A_.row(nf_ + 1) << -left_bound  * R_transpose.row(2),  R_transpose.row(0);
+  A_.row(nf_ + 2) <<  right_bound * R_transpose.row(2), -R_transepose.row(0);
+  A_.row(nf_ + 3) <<  back_bound  * R_transpose.row(2),  R_transpose.row(1);
+  A_.row(nf_ + 4) << -front_bound * R_transpose.row(2), -R_transpose.row(1);
 
   // Yaw-tau information
-  const Scalar mu_LW = -mu * (L + W);
+  const Scalar mu_LW = -mu * (L + W); // Todo there's probably a bug in this.
   // The segment of the matrix that encodes the minimum torque is defined as
   // [ W  L -mu*(L+W) -mu -mu -1;
   //   W -L -mu*(L+W) -mu  mu -1;
   //  -W  L -mu*(L+W)  mu -mu -1;
   //  -W -L -mu*(L+W)  mu  mu -1]
-  A_.row(nf_ + 5) << Vector3s(W, L, mu_LW).transpose() * R_transpose,
+  A_.row(nf_ + 5) << Vector3s(left_bound, front_bound, mu_LW).transpose() * R_transpose,
       Vector3s(-mu, -mu, Scalar(-1.)).transpose() * R_transpose;
-  A_.row(nf_ + 6) << Vector3s(W, -L, mu_LW).transpose() * R_transpose,
+  A_.row(nf_ + 6) << Vector3s(left_bound, -back_bound, mu_LW).transpose() * R_transpose,
       Vector3s(-mu, mu, Scalar(-1.)).transpose() * R_transpose;
-  A_.row(nf_ + 7) << Vector3s(-W, L, mu_LW).transpose() * R_transpose,
+  A_.row(nf_ + 7) << Vector3s(right_bound, front_bound, mu_LW).transpose() * R_transpose,
       Vector3s(mu, -mu, Scalar(-1.)).transpose() * R_transpose;
-  A_.row(nf_ + 8) << Vector3s(-W, -L, mu_LW).transpose() * R_transpose,
+  A_.row(nf_ + 8) << Vector3s(right_bound, back_bound, mu_LW).transpose() * R_transpose,
       Vector3s(mu, mu, Scalar(-1.)).transpose() * R_transpose;
   // The segment of the matrix that encodes the infinity torque is defined as
   // [ W  L -mu*(L+W)  mu  mu 1;

--- a/unittest/test_wrench_cone.cpp
+++ b/unittest/test_wrench_cone.cpp
@@ -342,6 +342,20 @@ void test_negative_force_along_wrench_cone_normal() {
   BOOST_CHECK(casted_data->a_value > 0.);
 }
 
+void test_setter() {
+  // Create the wrench cone
+  Eigen::Matrix3d R = Eigen::Matrix3d::Identity();
+  double mu = random_real_in_range(0.01, 1.);
+  Eigen::Vector2d cone_box = Eigen::Vector2d(random_real_in_range(0.01, 0.1),
+                                             random_real_in_range(0.01, 0.1));
+  crocoddyl::WrenchCone cone(R, mu, cone_box);
+
+  mu = random_real_in_range(0.01, 1.);
+  cone.set_mu(mu);
+
+  BOOST_CHECK(cone.get_mu() == mu);
+}
+
 void test_force_parallel_to_wrench_cone_normal() {
   // Create the wrench cone
   Eigen::Matrix3d R = Eigen::Matrix3d::Identity();
@@ -390,6 +404,8 @@ void register_unit_tests() {
       boost::bind(&test_negative_force_along_wrench_cone_normal)));
   framework::master_test_suite().add(
       BOOST_TEST_CASE(boost::bind(&test_force_parallel_to_wrench_cone_normal)));
+  framework::master_test_suite().add(
+      BOOST_TEST_CASE(boost::bind(&test_setter)));
 }
 
 bool init_function() {


### PR DESCRIPTION
This PR looks to allow moving the center of the wrench cone polygon in the foot. This will allow setting up the "on toes" state without having to do anything else. This could be done by changing the box length to 0 (or something small to maintain a box structure), and setting the center of the box using the new `set_center` function to half the length of the foot. 

By default the center is 0, making this change do nothing unless called.

It builds off PR https://github.com/loco-3d/crocoddyl/pull/1343. 