### PR TITLE
[bugfix]: base classes of DataCollectorJointActMultibodyInContact

### DIFF
--- a/bindings/python/crocoddyl/multibody/data/contacts.cpp.in
+++ b/bindings/python/crocoddyl/multibody/data/contacts.cpp.in
@@ -83,8 +83,8 @@ struct DataCollectorContactVisitor
 #define CROCODDYL_DATA_COLLECTOR_JOINT_ACTMULTIBODY_CONTACT_PYTHON_BINDINGS(   \
     Scalar)                                                                    \
   typedef DataCollectorJointActMultibodyInContactTpl<Scalar> JAMData;             \
-  typedef DataCollectorMultibodyInContactTpl<Scalar> JAMDataBase1;                \
-  typedef DataCollectorActuationTpl<Scalar> JAMDataBase2;                         \
+  typedef DataCollectorActMultibodyInContactTpl<Scalar> JAMDataBase1;                \
+  typedef DataCollectorJointTpl<Scalar> JAMDataBase2;                         \
   typedef pinocchio::DataTpl<Scalar> PinocchioData;                            \
   typedef ActuationDataAbstractTpl<Scalar> ActuationData;                      \
   typedef JointDataAbstractTpl<Scalar> JointData;                              \

--- a/include/crocoddyl/core/costs/cost-sum.hxx
+++ b/include/crocoddyl/core/costs/cost-sum.hxx
@@ -48,7 +48,8 @@ void CostModelSumTpl<Scalar>::addCost(const std::string& name,
 }
 
 template <typename Scalar>
-void CostModelSumTpl<Scalar>::addCost(const std::shared_ptr<CostItem>& cost_item) {
+void CostModelSumTpl<Scalar>::addCost(
+    const std::shared_ptr<CostItem>& cost_item) {
   if (cost_item->cost->get_nu() != nu_) {
     throw_pretty(
         cost_item->name


### PR DESCRIPTION
Hi @cmastalli this PR fixes a bug in the python bindings of the class `DataCollectorJointActMultibodyInContact`.
The class had the wrong base classes resulting in the `joint` attribute to not exist.