### PR TITLE
Fixed the compiler-flag definition + replace default flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+* Fixed the compiler-flag definition used for action codegen + updated default compilation flags in https://github.com/loco-3d/crocoddyl/pull/1469
 * Introduced safe difference and integration functions for states in https://github.com/loco-3d/crocoddyl/pull/1448
 * ROS: jrl_cmakemodules dependency + kilted CI in https://github.com/loco-3d/crocoddyl/pull/1441
 

--- a/bindings/python/crocoddyl/core/codegen/action.cpp.in
+++ b/bindings/python/crocoddyl/core/codegen/action.cpp.in
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2025-2025, Heriot-Watt University
+// Copyright (C) 2025-2026, Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -46,8 +46,8 @@ struct ActionModelCodeGenVisitor
             ":param updateParams: function used to update the calc and "
             "calcDiff's parameters (default empty function)\n"
             ":param compiler: type of compiler GCC or CLANG (default: CLANG)\n"
-            ":param compile_options: Compilation flags (default: '-Ofast "
-            "-march=native')"))
+            ":param compile_options: Compilation flags (default: '-O3 "
+            "-ffast-math -march=native')"))
         .def(bp::init<std::string, std::shared_ptr<Model>>(
             bp::args("self", "lib_fname", "model"),
             "Initialize the code generated action model from an pre-compiled "
@@ -211,8 +211,8 @@ struct ActionDataCodeGeneVisitor
           ":param updateParams: function used to update the calc and "         \
           "calcDiff's parameters (default empty function)\n"                   \
           ":param compiler: type of compiler GCC or CLANG (default: CLANG)\n"  \
-          ":param compile_options: Compilation flags (default: '-Ofast "       \
-          "-march=native')"))                                                  \
+          ":param compile_options: Compilation flags (default: '-O3 "          \
+          "-ffast-math -march=native')"))                                      \
       .def(ActionModelCodeGenVisitor<Model>())                                 \
       .def(PrintableVisitor<Model>())                                          \
       .def(CopyableVisitor<Model>());

--- a/include/crocoddyl/core/codegen/action.hpp
+++ b/include/crocoddyl/core/codegen/action.hpp
@@ -2,7 +2,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2025, LAAS-CNRS, INRIA, University of Edinburgh,
+// Copyright (C) 2019-2026, LAAS-CNRS, INRIA, University of Edinburgh,
 //                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
@@ -98,7 +98,7 @@ class ActionModelCodeGenTpl : public ActionModelAbstractTpl<_Scalar> {
    * @param[in] updateParams  Function used to update the calc and calcDiff's
    * parameters (default empty function)
    * @param[in] compiler      Type of compiler GCC or CLANG (default: CLANG)
-   * @param[in] compile_options  Compilation flags (default: "-Ofast
+   * @param[in] compile_options  Compilation flags (default: "-O3 -ffast-math
    * -march=native")
    */
   ActionModelCodeGenTpl(
@@ -106,7 +106,7 @@ class ActionModelCodeGenTpl : public ActionModelAbstractTpl<_Scalar> {
       bool autodiff = false, const std::size_t np = 0,
       ParamsEnvironment updateParams = EmptyParamsEnv,
       CompilerType compiler = CLANG,
-      const std::string& compile_options = "-Ofast -march=native");
+      const std::string& compile_options = "-O3 -ffast-math -march=native");
 
   /**
    * @brief Initialize the code generated action model from an AD model
@@ -120,7 +120,7 @@ class ActionModelCodeGenTpl : public ActionModelAbstractTpl<_Scalar> {
    * @param[in] updateParams  Function used to update the calc and calcDiff's
    * parameters (default empty function)
    * @param[in] compiler      Type of compiler GCC or CLANG (default: CLANG)
-   * @param[in] compile_options  Compilation flags (default: "-Ofast
+   * @param[in] compile_options  Compilation flags (default: "-O3 -ffast-math
    * -march=native")
    */
   ActionModelCodeGenTpl(
@@ -128,7 +128,7 @@ class ActionModelCodeGenTpl : public ActionModelAbstractTpl<_Scalar> {
       bool autodiff = false, const std::size_t np = 0,
       ParamsEnvironment updateParams = EmptyParamsEnv,
       CompilerType compiler = CLANG,
-      const std::string& compile_options = "-Ofast -march=native");
+      const std::string& compile_options = "-O3 -ffast-math -march=native");
 
   /**
    * @brief Initialize the code generated action model from an pre-compiled

--- a/include/crocoddyl/core/codegen/action.hxx
+++ b/include/crocoddyl/core/codegen/action.hxx
@@ -2,7 +2,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2025, LAAS-CNRS, INRIA, University of Edinburgh,
+// Copyright (C) 2019-2026, LAAS-CNRS, INRIA, University of Edinburgh,
 //                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
@@ -365,11 +365,23 @@ void ActionModelCodeGenTpl<Scalar>::compileLib() {
                  << lib_fname_ + SystemInfo::DYNAMIC_LIB_EXTENSION
                  << " should not be compiled again");
   }
+  auto splitFlags = [](const std::string& flags) {
+    std::istringstream iss(flags);
+    std::vector<std::string> out;
+    std::string flag;
+    while (iss >> flag) {
+      out.push_back(flag);
+    }
+    return out;
+  };
   switch (compiler_type_) {
     case GCC: {
       CppAD::cg::GccCompiler<Scalar> compiler("/usr/bin/gcc");
       std::vector<std::string> compile_flags = compiler.getCompileFlags();
-      compile_flags[0] = compile_options_;
+      compile_flags.clear();
+      auto extra_flags = splitFlags(compile_options_);
+      compile_flags.insert(compile_flags.end(), extra_flags.begin(),
+                           extra_flags.end());
       compiler.setCompileFlags(compile_flags);
       dynLibManager_->createDynamicLibrary(compiler, false);
       break;
@@ -377,7 +389,10 @@ void ActionModelCodeGenTpl<Scalar>::compileLib() {
     case CLANG: {
       CppAD::cg::ClangCompiler<Scalar> compiler("/usr/bin/clang");
       std::vector<std::string> compile_flags = compiler.getCompileFlags();
-      compile_flags[0] = compile_options_;
+      compile_flags.clear();
+      auto extra_flags = splitFlags(compile_options_);
+      compile_flags.insert(compile_flags.end(), extra_flags.begin(),
+                           extra_flags.end());
       compiler.setCompileFlags(compile_flags);
       dynLibManager_->createDynamicLibrary(compiler, false);
       break;
@@ -651,7 +666,7 @@ ActionModelCodeGenTpl<Scalar>::ActionModelCodeGenTpl()
       np_(0),
       lib_fname_(""),
       compiler_type_(CLANG),
-      compile_options_("-Ofast -march=native"),
+      compile_options_("-O -ffast-math -march=native"),
       updateParams_(EmptyParamsEnv) {
   // Add initialization logic if necessary
 }

--- a/notebooks/unicycle_towards_origin.ipynb
+++ b/notebooks/unicycle_towards_origin.ipynb
@@ -1,5 +1,5 @@
 {
-  "cells": [
+ "cells": [
   {
    "attachments": {
     "image.png": {


### PR DESCRIPTION
I noticed that our action codegen wasn't properly setting the compilation flags. This happened after moving the default flag, which is deprecated by Clang.

This PR fixed this issue and updated the default compilation flag used when generating codegen libraries.