### PR TITLE
Fixed OpenMP CMake export + updated cmake submodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+* Fixed OpenMP CMake export in https://github.com/loco-3d/crocoddyl/pull/1523
 * Fixed a bug where set_runningModels did not correctly update running_models_ in https://github.com/loco-3d/crocoddyl/pull/1489
 * Introduced single-floating point, shootings, numerics, endpoints features in solvers in https://github.com/loco-3d/crocoddyl/pull/1482
 * Fixed the compiler-flag definition used for action codegen + updated default compilation flags in https://github.com/loco-3d/crocoddyl/pull/1469

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,7 +226,7 @@ endif()
 
 # Add OpenMP
 if(BUILD_WITH_MULTITHREADS)
-  find_package(OpenMP REQUIRED COMPONENTS CXX)
+  add_project_dependency(OpenMP REQUIRED COMPONENTS CXX)
 
   add_definitions(-DCROCODDYL_WITH_MULTITHREADING)
   add_definitions(-DCROCODDYL_WITH_NTHREADS=${BUILD_WITH_NTHREADS})


### PR DESCRIPTION
This PR allows consumer projects to export OpenMP properly from Crocoddyl.