### PR TITLE
Extending l1 activations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+* :warning: BREAKING: `ActivationModelSmooth1Norm` and `ActivationModelWeightedSmooth1Norm` now use the classical pseudo-Huber form `delta^2 * (sqrt(1 + (r_i / delta)^2) - 1)`. For an old `eps`, use `delta = sqrt(eps)`. To additionally preserve the old derivatives, divide the containing cost weight by `delta` for the unweighted model, or divide the residual weights by `delta` for the weighted model; the resulting activation differs from the old one only by a constant.
 * Fixed OpenMP CMake export in https://github.com/loco-3d/crocoddyl/pull/1523
 * Fixed a bug where set_runningModels did not correctly update running_models_ in https://github.com/loco-3d/crocoddyl/pull/1489
 * Introduced single-floating point, shootings, numerics, endpoints features in solvers in https://github.com/loco-3d/crocoddyl/pull/1482

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-* :warning: BREAKING: `ActivationModelSmooth1Norm` and `ActivationModelWeightedSmooth1Norm` now use the classical pseudo-Huber form `delta^2 * (sqrt(1 + (r_i / delta)^2) - 1)`. For an old `eps`, use `delta = sqrt(eps)`. To additionally preserve the old derivatives, divide the containing cost weight by `delta` for the unweighted model, or divide the residual weights by `delta` for the weighted model; the resulting activation differs from the old one only by a constant.
+* :warning: BREAKING: `ActivationModelSmooth1Norm` and `ActivationModelWeightedSmooth1Norm` now use the classical pseudo-Huber form `delta^2 * (sqrt(1 + (r_i / delta)^2) - 1)`. For an old `eps`, use `delta = sqrt(eps)`. To additionally preserve the old derivatives, divide the containing cost weight by `delta` for the unweighted model, or divide the residual weights by `delta` for the weighted model; the resulting activation differs from the old one only by a constant. Fixed `ActivationModelSmooth2Norm` and `ActivationModelWeightedQuadraticBarrier` to compute the activation Hessian diagonal properly. Included a new weighted l1 activation in https://github.com/loco-3d/crocoddyl/pull/1524
 * Fixed OpenMP CMake export in https://github.com/loco-3d/crocoddyl/pull/1523
 * Fixed a bug where set_runningModels did not correctly update running_models_ in https://github.com/loco-3d/crocoddyl/pull/1489
 * Introduced single-floating point, shootings, numerics, endpoints features in solvers in https://github.com/loco-3d/crocoddyl/pull/1482

