### PR TITLE
add missing include

### DIFF
--- a/include/crocoddyl/core/utils/conversions.hpp
+++ b/include/crocoddyl/core/utils/conversions.hpp
@@ -9,6 +9,7 @@
 #ifndef CROCODDYL_UTILS_CONVERSIONS_HPP_
 #define CROCODDYL_UTILS_CONVERSIONS_HPP_
 
+#include <memory>
 #include <vector>
 
 #ifdef CROCODDYL_WITH_CODEGEN


### PR DESCRIPTION
fix in mim-solvers:
```cpp
In file included from /…-crocoddyl-3.1.0/include/crocoddyl/core/utils/scalar.hpp:14,
                 from /…-crocoddyl-3.1.0/include/crocoddyl/core/utils/math.hpp:19,
                 from /…-crocoddyl-3.1.0/include/crocoddyl/core/mathbase.hpp:13,
                 from /build/source/include/mim_solvers/ddp.hpp:19,
                 from /build/source/src/ddp.cpp:15:
/…-crocoddyl-3.1.0/include/crocoddyl/core/utils/conversions.hpp:52:18: error: 'shared_ptr' is not a member of 'std'
   52 | std::vector<std::shared_ptr<ItemTpl<NewScalar>>> vector_cast(
      |                  ^~~~~~~~~~
```