### PR TITLE
Restore Doxygen's default stylesheet in generated docs

### DIFF
--- a/doc/Doxyfile.extra.in
+++ b/doc/Doxyfile.extra.in
@@ -1223,7 +1223,7 @@ HTML_FOOTER            =
 # obsolete.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_STYLESHEET        = @PROJECT_SOURCE_DIR@/doc/package.css
+HTML_STYLESHEET        =
 
 # The HTML_EXTRA_STYLESHEET tag can be used to specify additional user-defined
 # cascading style sheets that are included after the standard style sheets


### PR DESCRIPTION
## Summary

Stop replacing Doxygen's base stylesheet with the nonexistent `doc/package.css` while keeping `customdoxygen.css` as the project override.

## Why

With `HTML_STYLESHEET` pointing to a missing file, published output omitted Doxygen's generated `doxygen.css`. Doxygen's supported behavior is to leave that setting empty so it generates the default stylesheet, then apply project overrides through `HTML_EXTRA_STYLESHEET`.

## Verification

- settings checked against current Doxygen configuration semantics
- confirmed `doc/package.css` is absent and `doc/customdoxygen.css` exists
- `git diff --check`

A full local Doxygen render was not available.

Fixes #1252