### PR TITLE
[bugfix] Preserve solver feasibility state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+* Fixed solver feasibility propagation so BoxFDDP applies box-QP constraints to feasible warm starts in https://github.com/loco-3d/crocoddyl/pull/1534
 * Introduced task-convergence residuals, guidance models, and multibody task support in https://github.com/loco-3d/crocoddyl/pull/1529
 * :warning: BREAKING: `ActivationModelSmooth1Norm` and `ActivationModelWeightedSmooth1Norm` now use the classical pseudo-Huber form `delta^2 * (sqrt(1 + (r_i / delta)^2) - 1)`. For an old `eps`, use `delta = sqrt(eps)`. To additionally preserve the old derivatives, divide the containing cost weight by `delta` for the unweighted model, or divide the residual weights by `delta` for the weighted model; the resulting activation differs from the old one only by a constant. Fixed `ActivationModelSmooth2Norm` and `ActivationModelWeightedQuadraticBarrier` to compute the activation Hessian diagonal properly. Included a new weighted l1 activation in https://github.com/loco-3d/crocoddyl/pull/1524
 * Fixed OpenMP CMake export in https://github.com/loco-3d/crocoddyl/pull/1523

--- a/include/crocoddyl/core/solver-base.hxx
+++ b/include/crocoddyl/core/solver-base.hxx
@@ -37,7 +37,8 @@ SolverAbstractTpl<Scalar>::SolverAbstractTpl(
 template <typename Scalar>
 bool SolverAbstractTpl<Scalar>::solve(const std::vector<VectorXs>& init_xs,
                                       const std::vector<VectorXs>& init_us,
-                                      const std::size_t maxiter, const bool,
+                                      const std::size_t maxiter,
+                                      const bool is_feasible,
                                       const Scalar init_reg) {
   START_PROFILER("SolverAbstract::solve");
   const std::size_t nh_T = problem_->get_terminalModel()->get_nh_T();
@@ -50,8 +51,7 @@ bool SolverAbstractTpl<Scalar>::solve(const std::vector<VectorXs>& init_xs,
     nh_T_ = nh_T;
     ng_T_ = ng_T;
   }
-  // TODO: Deprecate isfeasible_. Update setCandidate API.
-  setCandidate(init_xs, init_us, false);
+  setCandidate(init_xs, init_us, is_feasible);
   // Initialize the value used for primal and dual regularization
   if (isnan(init_reg)) {
     preg_ = reg_min_;
@@ -103,7 +103,9 @@ bool SolverAbstractTpl<Scalar>::solve(const std::vector<VectorXs>& init_xs,
       acceptstep_ = checkAcceptance();
       // Set candidate guess, cost and feasibilities if we accept the step
       if (acceptstep_) {
-        setCandidate(xs_try_, us_try_, false);
+        was_feasible_ = is_feasible_;
+        setCandidate(xs_try_, us_try_,
+                     was_feasible_ || steplength_ == Scalar(1.));
         updateCandidate();
         break;
       }

--- a/unittest/test_solvers.cpp
+++ b/unittest/test_solvers.cpp
@@ -360,6 +360,46 @@ void test_solver_convergence(SolverTypes::Type solver_type,
 
 //____________________________________________________________________________//
 
+void test_solver_feasibility_updates() {
+  const std::size_t T = 10;
+  std::shared_ptr<crocoddyl::ActionModelAbstract> model =
+      ActionModelFactory().create(ActionModelTypes::ActionModelLQRDriftFree);
+  std::shared_ptr<crocoddyl::ActionModelAbstract> model2 =
+      ActionModelFactory().create(ActionModelTypes::ActionModelLQRDriftFree,
+                                  ActionModelFactory::Second);
+  std::shared_ptr<crocoddyl::ActionModelAbstract> modelT =
+      ActionModelFactory().create(ActionModelTypes::ActionModelLQRDriftFree,
+                                  ActionModelFactory::Terminal);
+
+  SolverFactory solver_factory;
+  std::shared_ptr<crocoddyl::SolverAbstract> solver = solver_factory.create(
+      SolverTypes::SolverBoxFDDP_FeasShoot, model, model2, modelT, T);
+  const std::shared_ptr<crocoddyl::ShootingProblem>& problem =
+      solver->get_problem();
+
+  std::vector<Eigen::VectorXd> us;
+  us.reserve(T);
+  for (const std::shared_ptr<crocoddyl::ActionModelAbstract>& running_model :
+       problem->get_runningModels()) {
+    us.push_back(Eigen::VectorXd::Zero(running_model->get_nu()));
+  }
+  std::vector<Eigen::VectorXd> xs = problem->rollout_us(us);
+
+  // BoxFDDP needs the feasibility label during its first backward pass to
+  // enforce the control limits through the box-QP.
+  solver->solve(xs, us, 0, true);
+  BOOST_CHECK(solver->get_is_feasible());
+
+  // A full forward pass closes all dynamics gaps, even when the initial
+  // candidate was labelled infeasible.
+  perturbSolverTrajectoryGuess(problem, &xs, &us);
+  solver->solve(xs, us, 1, false);
+  BOOST_REQUIRE_EQUAL(solver->get_steplength(), 1.);
+  BOOST_CHECK(solver->get_is_feasible());
+}
+
+//____________________________________________________________________________//
+
 void test_casted_solver(SolverTypes::Type solver_type,
                         ActionModelTypes::Type action_type, size_t T) {
   // Create action models
@@ -629,6 +669,9 @@ bool init_function() {
   setenv("KMP_ALL_THREADS", "1", 1);
 
   std::size_t T = 10;
+
+  framework::master_test_suite().add(
+      BOOST_TEST_CASE(&test_solver_feasibility_updates));
 
   for (size_t s = 1; s < SolverTypes::all.size(); ++s) {
     for (size_t i = ActionModelTypes::ActionModelLQRDriftFree;


### PR DESCRIPTION
## Summary

- propagate the documented `is_feasible` argument into the initial solver candidate
- preserve feasibility after accepted steps when the previous candidate was feasible or the forward pass used a full step
- add regression coverage for both state transitions with `SolverBoxFDDP`

## Motivation

`SolverAbstract::solve()` documents `is_feasible` as indicating that the initial state trajectory comes from rolling out the controls. Since the shared solver loop was introduced in #1482, however, that argument has been ignored and every initial candidate has been marked infeasible. Accepted trial trajectories have likewise always been marked infeasible.

This distinction is observable in `SolverBoxFDDP::computePolicy()`: an infeasible candidate intentionally uses the unconstrained FDDP backward pass, while a feasible candidate uses the box-QP path that enforces the control bounds. Losing the label therefore causes a valid rollout warm start to bypass the box-QP path.

## Implementation

The shared loop now passes `is_feasible` to `setCandidate()` for the initial trajectory. Before accepting a trial trajectory, it records the previous candidate state and marks the new candidate feasible when either:

1. the previous candidate was already feasible, or
2. the accepted forward pass used a full step (`alpha == 1`), which closes all dynamics gaps.

Partial steps from an infeasible candidate remain infeasible, preserving the FDDP gap-handling semantics.

The regression test exercises both transitions with `SolverBoxFDDP`: a rollout warm start retains its feasible label before the first iteration, and a full accepted step promotes an infeasible candidate to feasible.

## Result

Before this change, the regression test fails both feasibility assertions. With the fix, the focused regression and the complete `test_solvers` executable pass.

Fixes #1512.

## Testing

- `./build-baseline/unittest/test_solvers --run_test=test_solver_feasibility_updates --log_level=test_suite`
- `./build-baseline/unittest/test_solvers`
- `pre-commit run --files include/crocoddyl/core/solver-base.hxx unittest/test_solvers.cpp`
- `git diff --check`
