### PR TITLE
CMake: make example-robot-data more optional for ROS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 * Fixed the compiler-flag definition used for action codegen + updated default compilation flags in https://github.com/loco-3d/crocoddyl/pull/1469
+* CMake: make example-robot-data more optional for ROS in https://github.com/loco-3d/crocoddyl/pull/1467
 
 ## [3.2.0] - 2025-12-09
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,14 +139,24 @@ if(BUILD_PYTHON_INTERFACE)
 endif(BUILD_PYTHON_INTERFACE)
 add_project_dependency(pinocchio 3.1.0 REQUIRED PKG_CONFIG_REQUIRES
                        "pinocchio >= 3.1.0")
+
+# example-robot-data is not available in ROS and it is only used for tests,
+# examples, and benchmarks
 if(BUILD_EXAMPLES
    OR BUILD_TESTING
    OR BUILD_BENCHMARK)
-  add_project_dependency(example-robot-data 4.0.9 REQUIRED PKG_CONFIG_REQUIRES
-                         "example-robot-data >= 4.0.9")
-else()
-  add_optional_dependency(example-robot-data)
+  find_package(example-robot-data 4.0.9 QUIET)
+  if(NOT TARGET example-robot-data::example-robot-data)
+    message(STATUS "example-robot-data not found (>= 4.0.9). Let's fetch it.")
+    include(FetchContent)
+    FetchContent_Declare(
+      "example-robot-data"
+      GIT_REPOSITORY "https://github.com/gepetto/example-robot-data.git"
+      GIT_TAG v4.4.0)
+    FetchContent_MakeAvailable("example-robot-data")
+  endif()
 endif()
+
 if(BUILD_WITH_IPOPT)
   add_optional_dependency(ipopt)
 endif()

--- a/package.xml
+++ b/package.xml
@@ -26,7 +26,7 @@
   <depend>eigenpy</depend>
   <depend>pinocchio</depend>
   <depend>coinor-libipopt-dev</depend>
-  <exec_depend>example-robot-data</exec_depend>
+  <!-- <test_depend>example_robot_data</test_depend> -->
   <test_depend>python3-scipy</test_depend>
   <test_depend>jupyter-notebook</test_depend>
   <test_depend>jupyter-nbconvert</test_depend>


### PR DESCRIPTION
fix #1466