--- a/benchmark/read_csv.py
+++ b/benchmark/read_csv.py
@@ -41,17 +41,17 @@ def parseCsvFile(filename, sep=",", delimiter=None):
     input: (string) filename
     output: (numpy array) seq
     """
-    col_types = dict(
-        fn_name=str,
-        nthreads=int,
-        with_cg=bool,
-        mean=float,
-        stddev=float,
-        max=float,
-        min=float,
-        mean_per_nodes=float,
-        stddev_per_nodes=float,
-    )
+    col_types = {
+        "fn_name": str,
+        "nthreads": int,
+        "with_cg": bool,
+        "mean": float,
+        "stddev": float,
+        "max": float,
+        "min": float,
+        "mean_per_nodes": float,
+        "stddev_per_nodes": float,
+    }
 
     seq = pd.read_csv(
         filename,

--- a/bindings/python/crocoddyl/__init__.py
+++ b/bindings/python/crocoddyl/__init__.py
@@ -94,6 +94,20 @@ class DisplayAbstract(ABC):
         dts=None,
         factor=1.0,
     ):
+        if us is None:
+            us = []
+        if rs is None:
+            rs = []
+        if ps is None:
+            ps = []
+        if pds is None:
+            pds = []
+        if fs is None:
+            fs = []
+        if ss is None:
+            ss = []
+        if dts is None:
+            dts = []
         if ps:
             self.displayFramePoses(ps)
         if not dts:
@@ -813,6 +827,20 @@ class RvizDisplay(DisplayAbstract):
         dts=None,
         factor=1.0,
     ):
+        if us is None:
+            us = []
+        if rs is None:
+            rs = []
+        if ps is None:
+            ps = []
+        if pds is None:
+            pds = []
+        if fs is None:
+            fs = []
+        if ss is None:
+            ss = []
+        if dts is None:
+            dts = []
         nq = self.robot.model.nq
         if not dts:
             dts = [0.01] * len(xs)

--- a/bindings/python/crocoddyl/__init__.py
+++ b/bindings/python/crocoddyl/__init__.py
@@ -15,6 +15,16 @@ except ImportError:
 from .libcrocoddyl_pywrap_float64 import *
 from .libcrocoddyl_pywrap_float64 import __raw_version__, __version__  # noqa: F401
 
+_CONTACT_DIFFERENTIAL_DATA_TYPES = (
+    DifferentialActionDataContactFwdDynamics,
+    DifferentialActionModelContactInvDynamics.DifferentialActionDataContactInvDynamics,
+)
+
+_INV_DIFFERENTIAL_DATA_TYPES = (
+    DifferentialActionModelFreeInvDynamics,
+    DifferentialActionModelContactInvDynamics,
+)
+
 
 def rotationMatrixFromTwoVectors(a, b):
     a_norm = np.linalg.norm(a)
@@ -73,7 +83,16 @@ class DisplayAbstract(ABC):
         self.display(solver.xs, dts, rs, ps, [], fs, [], dts, factor)
 
     def display(
-        self, xs, us=[], rs=[], ps=[], pds=[], fs=[], ss=[], dts=[], factor=1.0
+        self,
+        xs,
+        us=None,
+        rs=None,
+        ps=None,
+        pds=None,
+        fs=None,
+        ss=None,
+        dts=None,
+        factor=1.0,
     ):
         if ps:
             self.displayFramePoses(ps)
@@ -88,7 +107,7 @@ class DisplayAbstract(ABC):
                             # Display the thrust forces
                             self.displayThrustForce(r)
                     else:
-                        for key, _ in self.activeThrust.items():
+                        for key in self.activeThrust:
                             thrustName = self.thrustGroup + "/" + key
                             self.setVisibility(thrustName, False)
                 if fs:
@@ -127,11 +146,11 @@ class DisplayAbstract(ABC):
                         name = self.robot.model.frames[c.impact.id].name
                     if name not in frameNames:
                         frameNames.append(name)
-            if hasattr(model, "differential"):
-                if isinstance(
-                    model.differential.actuation, ActuationModelFloatingBaseThrusters
-                ):
-                    thrusters.append(model.differential.actuation.thrusters)
+            if hasattr(model, "differential") and isinstance(
+                model.differential.actuation,
+                ActuationModelFloatingBaseThrusters,
+            ):
+                thrusters.append(model.differential.actuation.thrusters)
         for n in frameNames:
             frameId = self.robot.model.getFrameId(n)
             parentId = self.robot.model.frames[frameId].parentJoint
@@ -222,39 +241,35 @@ class DisplayAbstract(ABC):
         fs = []
         for i, model in enumerate(solver.problem.runningModels.tolist()):
             data = solver.problem.runningDatas[i]
-            if hasattr(model, "differential"):
-                if isinstance(
-                    model.differential.actuation, ActuationModelFloatingBaseThrusters
-                ):
-                    fc = []
-                    if isinstance(
-                        model.differential, DifferentialActionModelFreeInvDynamics
-                    ) or isinstance(
-                        model.differential, DifferentialActionModelContactInvDynamics
-                    ):
-                        ui = data.differential.multibody.actuation.u
-                    else:
-                        ui = solver.us[i]
-                    for t, thrust in enumerate(model.differential.actuation.thrusters):
-                        frameName = self.robot.model.frames[2].name
-                        frameId = self.robot.model.getFrameId(frameName)
-                        pinocchio.updateFramePlacement(
-                            model.differential.state.pinocchio,
-                            data.differential.pinocchio,
-                            frameId,
-                        )
-                        oMb = data.differential.pinocchio.oMf[frameId]
-                        oMf = oMb.act(thrust.pose)
-                        force = ui[t]
-                        fc.append(
-                            {
-                                "key": str(t),
-                                "oMf": oMf,
-                                "f": force,
-                                "type": thrust.type,
-                            }
-                        )
-                    fs.append(fc)
+            if hasattr(model, "differential") and isinstance(
+                model.differential.actuation,
+                ActuationModelFloatingBaseThrusters,
+            ):
+                fc = []
+                if isinstance(data.differential, _INV_DIFFERENTIAL_DATA_TYPES):
+                    ui = data.differential.multibody.actuation.u
+                else:
+                    ui = solver.us[i]
+                for t, thrust in enumerate(model.differential.actuation.thrusters):
+                    frameName = self.robot.model.frames[2].name
+                    frameId = self.robot.model.getFrameId(frameName)
+                    pinocchio.updateFramePlacement(
+                        model.differential.state.pinocchio,
+                        data.differential.pinocchio,
+                        frameId,
+                    )
+                    oMb = data.differential.pinocchio.oMf[frameId]
+                    oMf = oMb.act(thrust.pose)
+                    force = ui[t]
+                    fc.append(
+                        {
+                            "key": str(t),
+                            "oMf": oMf,
+                            "f": force,
+                            "type": thrust.type,
+                        }
+                    )
+                fs.append(fc)
         return fs
 
     def getFrameTrajectoryFromSolver(self, solver):
@@ -300,39 +315,21 @@ class DisplayAbstract(ABC):
 
     def _hasContacts(self, data):
         if hasattr(data, "differential"):
-            if isinstance(
-                data.differential,
-                DifferentialActionDataContactFwdDynamics,
-            ) or isinstance(
-                data.differential,
-                DifferentialActionModelContactInvDynamics.DifferentialActionDataContactInvDynamics,
-            ):
+            if isinstance(data.differential, _CONTACT_DIFFERENTIAL_DATA_TYPES):
                 return True
         elif isinstance(data, ActionDataImpulseFwdDynamics):
             return True
 
     def _getContactModelAndData(self, model, data):
         if hasattr(data, "differential"):
-            if isinstance(
-                data.differential,
-                DifferentialActionDataContactFwdDynamics,
-            ) or isinstance(
-                data.differential,
-                DifferentialActionModelContactInvDynamics.DifferentialActionDataContactInvDynamics,
-            ):
+            if isinstance(data.differential, _CONTACT_DIFFERENTIAL_DATA_TYPES):
                 return (
                     model.differential.contacts.contacts,
                     data.differential.multibody.contacts.contacts,
                 )
-            elif isinstance(data.differential, StdVec_DiffActionData) and (
-                isinstance(
-                    data.differential,
-                    DifferentialActionDataContactFwdDynamics,
-                )
-                or isinstance(
-                    data.differential,
-                    DifferentialActionModelContactInvDynamics.DifferentialActionDataContactInvDynamics,
-                )
+            elif isinstance(data.differential, StdVec_DiffActionData) and isinstance(
+                data.differential[0],
+                _CONTACT_DIFFERENTIAL_DATA_TYPES,
             ):
                 return (
                     model.differential[0].contacts.contacts,
@@ -361,14 +358,16 @@ class DisplayAbstract(ABC):
                 R = np.eye(3)
                 mu = 0.7
                 for c in cost_model.todict().values():
-                    if isinstance(
-                        c.cost.residual,
-                        ResidualModelContactFrictionCone,
+                    if (
+                        isinstance(
+                            c.cost.residual,
+                            ResidualModelContactFrictionCone,
+                        )
+                        and contact.frame == c.cost.residual.id
                     ):
-                        if contact.frame == c.cost.residual.id:
-                            R = c.cost.residual.reference.R
-                            mu = c.cost.residual.reference.mu
-                            continue
+                        R = c.cost.residual.reference.R
+                        mu = c.cost.residual.reference.mu
+                        continue
                 fc.append(
                     {
                         "key": str(joint),
@@ -590,8 +589,8 @@ class MeshcatDisplay(DisplayAbstract):
         self.robot.viewer[name].set_property("visible", status)
 
     def displayFramePoses(self, ps):
-        for key in ps.keys():
-            vertices = np.array(ps[key]).T
+        for key, value in ps.items():
+            vertices = np.array(value).T
             self._addFrameCurves(key, vertices)
 
     def displayContactForce(self, f):
@@ -803,7 +802,16 @@ class RvizDisplay(DisplayAbstract):
         self.display(xs, us, dts, ps, pds, fs, ss, dts, factor)
 
     def display(
-        self, xs, us=[], rs=[], ps=[], pds=[], fs=[], ss=[], dts=[], factor=1.0
+        self,
+        xs,
+        us=None,
+        rs=None,
+        ps=None,
+        pds=None,
+        fs=None,
+        ss=None,
+        dts=None,
+        factor=1.0,
     ):
         nq = self.robot.model.nq
         if not dts:
@@ -876,16 +884,17 @@ class RvizDisplay(DisplayAbstract):
         if hasattr(data, "differential"):
             if hasattr(data.differential, "multibody"):
                 return data.differential.multibody.pinocchio
-            elif isinstance(data.differential, StdVec_DiffActionData):
-                if hasattr(data.differential[0], "multibody"):
-                    return data.differential[0].multibody.pinocchio
+            elif isinstance(data.differential, StdVec_DiffActionData) and hasattr(
+                data.differential[0], "multibody"
+            ):
+                return data.differential[0].multibody.pinocchio
         elif isinstance(data, ActionDataImpulseFwdDynamics):
             return data.multibody.pinocchio
 
     def _get_pc(self, pinocchio_data):
         if len(self.frameTrajNames) == 0:
             return None
-        popt = dict()
+        popt = {}
         for frame in self.frameTrajNames:
             frame_id = int(frame)
             name = self.robot.model.frames[frame_id].name
@@ -896,7 +905,7 @@ class RvizDisplay(DisplayAbstract):
     def _get_pdc(self, pinocchio_data):
         if len(self.frameTrajNames) == 0:
             return None
-        pdopt = dict()
+        pdopt = {}
         for frame in self.frameTrajNames:
             frame_id = int(frame)
             name = self.robot.model.frames[frame_id].name
@@ -914,7 +923,7 @@ class RvizDisplay(DisplayAbstract):
 
         if len(self.frameTrajNames) == 0:
             return None
-        fc = dict()
+        fc = {}
         for frame in self.frameTrajNames:
             frame_id = int(frame)
             name = self.robot.model.frames[frame_id].name
@@ -935,7 +944,7 @@ class RvizDisplay(DisplayAbstract):
         return fc
 
     def _get_sc(self, contact_data):
-        sc = dict()
+        sc = {}
         self.mu = 0.7
         for frame in self.frameTrajNames:
             frame_id = int(frame)

--- a/bindings/python/crocoddyl/core/activations/smooth-1norm.cpp.in
+++ b/bindings/python/crocoddyl/core/activations/smooth-1norm.cpp.in
@@ -32,7 +32,8 @@ struct ActivationModelSmooth1NormVisitor
              ":param data: activation data\n"
              ":param r: residual vector \n")
         .def("createData", &Model::createData, bp::args("self"),
-             "Create the smooth-abs activation data.\n\n");
+             "Create the smooth-abs activation data.\n\n")
+        .add_property("delta", &Model::get_delta, "smoothing scale");
   }
 };
 
@@ -44,7 +45,7 @@ struct ActivationDataSmooth1NormVisitor
   void visit(PyClass& cl) const {
     cl.add_property(
         "a", bp::make_getter(&Data::a, bp::return_internal_reference<>()),
-        "sqrt{eps + ||ri||^2} value");
+        "element-wise sqrt(delta^2 + r_i^2) values");
   }
 };
 
@@ -56,14 +57,14 @@ struct ActivationDataSmooth1NormVisitor
       "ActivationModelSmooth1Norm",                                            \
       "Smooth-absolute activation model.\n\n"                                  \
       "It describes a smooth representation of an absolute activation "        \
-      "(1-norm), i.e., sum^nr_{i=0} sqrt{eps + ||ri||^2}, where ri is the "    \
-      "scalar residual for the i constraints, and nr is the dimension of the " \
-      "residual vector.",                                                      \
+      "(1-norm), i.e., sum^nr_{i=0} delta^2 * "                                \
+      "(sqrt{1 + (ri / delta)^2} - 1), where delta is the smoothing scale, "   \
+      "ri is a scalar residual, and nr is the residual dimension.",            \
       bp::init<std::size_t, bp::optional<Scalar>>(                             \
-          bp::args("self", "nr", "eps"),                                       \
+          bp::args("self", "nr", "delta"),                                     \
           "Initialize the activation model.\n\n"                               \
           ":param nr: dimension of the residual vector\n"                      \
-          ":param eps: smoothing factor (default: 1.)"))                       \
+          ":param delta: strictly positive smoothing scale (default: 1)"))     \
       .def(ActivationModelSmooth1NormVisitor<Model>())                         \
       .def(CastVisitor<Model>())                                               \
       .def(PrintableVisitor<Model>())                                          \

--- a/bindings/python/crocoddyl/core/activations/weighted-smooth-1norm.cpp.in
+++ b/bindings/python/crocoddyl/core/activations/weighted-smooth-1norm.cpp.in
@@ -1,0 +1,100 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2026, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/activations/weighted-smooth-1norm.hpp"
+
+#include "python/crocoddyl/core/activation-base.hpp"
+#include "python/crocoddyl/core/core.hpp"
+
+namespace crocoddyl {
+namespace python {
+
+template <typename Model>
+struct ActivationModelWeightedSmooth1NormVisitor
+    : public bp::def_visitor<
+          ActivationModelWeightedSmooth1NormVisitor<Model>> {
+  template <class PyClass>
+  void visit(PyClass& cl) const {
+    cl.def("calc", &Model::calc, bp::args("self", "data", "r"),
+           "Compute the weighted smooth-1norm activation.\n\n"
+           ":param data: activation data\n"
+           ":param r: residual vector")
+        .def("calcDiff", &Model::calcDiff, bp::args("self", "data", "r"),
+             "Compute the activation derivatives.\n\n"
+             "It assumes that calc has been run first.\n"
+             ":param data: activation data\n"
+             ":param r: residual vector")
+        .def("createData", &Model::createData, bp::args("self"),
+             "Create the weighted smooth-1norm activation data.")
+        .add_property("weights",
+                      bp::make_function(&Model::get_weights,
+                                        bp::return_internal_reference<>()),
+                      &Model::set_weights, "nonnegative residual weights")
+        .add_property("eps", &Model::get_eps, "smoothing factor");
+  }
+};
+
+template <typename Data>
+struct ActivationDataWeightedSmooth1NormVisitor
+    : public bp::def_visitor<
+          ActivationDataWeightedSmooth1NormVisitor<Data>> {
+  template <class PyClass>
+  void visit(PyClass& cl) const {
+    cl.add_property(
+        "a", bp::make_getter(&Data::a, bp::return_internal_reference<>()),
+        "element-wise sqrt(eps + r_i^2) values");
+  }
+};
+
+#define CROCODDYL_ACTIVATION_MODEL_WEIGHTEDSMOOTH1NORM_PYTHON_BINDINGS( \
+    Scalar)                                                            \
+  typedef ActivationModelWeightedSmooth1NormTpl<Scalar> Model;         \
+  typedef ActivationModelAbstractTpl<Scalar> ModelBase;                \
+  typedef typename Model::VectorXs VectorXs;                           \
+  bp::register_ptr_to_python<std::shared_ptr<Model>>();                \
+  bp::class_<Model, bp::bases<ModelBase>>(                             \
+      "ActivationModelWeightedSmooth1Norm",                            \
+      "Weighted smooth-1norm activation model.\n\n"                    \
+      "It computes sum_i w_i * sqrt(eps + r_i^2), where w contains "   \
+      "nonnegative weights and eps is a strictly positive smoothing "  \
+      "factor.",                                                       \
+      bp::init<VectorXs, bp::optional<Scalar>>(                        \
+          bp::args("self", "weights", "eps"),                          \
+          "Initialize the activation model.\n\n"                       \
+          ":param weights: nonnegative residual weights\n"             \
+          ":param eps: smoothing factor (default: 1)"))                \
+      .def(ActivationModelWeightedSmooth1NormVisitor<Model>())         \
+      .def(CastVisitor<Model>())                                       \
+      .def(PrintableVisitor<Model>())                                  \
+      .def(CopyableVisitor<Model>());
+
+#define CROCODDYL_ACTIVATION_DATA_WEIGHTEDSMOOTH1NORM_PYTHON_BINDINGS( \
+    Scalar)                                                            \
+  typedef ActivationDataWeightedSmooth1NormTpl<Scalar> Data;           \
+  typedef ActivationDataAbstractTpl<Scalar> DataBase;                  \
+  typedef ActivationModelWeightedSmooth1NormTpl<Scalar> Model;         \
+  bp::register_ptr_to_python<std::shared_ptr<Data>>();                 \
+  bp::class_<Data, bp::bases<DataBase>>(                               \
+      "ActivationDataWeightedSmooth1Norm",                             \
+      "Data for weighted smooth-1norm activation.\n\n",                \
+      bp::init<Model*>(bp::args("self", "model"),                      \
+                       "Create weighted smooth-1norm activation data." \
+                       "\n\n:param model: activation model"))          \
+      .def(ActivationDataWeightedSmooth1NormVisitor<Data>())           \
+      .def(CopyableVisitor<Data>());
+
+void exposeActivationWeightedSmooth1Norm() {
+  CROCODDYL_ACTIVATION_MODEL_WEIGHTEDSMOOTH1NORM_PYTHON_BINDINGS(
+      @SCALAR_TYPE@)
+  CROCODDYL_ACTIVATION_DATA_WEIGHTEDSMOOTH1NORM_PYTHON_BINDINGS(
+      @SCALAR_TYPE@)
+}
+
+}  // namespace python
+}  // namespace crocoddyl

--- a/bindings/python/crocoddyl/core/activations/weighted-smooth-1norm.cpp.in
+++ b/bindings/python/crocoddyl/core/activations/weighted-smooth-1norm.cpp.in
@@ -36,7 +36,7 @@ struct ActivationModelWeightedSmooth1NormVisitor
                       bp::make_function(&Model::get_weights,
                                         bp::return_internal_reference<>()),
                       &Model::set_weights, "nonnegative residual weights")
-        .add_property("eps", &Model::get_eps, "smoothing factor");
+        .add_property("delta", &Model::get_delta, "smoothing scale");
   }
 };
 
@@ -48,7 +48,7 @@ struct ActivationDataWeightedSmooth1NormVisitor
   void visit(PyClass& cl) const {
     cl.add_property(
         "a", bp::make_getter(&Data::a, bp::return_internal_reference<>()),
-        "element-wise sqrt(eps + r_i^2) values");
+        "element-wise sqrt(delta^2 + r_i^2) values");
   }
 };
 
@@ -61,14 +61,14 @@ struct ActivationDataWeightedSmooth1NormVisitor
   bp::class_<Model, bp::bases<ModelBase>>(                             \
       "ActivationModelWeightedSmooth1Norm",                            \
       "Weighted smooth-1norm activation model.\n\n"                    \
-      "It computes sum_i w_i * sqrt(eps + r_i^2), where w contains "   \
-      "nonnegative weights and eps is a strictly positive smoothing "  \
-      "factor.",                                                       \
+      "It computes sum_i w_i * delta^2 * "                             \
+      "(sqrt(1 + (r_i / delta)^2) - 1), where w contains nonnegative " \
+      "weights and delta is a strictly positive smoothing scale.",     \
       bp::init<VectorXs, bp::optional<Scalar>>(                        \
-          bp::args("self", "weights", "eps"),                          \
+          bp::args("self", "weights", "delta"),                        \
           "Initialize the activation model.\n\n"                       \
           ":param weights: nonnegative residual weights\n"             \
-          ":param eps: smoothing factor (default: 1)"))                \
+          ":param delta: smoothing scale (default: 1)"))               \
       .def(ActivationModelWeightedSmooth1NormVisitor<Model>())         \
       .def(CastVisitor<Model>())                                       \
       .def(PrintableVisitor<Model>())                                  \

--- a/bindings/python/crocoddyl/core/core.cpp
+++ b/bindings/python/crocoddyl/core/core.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2025, University of Edinburgh, LAAS-CNRS,
+// Copyright (C) 2019-2026, University of Edinburgh, LAAS-CNRS,
 //                          Heriot-Watt University, University of Trento
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
@@ -61,6 +61,7 @@ void exposeCore() {
   exposeActivationQuadraticBarrier();
   exposeActivationWeightedQuadraticBarrier();
   exposeActivationSmooth1Norm();
+  exposeActivationWeightedSmooth1Norm();
   exposeActivationSmooth2Norm();
   exposeActivation2NormBarrier();
   exposeSolverKKT();

--- a/bindings/python/crocoddyl/core/core.hpp
+++ b/bindings/python/crocoddyl/core/core.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2025, LAAS-CNRS, University of Edinburgh,
+// Copyright (C) 2019-2026, LAAS-CNRS, University of Edinburgh,
 //                          Heriot-Watt University, University of Trento
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
@@ -63,6 +63,7 @@ void exposeActivationWeightedQuad();
 void exposeActivationQuadraticBarrier();
 void exposeActivationWeightedQuadraticBarrier();
 void exposeActivationSmooth1Norm();
+void exposeActivationWeightedSmooth1Norm();
 void exposeActivationSmooth2Norm();
 void exposeActivation2NormBarrier();
 void exposeSolverDDP();

--- a/bindings/python/crocoddyl/core/numdiff/activation.cpp.in
+++ b/bindings/python/crocoddyl/core/numdiff/activation.cpp.in
@@ -47,6 +47,7 @@ struct ActivationModelNumDiffVisitor
             "action model")
         .add_property(
             "disturbance", bp::make_function(&Model::get_disturbance),
+            &Model::set_disturbance,
             "disturbance constant used in the numerical differentiation");
   }
 };

--- a/bindings/python/crocoddyl/utils/humanoid.py
+++ b/bindings/python/crocoddyl/utils/humanoid.py
@@ -53,11 +53,11 @@ class HumanoidLocoManipulation:
     def createModel(
         self,
         qref=None,
-        footContacts=list(),
-        handContacts=list(),
+        footContacts=None,
+        handContacts=None,
         bodiesTarget=None,
-        handsTarget=dict(),
-        feetTarget=dict(),
+        handsTarget=None,
+        feetTarget=None,
         switch=False,
         constraint=False,
     ):
@@ -250,7 +250,7 @@ class HumanoidLocoManipulation:
             dsSwitch2 = self.createModel(handsTarget=handsTarget3, switch=True)
             models += [dsModel] * Tds + [dsSwitch2]
         # Model for leaving the bars
-        handsTermTarget = dict()
+        handsTermTarget = {}
         q0 = copy.deepcopy(self.q0)
         q0[:2] = (LF_pose.translation + RF_pose.translation)[:2] / 2
         pinocchio.forwardKinematics(self.robot_model, self.robot_data, q0)
@@ -401,7 +401,7 @@ class HumanoidLocoManipulation:
                 )
             models += [dsModel] * Tds + [dsSwitch2]
         # Model for leaving the bars
-        handsTermTarget = dict()
+        handsTermTarget = {}
         q0 = copy.deepcopy(self.q0)
         q0[:2] = (LF_pose.translation + RF_pose.translation)[:2] / 2
         pinocchio.forwardKinematics(self.robot_model, self.robot_data, q0)
@@ -540,7 +540,7 @@ class HumanoidLocoManipulation:
                 )
             models += [backflipModel] * Tflipseg + [backflipAngleModel]
         # Model for resting posture
-        handsTermTarget = dict()
+        handsTermTarget = {}
         qref = copy.deepcopy(self.qref)
         qref[:2] = (LF_pose.translation + RF_pose.translation)[:2] / 2
         pinocchio.forwardKinematics(self.robot_model, self.robot_data, qref)
@@ -548,7 +548,7 @@ class HumanoidLocoManipulation:
             frame_id = self.robot_model.getFrameId(name)
             pinocchio.updateFramePlacement(self.robot_model, self.robot_data, frame_id)
             handsTermTarget[name] = self.robot_data.oMf[frame_id]
-        bodiesTarget = dict()
+        bodiesTarget = {}
         bodiesTarget["torso_1_joint"] = np.eye(3)
         bodiesTarget["torso_2_joint"] = pinocchio.SE3(np.eye(3), qref[:3])
         models += [standModel] * Tend

--- a/bindings/python/crocoddyl/utils/humanoid.py
+++ b/bindings/python/crocoddyl/utils/humanoid.py
@@ -61,6 +61,16 @@ class HumanoidLocoManipulation:
         switch=False,
         constraint=False,
     ):
+        if footContacts is None:
+            footContacts = []
+        if handContacts is None:
+            handContacts = []
+        if bodiesTarget is None:
+            bodiesTarget = {}
+        if handsTarget is None:
+            handsTarget = {}
+        if feetTarget is None:
+            feetTarget = {}
         if self._fwddyn:
             nu = self.actuation.nu if switch is False else 0
         else:
@@ -76,22 +86,21 @@ class HumanoidLocoManipulation:
         else:
             impulses = crocoddyl.ImpulseModelMultiple(self.state)
         # Cost for body target
-        if bodiesTarget is not None:
-            for name, Mref in bodiesTarget.items():
-                frame_id = self.robot_model.getFrameId(name)
-                # Cost for target reaching: bodies
-                if isinstance(Mref, (np.ndarray, np.generic)):
-                    costs.addCost(
-                        name + "_pose",
-                        self._createFrameRotationCost(name, Mref, np.ones(3), nu),
-                        1e3,
-                    )
-                elif isinstance(Mref, pinocchio.SE3):
-                    costs.addCost(
-                        name + "_pose",
-                        self._createFramePlacementCost(name, Mref, np.ones(6), nu),
-                        1e3,
-                    )
+        for name, Mref in bodiesTarget.items():
+            frame_id = self.robot_model.getFrameId(name)
+            # Cost for target reaching: bodies
+            if isinstance(Mref, (np.ndarray, np.generic)):
+                costs.addCost(
+                    name + "_pose",
+                    self._createFrameRotationCost(name, Mref, np.ones(3), nu),
+                    1e3,
+                )
+            elif isinstance(Mref, pinocchio.SE3):
+                costs.addCost(
+                    name + "_pose",
+                    self._createFramePlacementCost(name, Mref, np.ones(6), nu),
+                    1e3,
+                )
         # Cost for self-collision, and for state and control regularization
         costs.addCost("stateLimitsCost", self._createStateLimsCost(nu), 1e3)
         costs.addCost(

--- a/examples/aerial_manipulator_fwddyn.py
+++ b/examples/aerial_manipulator_fwddyn.py
@@ -149,7 +149,7 @@ if WITHDISPLAY:
                 solverSQP.setCallbacks(
                     [crocoddyl.CallbackVerbose(), crocoddyl.CallbackDisplay(display)]
                 )
-    except Exception:
+    except (RuntimeError, ImportError):
         display = crocoddyl.MeshcatDisplay(borinot)
 if WITHPLOT:
     solver.setCallbacks([crocoddyl.CallbackVerbose(), crocoddyl.CallbackLogger()])

--- a/examples/aerial_manipulator_invdyn.py
+++ b/examples/aerial_manipulator_invdyn.py
@@ -149,7 +149,7 @@ if WITHDISPLAY:
                 solverSQP.setCallbacks(
                     [crocoddyl.CallbackVerbose(), crocoddyl.CallbackDisplay(display)]
                 )
-    except Exception:
+    except (RuntimeError, ImportError):
         display = crocoddyl.MeshcatDisplay(borinot)
 if WITHPLOT:
     solver.setCallbacks([crocoddyl.CallbackVerbose(), crocoddyl.CallbackLogger()])

--- a/examples/biped_gaits_fwddyn.py
+++ b/examples/biped_gaits_fwddyn.py
@@ -164,7 +164,7 @@ if WITHDISPLAY:
         gepetto.corbaserver.Client()
         cameraTF = [3.0, 3.68, 0.84, 0.2, 0.62, 0.72, 0.22]
         display = crocoddyl.GepettoDisplay(talos_legs, 4, 4, cameraTF)
-    except Exception:
+    except (RuntimeError, ImportError):
         display = crocoddyl.MeshcatDisplay(talos_legs)
     display.rate = -1
     display.freq = 1
@@ -208,5 +208,5 @@ if WITHPLOT:
                 log.steps,
                 figTitle=title,
                 figIndex=i + fig_idx + 3,
-                show=True if i == len(GAITPHASES) - 1 else False,
+                show=i == len(GAITPHASES) - 1,
             )

--- a/examples/biped_gaits_invdyn.py
+++ b/examples/biped_gaits_invdyn.py
@@ -164,7 +164,7 @@ if WITHDISPLAY:
         gepetto.corbaserver.Client()
         cameraTF = [3.0, 3.68, 0.84, 0.2, 0.62, 0.72, 0.22]
         display = crocoddyl.GepettoDisplay(talos_legs, 4, 4, cameraTF)
-    except Exception:
+    except (RuntimeError, ImportError):
         display = crocoddyl.MeshcatDisplay(talos_legs)
     display.rate = -1
     display.freq = 1
@@ -208,5 +208,5 @@ if WITHPLOT:
                 log.steps,
                 figTitle=title,
                 figIndex=i + fig_idx + 3,
-                show=True if i == len(GAITPHASES) - 1 else False,
+                show=i == len(GAITPHASES) - 1,
             )

--- a/examples/biped_pose_fwddyn.py
+++ b/examples/biped_pose_fwddyn.py
@@ -125,7 +125,7 @@ if WITHDISPLAY:
         gepetto.corbaserver.Client()
         cameraTF = [3.0, 3.68, 0.84, 0.2, 0.62, 0.72, 0.22]
         display = crocoddyl.GepettoDisplay(talos_legs, 4, 4, cameraTF)
-    except Exception:
+    except (RuntimeError, ImportError):
         display = crocoddyl.MeshcatDisplay(talos_legs)
     display.rate = -1
     display.freq = 1

--- a/examples/biped_pose_invdyn.py
+++ b/examples/biped_pose_invdyn.py
@@ -123,7 +123,7 @@ if WITHDISPLAY:
         gepetto.corbaserver.Client()
         cameraTF = [3.0, 3.68, 0.84, 0.2, 0.62, 0.72, 0.22]
         display = crocoddyl.GepettoDisplay(talos_legs, 4, 4, cameraTF)
-    except Exception:
+    except (RuntimeError, ImportError):
         display = crocoddyl.MeshcatDisplay(talos_legs)
     display.rate = -1
     display.freq = 1

--- a/examples/biped_walk_ubound.py
+++ b/examples/biped_walk_ubound.py
@@ -124,7 +124,7 @@ if WITHDISPLAY:
         gepetto.corbaserver.Client()
         cameraTF = [3.0, 3.68, 0.84, 0.2, 0.62, 0.72, 0.22]
         display = crocoddyl.GepettoDisplay(talos_legs, 4, 4, cameraTF)
-    except Exception:
+    except (RuntimeError, ImportError):
         display = crocoddyl.MeshcatDisplay(talos_legs)
     display.rate = -1
     display.freq = 1
@@ -149,5 +149,5 @@ if WITHPLOT:
             log.steps,
             figTitle=title,
             figIndex=i + 3,
-            show=True if i == len(GAITPHASES) - 1 else False,
+            show=i == len(GAITPHASES) - 1,
         )

--- a/examples/boxfddp_vs_boxddp.py
+++ b/examples/boxfddp_vs_boxddp.py
@@ -100,7 +100,7 @@ if WITHDISPLAY:
         gepetto.corbaserver.Client()
         cameraTF = [2.0, 2.68, 0.84, 0.2, 0.62, 0.72, 0.22]
         display = crocoddyl.GepettoDisplay(anymal, 4, 4, cameraTF)
-    except Exception:
+    except (RuntimeError, ImportError):
         display = crocoddyl.MeshcatDisplay(anymal)
     display.rate = -1
     display.freq = 1

--- a/examples/double_pendulum_continuous_fwddyn.py
+++ b/examples/double_pendulum_continuous_fwddyn.py
@@ -99,7 +99,7 @@ if WITHDISPLAY:
         gepetto.corbaserver.Client()
         cameraTF = [1.4, 0.0, 0.2, 0.5, 0.5, 0.5, 0.5]
         display = crocoddyl.GepettoDisplay(pendulum, 4, 4, cameraTF, floor=False)
-    except Exception:
+    except (RuntimeError, ImportError):
         display = crocoddyl.MeshcatDisplay(pendulum)
     display.rate = -1
     display.freq = 1

--- a/examples/double_pendulum_continuous_invdyn.py
+++ b/examples/double_pendulum_continuous_invdyn.py
@@ -106,7 +106,7 @@ if WITHDISPLAY:
         gepetto.corbaserver.Client()
         cameraTF = [1.4, 0.0, 0.2, 0.5, 0.5, 0.5, 0.5]
         display = crocoddyl.GepettoDisplay(pendulum, 4, 4, cameraTF, floor=False)
-    except Exception:
+    except (RuntimeError, ImportError):
         display = crocoddyl.MeshcatDisplay(pendulum)
     display.rate = -1
     display.freq = 1

--- a/examples/double_pendulum_fwddyn.py
+++ b/examples/double_pendulum_fwddyn.py
@@ -138,7 +138,7 @@ if WITHDISPLAY:
         gepetto.corbaserver.Client()
         cameraTF = [1.4, 0.0, 0.2, 0.5, 0.5, 0.5, 0.5]
         display = crocoddyl.GepettoDisplay(pendulum, 4, 4, cameraTF, floor=False)
-    except Exception:
+    except (RuntimeError, ImportError):
         display = crocoddyl.MeshcatDisplay(pendulum)
     display.rate = -1
     display.freq = 1

--- a/examples/double_pendulum_invdyn.py
+++ b/examples/double_pendulum_invdyn.py
@@ -144,7 +144,7 @@ if WITHDISPLAY:
         gepetto.corbaserver.Client()
         cameraTF = [1.4, 0.0, 0.2, 0.5, 0.5, 0.5, 0.5]
         display = crocoddyl.GepettoDisplay(pendulum, 4, 4, cameraTF, floor=False)
-    except Exception:
+    except (RuntimeError, ImportError):
         display = crocoddyl.MeshcatDisplay(pendulum)
     display.rate = -1
     display.freq = 1

--- a/examples/humanoid_backflip_fwddyn.py
+++ b/examples/humanoid_backflip_fwddyn.py
@@ -76,7 +76,7 @@ if WITHDISPLAY:
         gepetto.corbaserver.Client()
         cameraTF = [3.0, 3.68, 0.84, 0.2, 0.62, 0.72, 0.22]
         display = crocoddyl.GepettoDisplay(robot, 4, 4, cameraTF)
-    except Exception:
+    except (RuntimeError, ImportError):
         display = crocoddyl.MeshcatDisplay(robot)
     # Display the optimized motion
     display.rate = -1

--- a/examples/humanoid_backflip_invdyn.py
+++ b/examples/humanoid_backflip_invdyn.py
@@ -78,7 +78,7 @@ if WITHDISPLAY:
         gepetto.corbaserver.Client()
         cameraTF = [3.0, 3.68, 0.84, 0.2, 0.62, 0.72, 0.22]
         display = crocoddyl.GepettoDisplay(robot, 4, 4, cameraTF)
-    except Exception:
+    except (RuntimeError, ImportError):
         display = crocoddyl.MeshcatDisplay(robot)
     # Display the optimized motion
     display.rate = -1

--- a/examples/humanoid_bar_fwddyn.py
+++ b/examples/humanoid_bar_fwddyn.py
@@ -23,11 +23,11 @@ LH_name, RH_name = "gripper_left_inner_double_link", "gripper_right_inner_double
 q0 = robot_model.referenceConfigurations["half_sitting"]
 
 # Define the location of the bars
-bars = list()
+bars = []
 bars.append(np.array([0.2, 0.0, 2.15]))
 
 # Define the monkey-bar tasks
-RH_grasp_list, LH_grasp_list = list(), list()
+RH_grasp_list, LH_grasp_list = [], []
 for bar_pos in bars:
     Rhand = pinocchio.utils.rpyToMatrix(0, np.pi, np.pi / 2)
     t_rh = bar_pos - np.array([0.0, 0.45, 0.0])

--- a/examples/humanoid_bar_invdyn.py
+++ b/examples/humanoid_bar_invdyn.py
@@ -23,11 +23,11 @@ LH_name, RH_name = "gripper_left_inner_double_link", "gripper_right_inner_double
 q0 = robot_model.referenceConfigurations["half_sitting"]
 
 # Define the location of the bars
-bars = list()
+bars = []
 bars.append(np.array([0.2, 0.0, 2.15]))
 
 # Define the monkey-bar tasks
-RH_grasp_list, LH_grasp_list = list(), list()
+RH_grasp_list, LH_grasp_list = [], []
 for bar_pos in bars:
     Rhand = pinocchio.utils.rpyToMatrix(0, np.pi, np.pi / 2)
     t_rh = bar_pos - np.array([0.0, 0.45, 0.0])

--- a/examples/humanoid_frontflip_fwddyn.py
+++ b/examples/humanoid_frontflip_fwddyn.py
@@ -77,7 +77,7 @@ if WITHDISPLAY:
         gepetto.corbaserver.Client()
         cameraTF = [3.0, 3.68, 0.84, 0.2, 0.62, 0.72, 0.22]
         display = crocoddyl.GepettoDisplay(robot, 4, 4, cameraTF)
-    except Exception:
+    except (RuntimeError, ImportError):
         display = crocoddyl.MeshcatDisplay(robot)
     # Display the optimized motion
     display.rate = -1

--- a/examples/humanoid_frontflip_invdyn.py
+++ b/examples/humanoid_frontflip_invdyn.py
@@ -80,7 +80,7 @@ if WITHDISPLAY:
         gepetto.corbaserver.Client()
         cameraTF = [3.0, 3.68, 0.84, 0.2, 0.62, 0.72, 0.22]
         display = crocoddyl.GepettoDisplay(robot, 4, 4, cameraTF)
-    except Exception:
+    except (RuntimeError, ImportError):
         display = crocoddyl.MeshcatDisplay(robot)
     # Display the optimized motion
     display.rate = -1

--- a/examples/humanoid_handstanding_fwddyn.py
+++ b/examples/humanoid_handstanding_fwddyn.py
@@ -23,11 +23,11 @@ LH_name, RH_name = "gripper_left_inner_double_link", "gripper_right_inner_double
 q0 = robot_model.referenceConfigurations["half_sitting"]
 
 # Define the location of the bars
-bars = list()
+bars = []
 bars.append(np.array([0.4, 0.0, 0.3]))
 
 # Define the monkey-bar tasks
-RH_grasp_list, LH_grasp_list = list(), list()
+RH_grasp_list, LH_grasp_list = [], []
 for bar_pos in bars:
     Rhand = pinocchio.utils.rpyToMatrix(0.0, 0.0, np.pi / 2)
     t_rh = bar_pos - np.array([0.0, 0.45, 0.0])

--- a/examples/humanoid_handstanding_invdyn.py
+++ b/examples/humanoid_handstanding_invdyn.py
@@ -23,11 +23,11 @@ LH_name, RH_name = "gripper_left_inner_double_link", "gripper_right_inner_double
 q0 = robot_model.referenceConfigurations["half_sitting"]
 
 # Define the location of the bars
-bars = list()
+bars = []
 bars.append(np.array([0.4, 0.0, 0.3]))
 
 # Define the monkey-bar tasks
-RH_grasp_list, LH_grasp_list = list(), list()
+RH_grasp_list, LH_grasp_list = [], []
 for bar_pos in bars:
     Rhand = pinocchio.utils.rpyToMatrix(0.0, 0.0, np.pi / 2)
     t_rh = bar_pos - np.array([0.0, 0.45, 0.0])

--- a/examples/humanoid_manipulation.py
+++ b/examples/humanoid_manipulation.py
@@ -177,7 +177,7 @@ if WITHDISPLAY:
             display.robot.viewer.gui.applyConfiguration(
                 "world/point", [*target.tolist(), 0.0, 0.0, 0.0, 1.0]
             )  # xyz+quaternion
-        except Exception:
+        except (RuntimeError, ImportError):
             display = crocoddyl.MeshcatDisplay(robot)
     display.rate = -1
     display.freq = 1

--- a/examples/humanoid_manipulation_ubound.py
+++ b/examples/humanoid_manipulation_ubound.py
@@ -179,7 +179,7 @@ if WITHDISPLAY:
             display.robot.viewer.gui.applyConfiguration(
                 "world/point", [*target.tolist(), 0.0, 0.0, 0.0, 1.0]
             )  # xyz+quaternion
-        except Exception:
+        except (RuntimeError, ImportError):
             display = crocoddyl.MeshcatDisplay(robot)
     display.rate = -1
     display.freq = 1

--- a/examples/humanoid_monkey_bar_fwddyn.py
+++ b/examples/humanoid_monkey_bar_fwddyn.py
@@ -23,14 +23,14 @@ LH_name, RH_name = "gripper_left_inner_double_link", "gripper_right_inner_double
 q0 = robot_model.referenceConfigurations["half_sitting"]
 
 # Define the location of the bars
-bars = list()
+bars = []
 bars.append(np.array([0.2, 0.0, 2.15]))
 bars.append(np.array([0.6, 0.0, 2.15]))
 bars.append(np.array([1.0, 0.0, 2.15]))
 bars.append(np.array([1.4, 0.0, 2.15]))
 
 # Define the monkey-bar tasks
-RH_grasp_list, LH_grasp_list = list(), list()
+RH_grasp_list, LH_grasp_list = [], []
 for bar_pos in bars:
     Rhand = pinocchio.utils.rpyToMatrix(0, np.pi, np.pi / 2)
     t_rh = bar_pos - np.array([0.0, 0.45, 0.0])

--- a/examples/humanoid_monkey_bar_invdyn.py
+++ b/examples/humanoid_monkey_bar_invdyn.py
@@ -23,14 +23,14 @@ LH_name, RH_name = "gripper_left_inner_double_link", "gripper_right_inner_double
 q0 = robot_model.referenceConfigurations["half_sitting"]
 
 # Define the location of the bars
-bars = list()
+bars = []
 bars.append(np.array([0.2, 0.0, 2.15]))
 bars.append(np.array([0.6, 0.0, 2.15]))
 bars.append(np.array([1.0, 0.0, 2.15]))
 bars.append(np.array([1.4, 0.0, 2.15]))
 
 # Define the monkey-bar tasks
-RH_grasp_list, LH_grasp_list = list(), list()
+RH_grasp_list, LH_grasp_list = [], []
 for bar_pos in bars:
     Rhand = pinocchio.utils.rpyToMatrix(0, np.pi, np.pi / 2)
     t_rh = bar_pos - np.array([0.0, 0.45, 0.0])

--- a/examples/humanoid_taichi.py
+++ b/examples/humanoid_taichi.py
@@ -226,7 +226,7 @@ if WITHDISPLAY:
             display.robot.viewer.gui.applyConfiguration(
                 "world/point", [*target.tolist(), 0.0, 0.0, 0.0, 1.0]
             )  # xyz+quaternion
-        except Exception:
+        except (RuntimeError, ImportError):
             display = crocoddyl.MeshcatDisplay(robot)
     display.rate = -1
     display.freq = 1

--- a/examples/humanoid_walking_on_hands_fwddyn.py
+++ b/examples/humanoid_walking_on_hands_fwddyn.py
@@ -23,14 +23,14 @@ LH_name, RH_name = "gripper_left_inner_double_link", "gripper_right_inner_double
 q0 = robot_model.referenceConfigurations["half_sitting"]
 
 # Define the location of the bars
-bars = list()
+bars = []
 bars.append(np.array([0.4, 0.0, 0.3]))
 bars.append(np.array([0.8, 0.0, 0.3]))
 bars.append(np.array([1.2, 0.0, 0.3]))
 bars.append(np.array([1.6, 0.0, 0.3]))
 
 # Define the monkey-bar tasks
-RH_grasp_list, LH_grasp_list = list(), list()
+RH_grasp_list, LH_grasp_list = [], []
 for bar_pos in bars:
     Rhand = pinocchio.utils.rpyToMatrix(0.0, 0.0, np.pi / 2)
     t_rh = bar_pos - np.array([0.0, 0.45, 0.0])

--- a/examples/humanoid_walking_on_hands_invdyn.py
+++ b/examples/humanoid_walking_on_hands_invdyn.py
@@ -23,14 +23,14 @@ LH_name, RH_name = "gripper_left_inner_double_link", "gripper_right_inner_double
 q0 = robot_model.referenceConfigurations["half_sitting"]
 
 # Define the location of the bars
-bars = list()
+bars = []
 bars.append(np.array([0.4, 0.0, 0.3]))
 bars.append(np.array([0.8, 0.0, 0.3]))
 bars.append(np.array([1.2, 0.0, 0.3]))
 bars.append(np.array([1.6, 0.0, 0.3]))
 
 # Define the monkey-bar tasks
-RH_grasp_list, LH_grasp_list = list(), list()
+RH_grasp_list, LH_grasp_list = [], []
 for bar_pos in bars:
     Rhand = pinocchio.utils.rpyToMatrix(0.0, 0.0, np.pi / 2)
     t_rh = bar_pos - np.array([0.0, 0.45, 0.0])

--- a/examples/marine_manipulator_fwddyn.py
+++ b/examples/marine_manipulator_fwddyn.py
@@ -138,7 +138,7 @@ if WITHDISPLAY:
                 solverSQP.setCallbacks(
                     [crocoddyl.CallbackVerbose(), crocoddyl.CallbackDisplay(display)]
                 )
-    except Exception:
+    except (RuntimeError, ImportError):
         display = crocoddyl.MeshcatDisplay(bluevolta)
         # display.forceLength = 3
 if WITHPLOT:

--- a/examples/marine_manipulator_invdyn.py
+++ b/examples/marine_manipulator_invdyn.py
@@ -138,7 +138,7 @@ if WITHDISPLAY:
                 solverSQP.setCallbacks(
                     [crocoddyl.CallbackVerbose(), crocoddyl.CallbackDisplay(display)]
                 )
-    except Exception:
+    except (RuntimeError, ImportError):
         display = crocoddyl.MeshcatDisplay(bluevolta)
 if WITHPLOT:
     solver.setCallbacks([crocoddyl.CallbackVerbose(), crocoddyl.CallbackLogger()])

--- a/examples/quadrotor_ubound.py
+++ b/examples/quadrotor_ubound.py
@@ -132,7 +132,7 @@ if WITHDISPLAY:
                 target_quat[3],
             ],
         )
-    except Exception:
+    except (RuntimeError, ImportError):
         display = crocoddyl.MeshcatDisplay(hector)
     display.rate = -1
     display.freq = 1

--- a/examples/quadruped_gaits_fwddyn.py
+++ b/examples/quadruped_gaits_fwddyn.py
@@ -291,5 +291,5 @@ if WITHPLOT:
                 log.steps,
                 figTitle=title,
                 figIndex=i + fig_idx + 3,
-                show=True if i == len(GAITPHASES) - 1 else False,
+                show=i == len(GAITPHASES) - 1,
             )

--- a/examples/quadruped_gaits_invdyn.py
+++ b/examples/quadruped_gaits_invdyn.py
@@ -293,5 +293,5 @@ if WITHPLOT:
                 log.steps,
                 figTitle=title,
                 figIndex=i + fig_idx + 3,
-                show=True if i == len(GAITPHASES) - 1 else False,
+                show=i == len(GAITPHASES) - 1,
             )

--- a/examples/quadruped_walk_ubound.py
+++ b/examples/quadruped_walk_ubound.py
@@ -94,7 +94,7 @@ if WITHDISPLAY:
         gepetto.corbaserver.Client()
         cameraTF = [2.0, 2.68, 0.84, 0.2, 0.62, 0.72, 0.22]
         display = crocoddyl.GepettoDisplay(anymal, 4, 4, cameraTF)
-    except Exception:
+    except (RuntimeError, ImportError):
         display = crocoddyl.MeshcatDisplay(anymal)
     display.rate = -1
     display.freq = 1

--- a/include/crocoddyl/core/activations/smooth-1norm.hpp
+++ b/include/crocoddyl/core/activations/smooth-1norm.hpp
@@ -18,22 +18,23 @@ namespace crocoddyl {
 /**
  * @brief Smooth-abs activation
  *
- * This activation function describes a smooth representation of an absolute
- * activation (1-norm) for each element of a residual vector, i.e.
- * \{equation}{ sum^nr_{i=0} \sqrt{\epsilon + \|r_i\|^2} \f}
- * where \f$\epsilon\f$ defines the smoothing factor, \f$r_i\f$ is the scalar
- * residual for the \f$i\f$ constraints, \f$nr\f$ is the dimension of the
- * residual vector. It represents a shifted Charbonnier activation function,
- * which is a type of pseudo-Huber function that provides a smooth
- * approximation of the absolute value function. The smooth-abs activation is
- * differentiable everywhere, including at the origin, which makes it suitable
- * for optimization problems where smoothness is desired. The parameter
- * \f$\epsilon\f$ controls the degree of smoothing; smaller values lead to a
- * closer approximation to the absolute value function, while larger values
- * result in a smoother curve.
+ * This activation function describes a smooth representation of the 1-norm of
+ * a residual vector:
+ * \f[
+ *   a(\mathbf{r}) =
+ *     \sum_{i=0}^{nr-1}
+ *       \delta^2\left(\sqrt{1 + (r_i/\delta)^2} - 1\right).
+ * \f]
+ * Here, \f$\delta > 0\f$ is the smoothing scale, \f$r_i\f$ is a scalar
+ * residual, and \f$nr\f$ is the residual dimension. This is the classical
+ * pseudo-Huber form, equivalently
+ * \f$\delta\sqrt{\delta^2 + r_i^2} - \delta^2\f$. Its local quadratic
+ * approximation is \f$r_i^2/2\f$ for every \f$\delta\f$. The transition to the
+ * linear regime occurs around \f$|r_i| = \delta\f$, with asymptotic slope
+ * \f$\delta\f$.
  *
- * The computation of the function and it derivatives are carried out in
- * `calc()` and `caldDiff()`, respectively.
+ * The computation of the function and its derivatives are carried out in
+ * `calc()` and `calcDiff()`, respectively.
  *
  * \sa `calc()`, `calcDiff()`, `createData()`
  */
@@ -55,16 +56,17 @@ class ActivationModelSmooth1NormTpl
   /**
    * @brief Initialize the smooth-abs activation model
    *
-   * The default `eps` value is defined as 1.
+   * The default `delta` value is defined as 1.
    *
-   * @param[in] nr   Dimension of the residual vector
-   * @param[in] eps  Smoothing factor (default: 1.)
+   * @param[in] nr     Dimension of the residual vector
+   * @param[in] delta  Strictly positive smoothing scale (default: 1)
    */
   explicit ActivationModelSmooth1NormTpl(const std::size_t nr,
-                                         const Scalar eps = Scalar(1.))
-      : Base(nr), eps_(eps) {
-    if (eps <= Scalar(0.)) {
-      throw_pretty("Invalid argument: " << "eps should be a positive value");
+                                         const Scalar delta = Scalar(1.))
+      : Base(nr), delta_(delta) {
+    if (delta_ <= Scalar(0.)) {
+      throw_pretty(
+          "Invalid argument: delta should be a strictly positive value");
     }
   };
   virtual ~ActivationModelSmooth1NormTpl() = default;
@@ -84,8 +86,9 @@ class ActivationModelSmooth1NormTpl
     }
     std::shared_ptr<Data> d = std::static_pointer_cast<Data>(data);
 
-    d->a = (r.array().square() + eps_).sqrt().matrix();
-    data->a_value = d->a.sum();
+    d->a = (r.array().square() + delta_ * delta_).sqrt().matrix();
+    data->a_value =
+        delta_ * (r.array().square() / (d->a.array() + delta_)).sum();
   };
 
   /**
@@ -105,8 +108,9 @@ class ActivationModelSmooth1NormTpl
     std::shared_ptr<Data> d = std::static_pointer_cast<Data>(data);
     const VectorXs a_inv = d->a.cwiseInverse();
 
-    data->Ar = r.cwiseProduct(a_inv);
-    data->Arr.diagonal() = eps_ * a_inv.cwiseProduct(a_inv).cwiseProduct(a_inv);
+    data->Ar = delta_ * r.cwiseProduct(a_inv);
+    data->Arr.diagonal() = delta_ * delta_ * delta_ *
+                           a_inv.cwiseProduct(a_inv).cwiseProduct(a_inv);
   };
 
   /**
@@ -121,9 +125,11 @@ class ActivationModelSmooth1NormTpl
   template <typename NewScalar>
   ActivationModelSmooth1NormTpl<NewScalar> cast() const {
     typedef ActivationModelSmooth1NormTpl<NewScalar> ReturnType;
-    ReturnType res(nr_, scalar_cast<NewScalar>(eps_));
+    ReturnType res(nr_, scalar_cast<NewScalar>(delta_));
     return res;
   }
+
+  Scalar get_delta() const { return delta_; }
 
   /**
    * @brief Print relevant information of the smooth-1norm model
@@ -131,12 +137,13 @@ class ActivationModelSmooth1NormTpl
    * @param[out] os  Output stream object
    */
   virtual void print(std::ostream& os) const override {
-    os << "ActivationModelSmooth1Norm {nr=" << nr_ << ", eps=" << eps_ << "}";
+    os << "ActivationModelSmooth1Norm {nr=" << nr_ << ", delta=" << delta_
+       << "}";
   }
 
  protected:
   using Base::nr_;  //!< Dimension of the residual vector
-  Scalar eps_;      //!< Smoothing factor
+  Scalar delta_;    //!< Smoothing scale
 };
 
 template <typename _Scalar>

--- a/include/crocoddyl/core/activations/smooth-1norm.hpp
+++ b/include/crocoddyl/core/activations/smooth-1norm.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2025, LAAS-CNRS, University of Edinburgh,
+// Copyright (C) 2019-2026, LAAS-CNRS, University of Edinburgh,
 //                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
@@ -23,7 +23,14 @@ namespace crocoddyl {
  * \{equation}{ sum^nr_{i=0} \sqrt{\epsilon + \|r_i\|^2} \f}
  * where \f$\epsilon\f$ defines the smoothing factor, \f$r_i\f$ is the scalar
  * residual for the \f$i\f$ constraints, \f$nr\f$ is the dimension of the
- * residual vector.
+ * residual vector. It represents a shifted Charbonnier activation function,
+ * which is a type of pseudo-Huber function that provides a smooth
+ * approximation of the absolute value function. The smooth-abs activation is
+ * differentiable everywhere, including at the origin, which makes it suitable
+ * for optimization problems where smoothness is desired. The parameter
+ * \f$\epsilon\f$ controls the degree of smoothing; smaller values lead to a
+ * closer approximation to the absolute value function, while larger values
+ * result in a smoother curve.
  *
  * The computation of the function and it derivatives are carried out in
  * `calc()` and `caldDiff()`, respectively.

--- a/include/crocoddyl/core/activations/smooth-1norm.hpp
+++ b/include/crocoddyl/core/activations/smooth-1norm.hpp
@@ -63,13 +63,8 @@ class ActivationModelSmooth1NormTpl
   explicit ActivationModelSmooth1NormTpl(const std::size_t nr,
                                          const Scalar eps = Scalar(1.))
       : Base(nr), eps_(eps) {
-    if (eps < Scalar(0.)) {
+    if (eps <= Scalar(0.)) {
       throw_pretty("Invalid argument: " << "eps should be a positive value");
-    }
-    if (eps == Scalar(0.)) {
-      std::cerr << "Warning: eps=0 leads to derivatives discontinuities in the "
-                   "origin, it becomes the absolute function"
-                << std::endl;
     }
   };
   virtual ~ActivationModelSmooth1NormTpl() = default;
@@ -89,7 +84,7 @@ class ActivationModelSmooth1NormTpl
     }
     std::shared_ptr<Data> d = std::static_pointer_cast<Data>(data);
 
-    d->a = (r.array().cwiseAbs2().array() + eps_).array().cwiseSqrt();
+    d->a = (r.array().square() + eps_).sqrt().matrix();
     data->a_value = d->a.sum();
   };
 
@@ -108,9 +103,10 @@ class ActivationModelSmooth1NormTpl
     }
 
     std::shared_ptr<Data> d = std::static_pointer_cast<Data>(data);
-    data->Ar = r.cwiseProduct(d->a.cwiseInverse());
-    data->Arr.diagonal() =
-        d->a.cwiseProduct(d->a).cwiseProduct(d->a).cwiseInverse();
+    const VectorXs a_inv = d->a.cwiseInverse();
+
+    data->Ar = r.cwiseProduct(a_inv);
+    data->Arr.diagonal() = eps_ * a_inv.cwiseProduct(a_inv).cwiseProduct(a_inv);
   };
 
   /**

--- a/include/crocoddyl/core/activations/smooth-2norm.hpp
+++ b/include/crocoddyl/core/activations/smooth-2norm.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2020-2025, LAAS-CNRS, Heriot-Watt University
+// Copyright (C) 2020-2026, LAAS-CNRS, Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
@@ -91,7 +91,9 @@ class ActivationModelSmooth2NormTpl
     }
 
     data->Ar = r / data->a_value;
-    data->Arr.diagonal().array() = Scalar(1) / pow(data->a_value, Scalar(3));
+    data->Arr.diagonal().array() =
+        Scalar(1.) / data->a_value -
+        r.array().square() / pow(data->a_value, Scalar(3.));
   };
 
   /**

--- a/include/crocoddyl/core/activations/smooth-abs.hpp
+++ b/include/crocoddyl/core/activations/smooth-abs.hpp
@@ -26,7 +26,7 @@ class ActivationModelSmoothAbsTpl
   DEPRECATED("Use ActivationModelSmooth1Norm",
              explicit ActivationModelSmoothAbsTpl(
                  const std::size_t nr,
-                 const Scalar eps = Scalar(1.)) : Base(nr, eps){};)
+                 const Scalar delta = Scalar(1.)) : Base(nr, delta){};)
 };
 
 template <typename Scalar>

--- a/include/crocoddyl/core/activations/weighted-quadratic-barrier.hpp
+++ b/include/crocoddyl/core/activations/weighted-quadratic-barrier.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2025, University of Edinburgh, LAAS-CNRS,
+// Copyright (C) 2019-2026, University of Edinburgh, LAAS-CNRS,
 //                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
@@ -50,10 +50,9 @@ class ActivationModelWeightedQuadraticBarrierTpl
 
     d->rlb_min = (r - bounds_.lb).array().min(Scalar(0.));
     d->rub_max = (r - bounds_.ub).array().max(Scalar(0.));
-    d->rlb_min.array() *= weights_.array();
-    d->rub_max.array() *= weights_.array();
-    data->a_value = Scalar(0.5) * d->rlb_min.matrix().squaredNorm() +
-                    Scalar(0.5) * d->rub_max.matrix().squaredNorm();
+    data->a_value =
+        Scalar(0.5) * (weights_.array() * d->rlb_min.array().square()).sum() +
+        Scalar(0.5) * (weights_.array() * d->rub_max.array().square()).sum();
   };
 
   virtual void calcDiff(const std::shared_ptr<ActivationDataAbstract>& data,
@@ -64,18 +63,17 @@ class ActivationModelWeightedQuadraticBarrierTpl
                                       std::to_string(nr_) + ")");
     }
     std::shared_ptr<Data> d = std::static_pointer_cast<Data>(data);
-    data->Ar = (d->rlb_min + d->rub_max).matrix();
-    data->Ar.array() *= weights_.array();
+    data->Ar =
+        (weights_.array() * (d->rlb_min.array() + d->rub_max.array())).matrix();
 
     using pinocchio::internal::if_then_else;
-    for (Eigen::Index i = 0; i < data->Arr.cols(); i++) {
-      data->Arr.diagonal()[i] = if_then_else(
-          pinocchio::internal::LE, r[i] - bounds_.lb[i], Scalar(0.), Scalar(1.),
-          if_then_else(pinocchio::internal::GE, r[i] - bounds_.ub[i],
-                       Scalar(0.), Scalar(1.), Scalar(0.)));
+    for (Eigen::Index i = 0; i < data->Arr.rows(); ++i) {
+      const Scalar active =
+          if_then_else(pinocchio::internal::LT, r[i], bounds_.lb[i], Scalar(1.),
+                       if_then_else(pinocchio::internal::GT, r[i],
+                                    bounds_.ub[i], Scalar(1.), Scalar(0.)));
+      data->Arr.diagonal()[i] = active * weights_[i];
     }
-
-    data->Arr.diagonal().array() *= weights_.array();
   };
 
   virtual std::shared_ptr<ActivationDataAbstract> createData() override {

--- a/include/crocoddyl/core/activations/weighted-smooth-1norm.hpp
+++ b/include/crocoddyl/core/activations/weighted-smooth-1norm.hpp
@@ -20,15 +20,19 @@ namespace crocoddyl {
  * This activation function describes a weighted smooth representation of the
  * 1-norm of a residual vector:
  * \f[
- *   a(\mathbf{r}) = \sum_{i=0}^{nr-1} w_i\sqrt{\epsilon + r_i^2},
+ *   a(\mathbf{r}) =
+ *     \sum_{i=0}^{nr-1}
+ *       w_i\delta^2\left(\sqrt{1 + (r_i/\delta)^2} - 1\right),
  * \f]
- * where \f$\epsilon > 0\f$ is the smoothing factor, \f$w_i \geq 0\f$ is the
+ * where \f$\delta > 0\f$ is the smoothing scale, \f$w_i \geq 0\f$ is the
  * weight associated with the scalar residual \f$r_i\f$, and \f$nr\f$ is the
- * residual dimension. This activation represents a shifted and weighted
- * Charbonnier function.
+ * residual dimension. This is the weighted classical pseudo-Huber form,
+ * equivalently \f$w_i(\delta\sqrt{\delta^2 + r_i^2} - \delta^2)\f$.
  *
  * The weights scale the activation without changing the smoothing transition,
- * which occurs around \f$|r_i| = \sqrt{\epsilon}\f$.
+ * which occurs around \f$|r_i| = \delta\f$. The local quadratic approximation
+ * is \f$w_i r_i^2/2\f$ for every \f$\delta\f$, while the asymptotic slope of
+ * each term is \f$w_i\delta\f$.
  *
  * \sa `calc()`, `calcDiff()`, `createData()`
  */
@@ -51,14 +55,15 @@ class ActivationModelWeightedSmooth1NormTpl
    * @brief Initialize the weighted smooth-1norm activation model
    *
    * @param[in] weights  Nonnegative residual weights
-   * @param[in] eps      Strictly positive smoothing factor (default: 1)
+   * @param[in] delta    Strictly positive smoothing scale (default: 1)
    */
-  explicit ActivationModelWeightedSmooth1NormTpl(const VectorXs& weights,
-                                                 const Scalar eps = Scalar(1.))
-      : Base(weights.size()), weights_(weights), eps_(eps) {
+  explicit ActivationModelWeightedSmooth1NormTpl(
+      const VectorXs& weights, const Scalar delta = Scalar(1.))
+      : Base(weights.size()), weights_(weights), delta_(delta) {
     check_weights(weights_);
-    if (eps_ <= Scalar(0.)) {
-      throw_pretty("Invalid argument: eps should be a strictly positive value");
+    if (delta_ <= Scalar(0.)) {
+      throw_pretty(
+          "Invalid argument: delta should be a strictly positive value");
     }
   }
   virtual ~ActivationModelWeightedSmooth1NormTpl() = default;
@@ -78,8 +83,10 @@ class ActivationModelWeightedSmooth1NormTpl
     }
     std::shared_ptr<Data> d = std::static_pointer_cast<Data>(data);
 
-    d->a = (r.array().square() + eps_).sqrt().matrix();
-    data->a_value = weights_.dot(d->a);
+    d->a = (r.array().square() + delta_ * delta_).sqrt().matrix();
+    data->a_value =
+        delta_ *
+        (weights_.array() * r.array().square() / (d->a.array() + delta_)).sum();
   }
 
   /**
@@ -97,9 +104,9 @@ class ActivationModelWeightedSmooth1NormTpl
     }
     std::shared_ptr<Data> d = std::static_pointer_cast<Data>(data);
     const VectorXs a_inv = d->a.cwiseInverse();
-    data->Ar = weights_.cwiseProduct(r).cwiseProduct(a_inv);
+    data->Ar = delta_ * weights_.cwiseProduct(r).cwiseProduct(a_inv);
     data->Arr.diagonal() =
-        eps_ *
+        delta_ * delta_ * delta_ *
         weights_.cwiseProduct(a_inv.cwiseProduct(a_inv).cwiseProduct(a_inv));
   }
 
@@ -116,11 +123,11 @@ class ActivationModelWeightedSmooth1NormTpl
   ActivationModelWeightedSmooth1NormTpl<NewScalar> cast() const {
     typedef ActivationModelWeightedSmooth1NormTpl<NewScalar> ReturnType;
     return ReturnType(weights_.template cast<NewScalar>(),
-                      scalar_cast<NewScalar>(eps_));
+                      scalar_cast<NewScalar>(delta_));
   }
 
   const VectorXs& get_weights() const { return weights_; }
-  Scalar get_eps() const { return eps_; }
+  Scalar get_delta() const { return delta_; }
 
   void set_weights(const VectorXs& weights) {
     if (weights.size() != weights_.size()) {
@@ -138,8 +145,8 @@ class ActivationModelWeightedSmooth1NormTpl
    * @param[out] os  Output stream object
    */
   virtual void print(std::ostream& os) const override {
-    os << "ActivationModelWeightedSmooth1Norm {nr=" << nr_ << ", eps=" << eps_
-       << "}";
+    os << "ActivationModelWeightedSmooth1Norm {nr=" << nr_
+       << ", delta=" << delta_ << "}";
   }
 
  protected:
@@ -156,7 +163,7 @@ class ActivationModelWeightedSmooth1NormTpl
   }
 
   VectorXs weights_;  //!< Residual weights
-  Scalar eps_;        //!< Smoothing factor
+  Scalar delta_;      //!< Smoothing scale
 };
 
 template <typename _Scalar>
@@ -174,7 +181,7 @@ struct ActivationDataWeightedSmooth1NormTpl
       : Base(activation), a(VectorXs::Zero(activation->get_nr())) {}
   virtual ~ActivationDataWeightedSmooth1NormTpl() = default;
 
-  VectorXs a;  //!< Element-wise values \f$\sqrt{\epsilon + r_i^2}\f$
+  VectorXs a;  //!< Element-wise values \f$\sqrt{\delta^2 + r_i^2}\f$
 
   using Base::a_value;
   using Base::Ar;

--- a/include/crocoddyl/core/activations/weighted-smooth-1norm.hpp
+++ b/include/crocoddyl/core/activations/weighted-smooth-1norm.hpp
@@ -1,0 +1,191 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2026, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef CROCODDYL_CORE_ACTIVATIONS_WEIGHTED_SMOOTH_1NORM_HPP_
+#define CROCODDYL_CORE_ACTIVATIONS_WEIGHTED_SMOOTH_1NORM_HPP_
+
+#include "crocoddyl/core/activation-base.hpp"
+#include "crocoddyl/core/fwd.hpp"
+
+namespace crocoddyl {
+
+/**
+ * @brief Weighted smooth-1norm activation
+ *
+ * This activation function describes a weighted smooth representation of the
+ * 1-norm of a residual vector:
+ * \f[
+ *   a(\mathbf{r}) = \sum_{i=0}^{nr-1} w_i\sqrt{\epsilon + r_i^2},
+ * \f]
+ * where \f$\epsilon > 0\f$ is the smoothing factor, \f$w_i \geq 0\f$ is the
+ * weight associated with the scalar residual \f$r_i\f$, and \f$nr\f$ is the
+ * residual dimension. This activation represents a shifted and weighted
+ * Charbonnier function.
+ *
+ * The weights scale the activation without changing the smoothing transition,
+ * which occurs around \f$|r_i| = \sqrt{\epsilon}\f$.
+ *
+ * \sa `calc()`, `calcDiff()`, `createData()`
+ */
+template <typename _Scalar>
+class ActivationModelWeightedSmooth1NormTpl
+    : public ActivationModelAbstractTpl<_Scalar> {
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  CROCODDYL_DERIVED_CAST(ActivationModelBase,
+                         ActivationModelWeightedSmooth1NormTpl)
+
+  typedef _Scalar Scalar;
+  typedef MathBaseTpl<Scalar> MathBase;
+  typedef ActivationModelAbstractTpl<Scalar> Base;
+  typedef ActivationDataAbstractTpl<Scalar> ActivationDataAbstract;
+  typedef ActivationDataWeightedSmooth1NormTpl<Scalar> Data;
+  typedef typename MathBase::VectorXs VectorXs;
+
+  /**
+   * @brief Initialize the weighted smooth-1norm activation model
+   *
+   * @param[in] weights  Nonnegative residual weights
+   * @param[in] eps      Strictly positive smoothing factor (default: 1)
+   */
+  explicit ActivationModelWeightedSmooth1NormTpl(const VectorXs& weights,
+                                                 const Scalar eps = Scalar(1.))
+      : Base(weights.size()), weights_(weights), eps_(eps) {
+    check_weights(weights_);
+    if (eps_ <= Scalar(0.)) {
+      throw_pretty("Invalid argument: eps should be a strictly positive value");
+    }
+  }
+  virtual ~ActivationModelWeightedSmooth1NormTpl() = default;
+
+  /**
+   * @brief Compute the weighted smooth-1norm activation
+   *
+   * @param[in] data  Weighted smooth-1norm activation data
+   * @param[in] r     Residual vector \f$\mathbf{r}\in\mathbb{R}^{nr}\f$
+   */
+  virtual void calc(const std::shared_ptr<ActivationDataAbstract>& data,
+                    const Eigen::Ref<const VectorXs>& r) override {
+    if (static_cast<std::size_t>(r.size()) != nr_) {
+      throw_pretty(
+          "Invalid argument: " << "r has wrong dimension (it should be " +
+                                      std::to_string(nr_) + ")");
+    }
+    std::shared_ptr<Data> d = std::static_pointer_cast<Data>(data);
+
+    d->a = (r.array().square() + eps_).sqrt().matrix();
+    data->a_value = weights_.dot(d->a);
+  }
+
+  /**
+   * @brief Compute the activation derivatives
+   *
+   * @param[in] data  Weighted smooth-1norm activation data
+   * @param[in] r     Residual vector \f$\mathbf{r}\in\mathbb{R}^{nr}\f$
+   */
+  virtual void calcDiff(const std::shared_ptr<ActivationDataAbstract>& data,
+                        const Eigen::Ref<const VectorXs>& r) override {
+    if (static_cast<std::size_t>(r.size()) != nr_) {
+      throw_pretty(
+          "Invalid argument: " << "r has wrong dimension (it should be " +
+                                      std::to_string(nr_) + ")");
+    }
+    std::shared_ptr<Data> d = std::static_pointer_cast<Data>(data);
+    const VectorXs a_inv = d->a.cwiseInverse();
+    data->Ar = weights_.cwiseProduct(r).cwiseProduct(a_inv);
+    data->Arr.diagonal() =
+        eps_ *
+        weights_.cwiseProduct(a_inv.cwiseProduct(a_inv).cwiseProduct(a_inv));
+  }
+
+  /**
+   * @brief Create the weighted smooth-1norm activation data
+   *
+   * @return the activation data
+   */
+  virtual std::shared_ptr<ActivationDataAbstract> createData() override {
+    return std::allocate_shared<Data>(Eigen::aligned_allocator<Data>(), this);
+  }
+
+  template <typename NewScalar>
+  ActivationModelWeightedSmooth1NormTpl<NewScalar> cast() const {
+    typedef ActivationModelWeightedSmooth1NormTpl<NewScalar> ReturnType;
+    return ReturnType(weights_.template cast<NewScalar>(),
+                      scalar_cast<NewScalar>(eps_));
+  }
+
+  const VectorXs& get_weights() const { return weights_; }
+  Scalar get_eps() const { return eps_; }
+
+  void set_weights(const VectorXs& weights) {
+    if (weights.size() != weights_.size()) {
+      throw_pretty("Invalid argument: "
+                   << "weight vector has wrong dimension (it should be " +
+                          std::to_string(weights_.size()) + ")");
+    }
+    check_weights(weights);
+    weights_ = weights;
+  }
+
+  /**
+   * @brief Print relevant information of the weighted smooth-1norm model
+   *
+   * @param[out] os  Output stream object
+   */
+  virtual void print(std::ostream& os) const override {
+    os << "ActivationModelWeightedSmooth1Norm {nr=" << nr_ << ", eps=" << eps_
+       << "}";
+  }
+
+ protected:
+  using Base::nr_;  //!< Dimension of the residual vector
+
+ private:
+  static void check_weights(const VectorXs& weights) {
+    for (Eigen::Index i = 0; i < weights.size(); ++i) {
+      if (weights[i] < Scalar(0.)) {
+        throw_pretty(
+            "Invalid argument: weights should contain nonnegative values");
+      }
+    }
+  }
+
+  VectorXs weights_;  //!< Residual weights
+  Scalar eps_;        //!< Smoothing factor
+};
+
+template <typename _Scalar>
+struct ActivationDataWeightedSmooth1NormTpl
+    : public ActivationDataAbstractTpl<_Scalar> {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  typedef _Scalar Scalar;
+  typedef ActivationDataAbstractTpl<Scalar> Base;
+  typedef MathBaseTpl<Scalar> MathBase;
+  typedef typename MathBase::VectorXs VectorXs;
+
+  template <typename Activation>
+  explicit ActivationDataWeightedSmooth1NormTpl(Activation* const activation)
+      : Base(activation), a(VectorXs::Zero(activation->get_nr())) {}
+  virtual ~ActivationDataWeightedSmooth1NormTpl() = default;
+
+  VectorXs a;  //!< Element-wise values \f$\sqrt{\epsilon + r_i^2}\f$
+
+  using Base::a_value;
+  using Base::Ar;
+  using Base::Arr;
+};
+
+}  // namespace crocoddyl
+
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_CLASS(
+    crocoddyl::ActivationModelWeightedSmooth1NormTpl)
+CROCODDYL_DECLARE_EXTERN_TEMPLATE_STRUCT(
+    crocoddyl::ActivationDataWeightedSmooth1NormTpl)
+
+#endif  // CROCODDYL_CORE_ACTIVATIONS_WEIGHTED_SMOOTH_1NORM_HPP_

--- a/include/crocoddyl/core/fwd.hpp
+++ b/include/crocoddyl/core/fwd.hpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2025, LAAS-CNRS, University of Edinburgh,
+// Copyright (C) 2019-2026, LAAS-CNRS, University of Edinburgh,
 //                          Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
 // All rights reserved.
@@ -154,6 +154,11 @@ template <typename Scalar>
 class ActivationModelSmooth1NormTpl;
 template <typename Scalar>
 struct ActivationDataSmooth1NormTpl;
+
+template <typename Scalar>
+class ActivationModelWeightedSmooth1NormTpl;
+template <typename Scalar>
+struct ActivationDataWeightedSmooth1NormTpl;
 
 template <typename Scalar>
 class ActivationModelSmooth2NormTpl;
@@ -408,6 +413,10 @@ DEPRECATED(
     typedef ActivationDataSmooth1NormTpl<double> ActivationDataSmoothAbs;)
 typedef ActivationModelSmooth1NormTpl<double> ActivationModelSmooth1Norm;
 typedef ActivationDataSmooth1NormTpl<double> ActivationDataSmooth1Norm;
+typedef ActivationModelWeightedSmooth1NormTpl<double>
+    ActivationModelWeightedSmooth1Norm;
+typedef ActivationDataWeightedSmooth1NormTpl<double>
+    ActivationDataWeightedSmooth1Norm;
 typedef ActivationModelSmooth2NormTpl<double> ActivationModelSmooth2Norm;
 typedef ActivationDataSmooth2NormTpl<double> ActivationDataSmooth2Norm;
 typedef ActivationModel2NormBarrierTpl<double> ActivationModel2NormBarrier;

--- a/include/crocoddyl/core/numdiff/activation.hpp
+++ b/include/crocoddyl/core/numdiff/activation.hpp
@@ -84,9 +84,11 @@ class ActivationModelNumDiffTpl : public ActivationModelAbstractTpl<_Scalar> {
 
  private:
   std::shared_ptr<Base>
-      model_;     //!< model to compute the finite differentiation from
-  Scalar e_jac_;  //!< Constant used for computing disturbances in Jacobian
-                  //!< calculation
+      model_;      //!< model to compute the finite differentiation from
+  Scalar e_jac_;   //!< Constant used for computing disturbances in Jacobian
+                   //!< calculation
+  Scalar e_hess_;  //!< Constant used for computing disturbances in Hessian
+                   //!< calculation
 
  protected:
   using Base::nr_;
@@ -112,11 +114,9 @@ struct ActivationDataNumDiffTpl : public ActivationDataAbstractTpl<_Scalar> {
   explicit ActivationDataNumDiffTpl(Model<Scalar>* const model)
       : Base(model),
         dr(model->get_model()->get_nr()),
-        rp(model->get_model()->get_nr()),
-        Arr_(Arr.rows(), Arr.cols()) {
+        rp(model->get_model()->get_nr()) {
     dr.setZero();
     rp.setZero();
-    Arr_.setZero();
     data_0 = model->get_model()->createData();
     const std::size_t nr = model->get_model()->get_nr();
     data_rp.clear();
@@ -125,7 +125,7 @@ struct ActivationDataNumDiffTpl : public ActivationDataAbstractTpl<_Scalar> {
     }
 
     data_r2p.clear();
-    for (std::size_t i = 0; i < 4; ++i) {
+    for (std::size_t i = 0; i < 2; ++i) {
       data_r2p.push_back(model->get_model()->createData());
     }
   }
@@ -137,9 +137,9 @@ struct ActivationDataNumDiffTpl : public ActivationDataAbstractTpl<_Scalar> {
   std::vector<std::shared_ptr<Base> >
       data_rp;  //!< The temporary data associated with the input variation
   std::vector<std::shared_ptr<Base> >
-      data_r2p;  //!< The temporary data associated with the input variation
+      data_r2p;  //!< Temporary data for positive and negative Hessian
+                 //!< disturbances
 
-  MatrixXs Arr_;
   using Base::a_value;
   using Base::Ar;
   using Base::Arr;

--- a/include/crocoddyl/core/numdiff/activation.hxx
+++ b/include/crocoddyl/core/numdiff/activation.hxx
@@ -14,7 +14,9 @@ ActivationModelNumDiffTpl<Scalar>::ActivationModelNumDiffTpl(
     std::shared_ptr<Base> model)
     : Base(model->get_nr()),
       model_(model),
-      e_jac_(sqrt(Scalar(2.0) * std::numeric_limits<Scalar>::epsilon())) {}
+      e_jac_(sqrt(Scalar(2.0) * std::numeric_limits<Scalar>::epsilon())) {
+  e_hess_ = sqrt(Scalar(2.0) * e_jac_);
+}
 
 template <typename Scalar>
 ActivationModelNumDiffTpl<Scalar>::~ActivationModelNumDiffTpl() {}
@@ -58,9 +60,24 @@ void ActivationModelNumDiffTpl<Scalar>::calcDiff(
     data->Ar(i_r) = (data_nd->data_rp[i_r]->a_value - a_value0) / rh_jac;
   }
 
-  // Computing the d^2 action(r) / dr^2
-  data_nd->Arr_.noalias() = data->Ar * data->Ar.transpose();
-  data->Arr.diagonal() = data_nd->Arr_.diagonal();
+  // Computing the diagonal of d^2 activation(r) / dr^2
+  const Scalar rh_hess = e_hess_ * std::max(Scalar(1.), r.norm());
+  const Scalar rh_hess_squared = rh_hess * rh_hess;
+  data_nd->rp = r;
+  for (unsigned int i_r = 0; i_r < nr; ++i_r) {
+    data_nd->rp(i_r) += rh_hess;
+    model_->calc(data_nd->data_r2p[0], data_nd->rp);
+    const Scalar a_value_plus = data_nd->data_r2p[0]->a_value;
+
+    data_nd->rp(i_r) -= Scalar(2.) * rh_hess;
+    model_->calc(data_nd->data_r2p[1], data_nd->rp);
+    const Scalar a_value_minus = data_nd->data_r2p[1]->a_value;
+
+    data_nd->rp(i_r) += rh_hess;
+    data->Arr.diagonal()(i_r) =
+        (a_value_plus - Scalar(2.) * a_value0 + a_value_minus) /
+        rh_hess_squared;
+  }
 }
 
 template <typename Scalar>
@@ -96,6 +113,7 @@ void ActivationModelNumDiffTpl<Scalar>::set_disturbance(
     throw_pretty("Invalid argument: " << "Disturbance constant is positive");
   }
   e_jac_ = disturbance;
+  e_hess_ = sqrt(Scalar(2.0) * e_jac_);
 }
 
 }  // namespace crocoddyl

--- a/include/crocoddyl/multibody/friction-cone.hxx
+++ b/include/crocoddyl/multibody/friction-cone.hxx
@@ -151,16 +151,10 @@ template <typename Scalar>
 template <typename NewScalar>
 FrictionConeTpl<NewScalar> FrictionConeTpl<Scalar>::cast() const {
   typedef FrictionConeTpl<NewScalar> ReturnType;
-  ReturnType ret;
-  ret.nf_ = nf_;
-  ret.A_ = A_.template cast<NewScalar>();
-  ret.ub_ = ub_.template cast<NewScalar>();
-  ret.lb_ = lb_.template cast<NewScalar>();
-  ret.R_ = R_.template cast<NewScalar>();
-  ret.mu_ = scalar_cast<NewScalar>(mu_);
-  ret.inner_appr_ = inner_appr_;
-  ret.min_nforce_ = scalar_cast<NewScalar>(min_nforce_);
-  ret.max_nforce_ = scalar_cast<NewScalar>(max_nforce_);
+
+  ReturnType ret(R_.template cast<NewScalar>(), scalar_cast<NewScalar>(mu_),
+                 nf_, inner_appr_, scalar_cast<NewScalar>(min_nforce_),
+                 scalar_cast<NewScalar>(max_nforce_));
   return ret;
 }
 

--- a/notebooks/run_notebook.py
+++ b/notebooks/run_notebook.py
@@ -3,6 +3,7 @@ import re
 import sys
 
 import nbformat
+from nbclient.exceptions import CellExecutionError
 from nbconvert.preprocessors import ExecutePreprocessor
 
 
@@ -46,8 +47,8 @@ def run_notebook(notebook_path):
         ep.preprocess(notebook_content, {"metadata": {"path": "./"}})
         # Optionally: You can extract results and verify them here
         print(f"Notebook {notebook_path} executed successfully.")
-    except Exception as e:
-        print(f"Error executing notebook {notebook_path}: {e!s}")
+    except CellExecutionError as err:
+        print(f"Error executing notebook {notebook_path}: {err}")
         sys.exit(1)
 
 

--- a/src/core/activations/weighted-smooth-1norm.cpp.in
+++ b/src/core/activations/weighted-smooth-1norm.cpp.in
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2026, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+// Auto-generated file for @SCALAR_TYPE@
+#include "crocoddyl/core/activations/weighted-smooth-1norm.hpp"
+
+namespace crocoddyl {
+
+template class CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActivationModelWeightedSmooth1NormTpl<@SCALAR_TYPE@>;
+template struct CROCODDYL_EXPLICIT_INSTANTIATION_DEFINITION_DLLAPI
+    ActivationDataWeightedSmooth1NormTpl<@SCALAR_TYPE@>;
+
+}  // namespace crocoddyl

--- a/unittest/bindings/factory.py
+++ b/unittest/bindings/factory.py
@@ -1110,7 +1110,7 @@ class FrameVelocityCostDataDerived(crocoddyl.CostDataAbstract):
 
 class Contact1DModelDerived(crocoddyl.ContactModelAbstract):
     def __init__(
-        self, state, id, xref, type=pinocchio.ReferenceFrame.LOCAL, gains=[0.0, 0.0]
+        self, state, id, xref, type=pinocchio.ReferenceFrame.LOCAL, gains=(0.0, 0.0)
     ):
         crocoddyl.ContactModelAbstract.__init__(self, state, type, 1)
         self.id = id
@@ -1236,7 +1236,7 @@ class Contact1DModelDerived(crocoddyl.ContactModelAbstract):
 
 class Contact3DModelDerived(crocoddyl.ContactModelAbstract):
     def __init__(
-        self, state, id, xref, type=pinocchio.ReferenceFrame.LOCAL, gains=[0.0, 0.0]
+        self, state, id, xref, type=pinocchio.ReferenceFrame.LOCAL, gains=(0.0, 0.0)
     ):
         crocoddyl.ContactModelAbstract.__init__(self, state, type, 3)
         self.id = id
@@ -1398,7 +1398,7 @@ class Contact3DDataDerived(crocoddyl.ContactDataAbstract):
 
 class Contact6DModelDerived(crocoddyl.ContactModelAbstract):
     def __init__(
-        self, state, id, Mref, type=pinocchio.ReferenceFrame.LOCAL, gains=[0.0, 0.0]
+        self, state, id, Mref, type=pinocchio.ReferenceFrame.LOCAL, gains=(0.0, 0.0)
     ):
         crocoddyl.ContactModelAbstract.__init__(self, state, type, 6)
         self.id = id

--- a/unittest/bindings/test_copy.py
+++ b/unittest/bindings/test_copy.py
@@ -9,9 +9,9 @@ import crocoddyl
 
 
 class CopyModelTestCase(unittest.TestCase):
-    MODEL = list()
+    MODEL = []
     DATA = False
-    COLLECTOR = list()
+    COLLECTOR = []
 
     def test_copy(self):
         Mcopy = copy.copy(self.MODEL)
@@ -49,7 +49,7 @@ class CopyModelTestCase(unittest.TestCase):
 
 
 class ActionsTest(CopyModelTestCase):
-    MODEL = list()
+    MODEL = []
     DATA = True
     # core actions
     MODEL.append(crocoddyl.ActionModelUnicycle())
@@ -58,27 +58,27 @@ class ActionsTest(CopyModelTestCase):
     # multibody actions
     state = crocoddyl.StateMultibody(pinocchio.buildSampleModelHumanoidRandom())
     actuation = crocoddyl.ActuationModelFloatingBase(state)
-    cost = crocoddyl.CostModelSum(state, actuation.nu)
+    cost_fwd = crocoddyl.CostModelSum(state, actuation.nu)
     impulse = crocoddyl.ImpulseModelMultiple(state)
-    contact = crocoddyl.ContactModelMultiple(state, actuation.nu)
-    MODEL.append(crocoddyl.ActionModelImpulseFwdDynamics(state, impulse, cost))
+    contact_fwd = crocoddyl.ContactModelMultiple(state, actuation.nu)
+    MODEL.append(crocoddyl.ActionModelImpulseFwdDynamics(state, impulse, cost_fwd))
     MODEL.append(
         crocoddyl.DifferentialActionModelContactFwdDynamics(
-            state, actuation, contact, cost
+            state, actuation, contact_fwd, cost_fwd
         )
     )
     MODEL.append(
-        crocoddyl.DifferentialActionModelFreeFwdDynamics(state, actuation, cost)
+        crocoddyl.DifferentialActionModelFreeFwdDynamics(state, actuation, cost_fwd)
     )
-    cost = crocoddyl.CostModelSum(state, state.nv)
-    contact = crocoddyl.ContactModelMultiple(state, state.nv)
+    cost_inv = crocoddyl.CostModelSum(state, state.nv)
+    contact_inv = crocoddyl.ContactModelMultiple(state, state.nv)
     MODEL.append(
         crocoddyl.DifferentialActionModelContactInvDynamics(
-            state, actuation, contact, cost
+            state, actuation, contact_inv, cost_inv
         )
     )
     MODEL.append(
-        crocoddyl.DifferentialActionModelFreeInvDynamics(state, actuation, cost)
+        crocoddyl.DifferentialActionModelFreeInvDynamics(state, actuation, cost_inv)
     )
     # integrated actions
     MODEL.append(
@@ -101,7 +101,7 @@ class ActionsTest(CopyModelTestCase):
 
 
 class StatesTest(CopyModelTestCase):
-    MODEL = list()
+    MODEL = []
     # core states
     MODEL.append(crocoddyl.StateVector(2))
     MODEL.append(crocoddyl.StateNumDiff(crocoddyl.StateVector(2)))
@@ -110,9 +110,9 @@ class StatesTest(CopyModelTestCase):
 
 
 class ResidualsTest(CopyModelTestCase):
-    MODEL = list()
+    MODEL = []
     DATA = True
-    COLLECTOR = list()
+    COLLECTOR = []
     # core residuals
     state = crocoddyl.StateMultibody(pinocchio.buildSampleModelHumanoidRandom())
     actuation = crocoddyl.ActuationModelFloatingBase(state)
@@ -200,7 +200,7 @@ class ResidualsTest(CopyModelTestCase):
 
 
 class ActivationsTest(CopyModelTestCase):
-    MODEL = list()
+    MODEL = []
     DATA = True
     bounds = crocoddyl.ActivationBounds(np.zeros(2), np.ones(2), 0.1)
     MODEL.append(crocoddyl.ActivationModel2NormBarrier(2))
@@ -218,9 +218,9 @@ class ActivationsTest(CopyModelTestCase):
 
 
 class CostsTest(CopyModelTestCase):
-    MODEL = list()
+    MODEL = []
     DATA = True
-    COLLECTOR = list()
+    COLLECTOR = []
     state = crocoddyl.StateVector(2)
     residual = crocoddyl.ResidualModelControl(crocoddyl.StateVector(2))
     activation = crocoddyl.ActivationModelWeightedQuad(np.ones(1))
@@ -231,9 +231,9 @@ class CostsTest(CopyModelTestCase):
 
 
 class ConstraintsTest(CopyModelTestCase):
-    MODEL = list()
+    MODEL = []
     DATA = True
-    COLLECTOR = list()
+    COLLECTOR = []
     state = crocoddyl.StateVector(2)
     residual = crocoddyl.ResidualModelControl(crocoddyl.StateVector(2))
     MODEL.append(crocoddyl.ConstraintModelResidual(state, residual))
@@ -243,7 +243,7 @@ class ConstraintsTest(CopyModelTestCase):
 
 
 class ControlsTest(CopyModelTestCase):
-    MODEL = list()
+    MODEL = []
     DATA = True
     MODEL.append(crocoddyl.ControlParametrizationModelPolyZero(2))
     MODEL.append(crocoddyl.ControlParametrizationModelPolyOne(2))
@@ -253,7 +253,7 @@ class ControlsTest(CopyModelTestCase):
 
 
 class DataCollectorsTest(CopyModelTestCase):
-    MODEL = list()
+    MODEL = []
     DATA = False
     # core collectors
     state = crocoddyl.StateMultibody(pinocchio.buildSampleModelHumanoidRandom())
@@ -286,7 +286,7 @@ class DataCollectorsTest(CopyModelTestCase):
 
 
 class ActuationsTest(CopyModelTestCase):
-    MODEL = list()
+    MODEL = []
     DATA = True
     # core actuations
     state = crocoddyl.StateMultibody(pinocchio.buildSampleModelHumanoidRandom())
@@ -325,14 +325,13 @@ class ActuationsTest(CopyModelTestCase):
             crocoddyl.ThrusterType.CW,
         ),
     ]
-    actuation = crocoddyl.ActuationModelFloatingBaseThrusters(state, ps)
     MODEL.append(crocoddyl.ActuationModelFloatingBaseThrusters(state, ps))
 
 
 class ContactsTest(CopyModelTestCase):
-    MODEL = list()
+    MODEL = []
     DATA = True
-    COLLECTOR = list()
+    COLLECTOR = []
     state = crocoddyl.StateMultibody(pinocchio.buildSampleModelHumanoidRandom())
     actuation = crocoddyl.ActuationModelFloatingBase(state)
     frame_id = state.pinocchio.getFrameId("rleg6_joint")
@@ -377,14 +376,14 @@ class ContactsTest(CopyModelTestCase):
 
 
 class ConesTest(CopyModelTestCase):
-    MODEL = list()
+    MODEL = []
     MODEL.append(crocoddyl.FrictionCone())
     MODEL.append(crocoddyl.WrenchCone())
     MODEL.append(crocoddyl.CoPSupport())
 
 
 class ProblemAndSolversTest(CopyModelTestCase):
-    MODEL = list()
+    MODEL = []
     m = crocoddyl.ActionModelLQR(2, 2)
     problem = crocoddyl.ShootingProblem(m.state.zero(), [m] * 10, m)
     MODEL.append(problem)

--- a/unittest/factory/activation.cpp
+++ b/unittest/factory/activation.cpp
@@ -81,7 +81,7 @@ ActivationModelFactory::create(ActivationModelTypes::Type activation_type,
   Eigen::VectorXd nonnegative_weights = weights.cwiseAbs();
   double alpha = fabs(Eigen::VectorXd::Random(1)[0]);
   double eps = fabs(Eigen::VectorXd::Random(1)[0]);
-  double positive_eps = eps + 1e-3;
+  double delta = fabs(Eigen::VectorXd::Random(1)[0]) + 1e-3;
   bool hessian = random_boolean();
 
   switch (activation_type) {
@@ -98,12 +98,12 @@ ActivationModelFactory::create(ActivationModelTypes::Type activation_type,
       break;
     case ActivationModelTypes::ActivationModelSmooth1Norm:
       activation =
-          std::make_shared<crocoddyl::ActivationModelSmooth1Norm>(nr, eps);
+          std::make_shared<crocoddyl::ActivationModelSmooth1Norm>(nr, delta);
       break;
     case ActivationModelTypes::ActivationModelWeightedSmooth1Norm:
       activation =
           std::make_shared<crocoddyl::ActivationModelWeightedSmooth1Norm>(
-              nonnegative_weights, positive_eps);
+              nonnegative_weights, delta);
       break;
     case ActivationModelTypes::ActivationModelSmooth2Norm:
       activation =

--- a/unittest/factory/activation.cpp
+++ b/unittest/factory/activation.cpp
@@ -18,6 +18,7 @@
 #include "crocoddyl/core/activations/smooth-2norm.hpp"
 #include "crocoddyl/core/activations/weighted-quadratic-barrier.hpp"
 #include "crocoddyl/core/activations/weighted-quadratic.hpp"
+#include "crocoddyl/core/activations/weighted-smooth-1norm.hpp"
 
 namespace crocoddyl {
 namespace unittest {
@@ -38,6 +39,9 @@ std::ostream& operator<<(std::ostream& os, ActivationModelTypes::Type type) {
       break;
     case ActivationModelTypes::ActivationModelSmooth1Norm:
       os << "ActivationModelSmooth1Norm";
+      break;
+    case ActivationModelTypes::ActivationModelWeightedSmooth1Norm:
+      os << "ActivationModelWeightedSmooth1Norm";
       break;
     case ActivationModelTypes::ActivationModelSmooth2Norm:
       os << "ActivationModelSmooth2Norm";
@@ -74,8 +78,10 @@ ActivationModelFactory::create(ActivationModelTypes::Type activation_type,
   Eigen::VectorXd ub =
       lb + Eigen::VectorXd::Ones(nr) + Eigen::VectorXd::Random(nr);
   Eigen::VectorXd weights = 1. * Eigen::VectorXd::Random(nr);
+  Eigen::VectorXd nonnegative_weights = weights.cwiseAbs();
   double alpha = fabs(Eigen::VectorXd::Random(1)[0]);
   double eps = fabs(Eigen::VectorXd::Random(1)[0]);
+  double positive_eps = eps + 1e-3;
   bool hessian = random_boolean();
 
   switch (activation_type) {
@@ -93,6 +99,11 @@ ActivationModelFactory::create(ActivationModelTypes::Type activation_type,
     case ActivationModelTypes::ActivationModelSmooth1Norm:
       activation =
           std::make_shared<crocoddyl::ActivationModelSmooth1Norm>(nr, eps);
+      break;
+    case ActivationModelTypes::ActivationModelWeightedSmooth1Norm:
+      activation =
+          std::make_shared<crocoddyl::ActivationModelWeightedSmooth1Norm>(
+              nonnegative_weights, positive_eps);
       break;
     case ActivationModelTypes::ActivationModelSmooth2Norm:
       activation =

--- a/unittest/factory/activation.hpp
+++ b/unittest/factory/activation.hpp
@@ -21,6 +21,7 @@ struct ActivationModelTypes {
     ActivationModelQuadFlatExp,
     ActivationModelQuadFlatLog,
     ActivationModelSmooth1Norm,
+    ActivationModelWeightedSmooth1Norm,
     ActivationModelSmooth2Norm,
     ActivationModelWeightedQuad,
     ActivationModelQuadraticBarrier,

--- a/unittest/test_actions.cpp
+++ b/unittest/test_actions.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2025, LAAS-CNRS, New York University,
+// Copyright (C) 2019-2026, LAAS-CNRS, New York University,
 //                          Max Planck Gesellschaft, University of Edinburgh,
 //                          INRIA, Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
@@ -165,7 +165,7 @@ void test_partial_derivatives_against_numdiff(
       casted_data_num_diff = casted_model_num_diff.createData();
   casted_model_num_diff.calc(casted_data_num_diff, x_f, u_f);
   casted_model_num_diff.calcDiff(casted_data_num_diff, x_f, u_f);
-  tol_f = 80.0f * sqrt(casted_model_num_diff.get_disturbance());
+  tol_f = 300.0f * sqrt(casted_model_num_diff.get_disturbance());
   BOOST_CHECK((casted_data->Gx - casted_data_num_diff->Gx).isZero(tol_f));
   BOOST_CHECK((casted_data->Gu - casted_data_num_diff->Gu).isZero(tol_f));
   BOOST_CHECK((casted_data->Hx - casted_data_num_diff->Hx).isZero(tol_f));

--- a/unittest/test_activations.cpp
+++ b/unittest/test_activations.cpp
@@ -98,9 +98,8 @@ void test_partial_derivatives_against_numdiff(
   double tol = std::pow(model_num_diff.get_disturbance(), 1. / 3.);
   BOOST_CHECK(std::abs(data->a_value - data_num_diff->a_value) < tol);
   BOOST_CHECK((data->Ar - data_num_diff->Ar).isZero(tol));
-
-  // numerical differentiation of the Hessian is not good enough to be tested.
-  // BOOST_CHECK((data->Arr - data_num_diff->Arr).isMuchSmallerThan(1.0, tol));
+  BOOST_CHECK(
+      (data->Arr.diagonal() - data_num_diff->Arr.diagonal()).isZero(tol));
 
   // Checking that casted computation is the same
   const std::shared_ptr<crocoddyl::ActivationModelAbstractTpl<float>>&

--- a/unittest/test_activations.cpp
+++ b/unittest/test_activations.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (C) 2019-2025, LAAS-CNRS, New York University,
+// Copyright (C) 2019-2026, LAAS-CNRS, New York University,
 //                          Max Planck Gesellschaft, University of Edinburgh,
 //                          INRIA, Heriot-Watt University
 // Copyright note valid unless otherwise stated in individual files.
@@ -12,6 +12,10 @@
 #define BOOST_TEST_ALTERNATIVE_INIT_API
 
 #include "crocoddyl/core/activations/quadratic-barrier.hpp"
+#include "crocoddyl/core/activations/quadratic.hpp"
+#include "crocoddyl/core/activations/smooth-1norm.hpp"
+#include "crocoddyl/core/activations/weighted-quadratic.hpp"
+#include "crocoddyl/core/activations/weighted-smooth-1norm.hpp"
 #include "factory/activation.hpp"
 #include "unittest_common.hpp"
 
@@ -115,6 +119,68 @@ void test_partial_derivatives_against_numdiff(
   BOOST_CHECK((data->Ar.cast<float>() - casted_data->Ar).isZero(tol_f));
 }
 
+void test_activation_is_zero_at_zero(
+    ActivationModelTypes::Type activation_type) {
+  ActivationModelFactory factory;
+  const std::shared_ptr<crocoddyl::ActivationModelAbstract>& model =
+      factory.create(activation_type);
+  const Eigen::VectorXd r =
+      Eigen::VectorXd::Zero(static_cast<Eigen::Index>(model->get_nr()));
+  const std::shared_ptr<crocoddyl::ActivationDataAbstract>& data =
+      model->createData();
+  if (activation_type != ActivationModelTypes::ActivationModelSmooth2Norm &
+      activation_type !=
+          ActivationModelTypes::ActivationModelWeightedQuadraticBarrier &
+      activation_type != ActivationModelTypes::ActivationModelQuadraticBarrier &
+      activation_type != ActivationModelTypes::ActivationModel2NormBarrier) {
+    model->calc(data, r);
+    BOOST_CHECK_SMALL(data->a_value, std::numeric_limits<double>::epsilon());
+  }
+}
+
+void check_activation_local_quadratic_response(
+    crocoddyl::ActivationModelAbstract& model,
+    crocoddyl::ActivationModelAbstract& quadratic_model) {
+  const Eigen::VectorXd r =
+      Eigen::VectorXd::Zero(static_cast<Eigen::Index>(model.get_nr()));
+  const std::shared_ptr<crocoddyl::ActivationDataAbstract>& data =
+      model.createData();
+  const std::shared_ptr<crocoddyl::ActivationDataAbstract>& quadratic_data =
+      quadratic_model.createData();
+  model.calc(data, r);
+  model.calcDiff(data, r);
+  quadratic_model.calc(quadratic_data, r);
+  quadratic_model.calcDiff(quadratic_data, r);
+  const Eigen::MatrixXd hessian =
+      crocoddyl::ActivationDataAbstract::getHessianMatrix(*data);
+  const Eigen::MatrixXd quadratic_hessian =
+      crocoddyl::ActivationDataAbstract::getHessianMatrix(*quadratic_data);
+  BOOST_CHECK(hessian.isApprox(quadratic_hessian));
+}
+
+void test_smooth_1norm_properties() {
+  const double delta = 0.25;
+  crocoddyl::ActivationModelSmooth1Norm model(3, delta);
+  crocoddyl::ActivationModelSmooth1Norm large_delta_model(3, 100.);
+  crocoddyl::ActivationModelQuad quadratic_model(3);
+  BOOST_CHECK_EQUAL(model.get_delta(), delta);
+  check_activation_local_quadratic_response(model, quadratic_model);
+  check_activation_local_quadratic_response(large_delta_model, quadratic_model);
+}
+
+void test_weighted_smooth_1norm_properties() {
+  Eigen::VectorXd weights(3);
+  weights << 0.5, 2., 4.;
+  const double delta = 0.25;
+  crocoddyl::ActivationModelWeightedSmooth1Norm model(weights, delta);
+  crocoddyl::ActivationModelWeightedSmooth1Norm large_delta_model(weights,
+                                                                  100.);
+  crocoddyl::ActivationModelWeightedQuad quadratic_model(weights);
+  BOOST_CHECK_EQUAL(model.get_delta(), delta);
+  check_activation_local_quadratic_response(model, quadratic_model);
+  check_activation_local_quadratic_response(large_delta_model, quadratic_model);
+}
+
 void test_activation_bounds_with_infinity() {
   Eigen::VectorXd lb(1);
   Eigen::VectorXd ub(1);
@@ -150,6 +216,8 @@ void register_unit_tests(ActivationModelTypes::Type activation_type) {
       boost::bind(&test_calc_returns_a_value, activation_type)));
   ts->add(BOOST_TEST_CASE(
       boost::bind(&test_partial_derivatives_against_numdiff, activation_type)));
+  ts->add(BOOST_TEST_CASE(
+      boost::bind(&test_activation_is_zero_at_zero, activation_type)));
   framework::master_test_suite().add(ts);
 }
 
@@ -164,11 +232,25 @@ bool register_bounds_unit_test() {
   return true;
 }
 
+bool register_smooth_1norm_unit_tests() {
+  test_suite* smooth_ts =
+      BOOST_TEST_SUITE("test_ActivationModelSmooth1NormProperties");
+  smooth_ts->add(BOOST_TEST_CASE(&test_smooth_1norm_properties));
+  framework::master_test_suite().add(smooth_ts);
+
+  test_suite* ts =
+      BOOST_TEST_SUITE("test_ActivationModelWeightedSmooth1NormProperties");
+  ts->add(BOOST_TEST_CASE(&test_weighted_smooth_1norm_properties));
+  framework::master_test_suite().add(ts);
+  return true;
+}
+
 bool init_function() {
   for (size_t i = 0; i < ActivationModelTypes::all.size(); ++i) {
     register_unit_tests(ActivationModelTypes::all[i]);
   }
   register_bounds_unit_test();
+  register_smooth_1norm_unit_tests();
   return true;
 }
 

--- a/unittest/test_contact_constraints.cpp
+++ b/unittest/test_contact_constraints.cpp
@@ -72,7 +72,9 @@ void test_partial_derivatives_against_contact_numdiff(
   model->calcDiff(data, x, u);
   casted_model->calc(casted_data, x_f, u_f);
   casted_model->calcDiff(casted_data, x_f, u_f);
-  float tol_f = 10.f * std::sqrt(2.0f * std::numeric_limits<float>::epsilon());
+  float tol_f = 20.f * std::sqrt(2.0f * std::numeric_limits<float>::epsilon());
+  std::cout << "tol_f: " << tol_f << std::endl;
+  //   std::cout << data->Gx.cast<float>() - casted_data->Gx << std::endl;
   BOOST_CHECK((data->Gx.cast<float>() - casted_data->Gx).isZero(tol_f));
   BOOST_CHECK((data->Gu.cast<float>() - casted_data->Gu).isZero(tol_f));
   BOOST_CHECK((data->Hx.cast<float>() - casted_data->Hx).isZero(tol_f));

--- a/unittest/testutils.py
+++ b/unittest/testutils.py
@@ -6,6 +6,7 @@ from pinocchio.utils import zero
 
 EPS = np.finfo(float).eps
 NUMDIFF_MODIFIER = 1e4
+DEFAULT_NUMDIFF_STEP = np.sqrt(2 * EPS)
 
 
 class NumDiffException(Exception):
@@ -27,7 +28,7 @@ def assertNumDiff(A, B, threshold):
         )
 
 
-def df_dx(func, x, h=np.sqrt(2 * EPS)):
+def df_dx(func, x, h=DEFAULT_NUMDIFF_STEP):
     """Perform df/dx by num_diff.
     :params func: function to differentiate f : np.matrix -> np.matrix
     :params x: value at which f is differentiated. type np.matrix
@@ -45,7 +46,7 @@ def df_dx(func, x, h=np.sqrt(2 * EPS)):
     return res
 
 
-def df_dq(model, func, q, h=np.sqrt(2 * EPS)):
+def df_dq(model, func, q, h=DEFAULT_NUMDIFF_STEP):
     """Perform df/dq by num_diff. q is in the lie manifold.
     :params func: function to differentiate f : np.matrix -> np.matrix
     :params q: configuration value at which f is differentiated. type np.matrix


### PR DESCRIPTION
This PR introduces a weighted smooth L1 activation function, based on the classical pseudo-Huber loss. The new activation allows users to assign independent weights to each residual while preserving the smooth, robust behaviour of the pseudo-Huber formulation.

In addition, I revisited the existing `ActivationModelSmooth1Norm`. Although it is intended to represent a pseudo-Huber function, its formulation omits the standard scaling and offset terms. As a result, tuning is less intuitive, and it is not possible to recover the equivalent quadratic behaviour around the origin without additional adjustments. This PR updates the implementation to follow the conventional pseudo-Huber formulation, making its behaviour easier to interpret and tune.

Finally, while working on these changes, I identified incorrect Hessian implementations in both `ActivationModelSmooth2Norm` and `ActivationModelWeightedQuadraticBarrier`. Since these second-order derivatives are used by our solvers, this constitutes a significant bug. To prevent similar issues in the future, I extended the activation numerical differentiation class to validate Hessians as well, and added corresponding unit tests.